### PR TITLE
Allow fields with multiple values (array|list)

### DIFF
--- a/docs/dev_notes/mongo_notes.md
+++ b/docs/dev_notes/mongo_notes.md
@@ -38,6 +38,8 @@ db.createUser(
 Tutorial:
 https://www.mongodb.com/languages/python
 
+See `test_MongoClient_tutorial.py`.
+
 Installing Python client:
 
 ```sh

--- a/docs/feature_stories/FS_06_99_43_60.list_arg_value.md
+++ b/docs/feature_stories/FS_06_99_43_60.list_arg_value.md
@@ -10,7 +10,18 @@ Assigning multiple values per `arg_type` is equivalent of placing same `data_env
 into multiple coordinates within discrete space.
 
 In other words, `data_envelope` is supposed to be search-able by any of the value from `arg_value` list
-for that "coordinate" `arg_type` (logical OR).
+for that "coordinate" `arg_type`.
+
+Participation of multiple values per arg type in CLI query is problematic:
+*   Logical OR or AND?
+*   How many values to query before switching to the next arg type?
+But interrogating user for only one of the value (just like values from other arg type value sets) is simple.
+
+During loading, `data_envelope` fields which can contain list/array value may contain scalar values
+(which is equivalent to having singleton list/array).
+In fact, there should be nothing special to do:
+*   to load array list/array fields values, simply change value from scalar value `"a"` to list/array `[ "a" ]`.
+*   to query array list/array fields values, simply specify scalar value `"c"` (as it is used for querying scalar values).
 
 TODO: Why do we need that complexity?
       The other approach is to create for all permutations (with values from multiple arrays).
@@ -27,6 +38,7 @@ TODO: Interrogation for the values to be resolved.
       It is the problem similar to function varargs (FS_18_64_57_18) - not as `data_evenlope` set, as `arg_type` value set.
       SOLUTION:
       Conceptually, for CLI interrogation, only single value should be given - simply follow existing approach.
-      The fact that we want to find an object by "one of N" values (instead of "one of one" value) does not change "one of".
-      This may be differently handled in other apps, but that focuses on sensible minimal syntax simple search queries.
+      The fact that we want to find an object by "one of N" values (instead of "one of one" value) conveniently does not change "one of".
+      This may be differently handled in other apps, but that focuses on sensible minimal syntax simple search queries `argrelay` is for.
+      Searching "one of" also drops any debate whether logical OR or logical AND has to be used - it always logical IN (where scalar value is treated as array value with one value).
 

--- a/docs/feature_stories/FS_39_58_01_91.query_cache.md
+++ b/docs/feature_stories/FS_39_58_01_91.query_cache.md
@@ -1,0 +1,10 @@
+---
+feature_story: FS_39_58_01_91
+feature_title: query cache
+feature_status: DONE
+---
+
+The initial commit with LRU cache:
+https://github.com/argrelay/argrelay/commit/dce699a99355f84a85923141c4e10b5d7fadd2aa
+
+TODO: provide details.

--- a/docs/feature_stories/FS_56_43_05_79.search_diff_collection.md
+++ b/docs/feature_stories/FS_56_43_05_79.search_diff_collection.md
@@ -4,7 +4,7 @@ feature_title: search diff collection
 feature_status: TODO
 ---
 
-At the moment, `argrelay` server uses [single Mongo DB collection for all objects](https://github.com/uvsmtid/argrelay/blob/f4c6a6fb9e5cb1226137c3744dd71693ae12c051/src/argrelay/mongo_data/MongoClientWrapper.py#L32).
+At the moment, `argrelay` server uses [single Mongo DB collection for all objects][single_mongo_collection].
 
 Server:
 *   cleans this single collection completely and populates all `data_envelope`-s on start,
@@ -12,14 +12,19 @@ Server:
 
 It works fine for small data sets, but adds extra latency (observable with `mongomock`) for large ones.
 
-The idea is to add a special attribue/key to all `data_envelope`-s indicating collection they belong to:
+The idea is to add a special attribute/key to all `data_envelope`-s indicating collection they belong to:
 *   Server will inspect this attribute to select which collection it is supposed to be stored in.
 *   Selected function will provide information in `search_control` which collection specific `data_envelop` has to be searched in.
 
-This will reduce latency in only specific scenarios
-(also, for seemingly non-serious use cases with `mongomock` instead of real Mongo DB).
+This will avoid the hardest limitation of MongoDB (not applicable for `mongomock`):
+number of indexes per collection = 64
+https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Number-of-Indexes-per-Collection
+See: `test_MongoClient_index_limits.py`
+
+This will also reduce latency in for seemingly non-important use cases with `mongomock` instead of real Mongo DB.
 But `mongomock` is expected to be the default choice (majority of installations).
 
 It also enables us to set up different handling for different collections.
 Some of them might be too big to re-populate on re-start (too long).
 
+[single_mongo_collection]: https://github.com/argrelay/argrelay/blob/f4c6a6fb9e5cb1226137c3744dd71693ae12c051/src/argrelay/mongo_data/MongoClientWrapper.py#L32

--- a/docs/test_data/TD_63_37_05_36.demo_services_data.md
+++ b/docs/test_data/TD_63_37_05_36.demo_services_data.md
@@ -5,49 +5,49 @@ test_title: demo service data
 
 This data is what `ServiceLoader` uses for `relay_demo` client from root `readme.md`:
 
-| `CodeMaturity` | `GeoRegion` | `FlowStage`  | `ClusterName`          | `DataCenter` | `HostName`   | `ServiceName` | `IpAddress`      | is_populated     | comment                           |
-|----------------|-------------|--------------|------------------------|--------------|--------------|---------------|------------------|------------------|-----------------------------------|
-| -------------- | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | ---------------- | `dev` is everywhere but limited   |
-| `dev`          | `apac`      | `upstream`   | `dev-apac-upstream`    | `dc.01`      | `zxcv-du`    | `s_a`         | `ip.192.168.1.1` | Y                |                                   |
-| `dev`          | `apac`      | `upstream`   | `dev-apac-upstream`    | `dc.01`      | `zxcv-du`    | `s_b`         | `ip.192.168.1.1` | Y                |                                   |
-| `dev`          | `apac`      | `upstream`   | `dev-apac-upstream`    | `dc.01`      | `zxcv-du`    | `s_c`         | `ip.192.168.1.1` | Y                |                                   |
-|                |             | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | ---------------- |                                   |
-| `dev`          | `apac`      | `downstream` | `dev-apac-downstream`  | `dc.11`      | `zxcv-dd`    | `tt`          | `ip.172.16.1.2`  | Y                |                                   |
-| `dev`          | `apac`      | `downstream` | `dev-apac-downstream`  | `dc.01`      | `poiu-dd`    | `xx`          | `ip.192.168.1.3` | Y                |                                   |
-|                | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | ---------------- | `emea` has no `s_c`               |
-| `dev`          | `emea`      | `upstream`   | `dev-emea-upstream`    | `dc.22`      | `asdf-du`    | `s_a`         | `ip.172.16.2.1`  | Y                |                                   |
-| `dev`          | `emea`      | `upstream`   | `dev-emea-upstream`    | `dc.22`      | `asdf-du`    | `s_b`         | `ip.172.16.2.1`  | Y                |                                   |
-|                |             | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | ---------------- |                                   |
-| `dev`          | `emea`      | `downstream` | `dev-emea-downstream`  | `dc.02`      | `xcvb-dd`    | `xx`          | `ip.192.168.2.2` | Y                |                                   |
-| `dev`          | `emea`      | `downstream` | `dev-emea-downstream`  | `dc.02`      | `xcvb-dd`    | `zz`          | `ip.192.168.2.2` | Y                |                                   |
-|                | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- |                  | `amer` has only `dev` `upstream`  |
-| `dev`          | `amer`      | `upstream`   | `dev-amer-upstream`    | `dc.03`      | `qwer-du`    | `s_a`         | `ip.192.168.3.1` | Y                | `amer` has only `s_a` service     |
-| -------------- | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | ---------------- |                                   |
-| `qa`           | `apac`      | `upstream`   | `qa-apac-upstream`     | `dc.04`      | `hjkl-qu`    | `s_a`         | `ip.192.168.4.1` | Y                |                                   |
-| `qa`           | `apac`      | `upstream`   | `qa-apac-upstream`     | `dc.04`      | `hjkl-qu`    | `s_b`         | `ip.192.168.4.1` | Y                |                                   |
-| `qa`           | `apac`      | `upstream`   | `qa-apac-upstream`     | `dc.44`      | `poiu-qu`    | `s_c`         | `ip.172.16.4.2`  | Y                |                                   |
-|                | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | ---------------- |                                   |
-| `qa`           | `emea`      | `downstream` | `qa-emea-downstream`   | `dc.05`      |              |               |                  | Y                | no `qa` in `emea` (empty cluster) |
-|                | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | ---------------- |                                   |
-| `qa`           | `amer`      | `upstream`   | `qa-amer-upstream`     | `dc.06`      | `rtyu-qu`    | `s_a`         | `ip.192.168.6.1` | Y                |                                   |
-| `qa`           | `amer`      | `upstream`   | `qa-amer-upstream`     | `dc.06`      | `rt-qu`      |               | `ip.192.168.6.2` | Y                | host `rt-du` has no services      |
-|                |             | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | ---------------- |                                   |
-| `qa`           | `amer`      | `downstream` | `qa-amer-downstream`   | `dc.06`      | `sdfgh-qd`   | `tt1`         | `ip.192.168.6.3` | Y                |                                   |
-| `qa`           | `amer`      | `downstream` | `qa-amer-downstream`   | `dc.06`      | `sdfgb-qd`   | `xx`          | `ip.192.168.6.4` | Y                |                                   |
-| `qa`           | `amer`      | `downstream` | `qa-amer-downstream`   | `dc.66`      | `sdfg-qd`    |               | `ip.172.16.6.5`  | Y                | host `sdfg-qd` has no services    |
-| -------------- | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | ---------------- | `prod` is only in `apac`          |
-| `prod`         | `apac`      | `upstream`   | `prod-apac-upstream`   | `dc.07`      | `qwer-pd-1`  | `s_a`         | `ip.192.168.7.1` | Y                |                                   |
-| `prod`         | `apac`      | `upstream`   | `prod-apac-upstream`   | `dc.07`      | `qwer-pd-1`  | `s_b`         | `ip.192.168.7.1` | Y                |                                   |
-| `prod`         | `apac`      | `upstream`   | `prod-apac-upstream`   | `dc.07`      | `qwer-pd-3`  | `s_c`         | `ip.192.168.7.2` | Y                |                                   |
-| `prod`         | `apac`      | `upstream`   | `prod-apac-upstream`   | `dc.77`      | `qwer-pd-2`  | `s_a`         | `ip.172.16.7.2`  | Y                |                                   |
-| `prod`         | `apac`      | `upstream`   | `prod-apac-upstream`   | `dc.77`      | `qwer-pd-2`  | `s_b`         | `ip.172.16.7.2`  | Y                |                                   |
-| `prod`         | `apac`      | `upstream`   | `prod-apac-upstream`   | `dc.77`      | `qwer-pd-2`  | `s_c`         | `ip.172.16.7.2`  | Y                |                                   |
-|                | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | ---------------- |                                   |
-| `prod`         | `apac`      | `downstream` | `prod-apac-downstream` | `dc.07`      | `wert-pd-1`  | `tt1`         | `ip.192.168.7.3` | Y                |                                   |
-| `prod`         | `apac`      | `downstream` | `prod-apac-downstream` | `dc.07`      | `wert-pd-2`  | `tt2`         | `ip.192.168.7.4` | Y                |                                   |
-| `prod`         | `apac`      | `downstream` | `prod-apac-downstream` | `dc.07`      | `wert-pd-2`  | `xx`          | `ip.192.168.7.4` | Y                |                                   |
-| -------------- | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | ---------------- | ------------------------------    |
-|                |             |              |                        |              |              |               |                  |                  |                                   |
+| `CodeMaturity` | `GeoRegion` | `FlowStage`  | `ClusterName`          | `DataCenter` | `HostName`   | `ServiceName` | `IpAddress`      | `GroupLabel`         | is_populated     | comment                           |
+|----------------|-------------|--------------|------------------------|--------------|--------------|---------------|------------------|----------------------|------------------|-----------------------------------|
+| -------------- | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | -------------------- | ---------------- | `dev` is everywhere but limited   |
+| `dev`          | `apac`      | `upstream`   | `dev-apac-upstream`    | `dc.01`      | `zxcv-du`    | `s_a`         | `ip.192.168.1.1` | `aaa,sss`            | Y                |                                   |
+| `dev`          | `apac`      | `upstream`   | `dev-apac-upstream`    | `dc.01`      | `zxcv-du`    | `s_b`         | `ip.192.168.1.1` | `bbb,sss`            | Y                |                                   |
+| `dev`          | `apac`      | `upstream`   | `dev-apac-upstream`    | `dc.01`      | `zxcv-du`    | `s_c`         | `ip.192.168.1.1` | `ccc,sss`            | Y                |                                   |
+|                |             | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | -------------------- | ---------------- |                                   |
+| `dev`          | `apac`      | `downstream` | `dev-apac-downstream`  | `dc.11`      | `zxcv-dd`    | `tt`          | `ip.172.16.1.2`  | `rrr`                | Y                |                                   |
+| `dev`          | `apac`      | `downstream` | `dev-apac-downstream`  | `dc.01`      | `poiu-dd`    | `xx`          | `ip.192.168.1.3` | `rrr,hhh`            | Y                |                                   |
+|                | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | -------------------- | ---------------- | `emea` has no `s_c`               |
+| `dev`          | `emea`      | `upstream`   | `dev-emea-upstream`    | `dc.22`      | `asdf-du`    | `s_a`         | `ip.172.16.2.1`  | `aaa,sss`            | Y                |                                   |
+| `dev`          | `emea`      | `upstream`   | `dev-emea-upstream`    | `dc.22`      | `asdf-du`    | `s_b`         | `ip.172.16.2.1`  | `bbb,sss`            | Y                |                                   |
+|                |             | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | -------------------- | ---------------- |                                   |
+| `dev`          | `emea`      | `downstream` | `dev-emea-downstream`  | `dc.02`      | `xcvb-dd`    | `xx`          | `ip.192.168.2.2` | `rrr,hhh`            | Y                |                                   |
+| `dev`          | `emea`      | `downstream` | `dev-emea-downstream`  | `dc.02`      | `xcvb-dd`    | `zz`          | `ip.192.168.2.2` | `rrr,hhh,odd`        | Y                |                                   |
+|                | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | -------------------- | ---------------- | `amer` has only `dev` `upstream`  |
+| `dev`          | `amer`      | `upstream`   | `dev-amer-upstream`    | `dc.03`      | `qwer-du`    | `s_a`         | `ip.192.168.3.1` | `aaa,sss`            | Y                | `amer` has only `s_a` service     |
+| -------------- | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | -------------------- | ---------------- |                                   |
+| `qa`           | `apac`      | `upstream`   | `qa-apac-upstream`     | `dc.04`      | `hjkl-qu`    | `s_a`         | `ip.192.168.4.1` | `aaa,sss`            | Y                |                                   |
+| `qa`           | `apac`      | `upstream`   | `qa-apac-upstream`     | `dc.04`      | `hjkl-qu`    | `s_b`         | `ip.192.168.4.1` | `bbb,sss`            | Y                |                                   |
+| `qa`           | `apac`      | `upstream`   | `qa-apac-upstream`     | `dc.44`      | `poiu-qu`    | `s_c`         | `ip.172.16.4.2`  | `ccc,sss`            | Y                |                                   |
+|                | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | -------------------- | ---------------- |                                   |
+| `qa`           | `emea`      | `downstream` | `qa-emea-downstream`   | `dc.05`      |              |               |                  |                      | Y                | no `qa` in `emea` (empty cluster) |
+|                | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | -------------------- | ---------------- |                                   |
+| `qa`           | `amer`      | `upstream`   | `qa-amer-upstream`     | `dc.06`      | `rtyu-qu`    | `s_a`         | `ip.192.168.6.1` | `aaa,sss`            | Y                |                                   |
+| `qa`           | `amer`      | `upstream`   | `qa-amer-upstream`     | `dc.06`      | `rt-qu`      |               | `ip.192.168.6.2` |                      | Y                | host `rt-du` has no services      |
+|                |             | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | -------------------- | ---------------- |                                   |
+| `qa`           | `amer`      | `downstream` | `qa-amer-downstream`   | `dc.06`      | `sdfgh-qd`   | `tt1`         | `ip.192.168.6.3` | `rrr`                | Y                |                                   |
+| `qa`           | `amer`      | `downstream` | `qa-amer-downstream`   | `dc.06`      | `sdfgb-qd`   | `xx`          | `ip.192.168.6.4` | `rrr,hhh`            | Y                |                                   |
+| `qa`           | `amer`      | `downstream` | `qa-amer-downstream`   | `dc.66`      | `sdfg-qd`    |               | `ip.172.16.6.5`  |                      | Y                | host `sdfg-qd` has no services    |
+| -------------- | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | -------------------- | ---------------- | `prod` is only in `apac`          |
+| `prod`         | `apac`      | `upstream`   | `prod-apac-upstream`   | `dc.07`      | `qwer-pd-1`  | `s_a`         | `ip.192.168.7.1` | `aaa,sss`            | Y                |                                   |
+| `prod`         | `apac`      | `upstream`   | `prod-apac-upstream`   | `dc.07`      | `qwer-pd-1`  | `s_b`         | `ip.192.168.7.1` | `bbb,sss`            | Y                |                                   |
+| `prod`         | `apac`      | `upstream`   | `prod-apac-upstream`   | `dc.07`      | `qwer-pd-3`  | `s_c`         | `ip.192.168.7.2` | `ccc,sss`            | Y                |                                   |
+| `prod`         | `apac`      | `upstream`   | `prod-apac-upstream`   | `dc.77`      | `qwer-pd-2`  | `s_a`         | `ip.172.16.7.2`  | `aaa,sss`            | Y                |                                   |
+| `prod`         | `apac`      | `upstream`   | `prod-apac-upstream`   | `dc.77`      | `qwer-pd-2`  | `s_b`         | `ip.172.16.7.2`  | `bbb,sss`            | Y                |                                   |
+| `prod`         | `apac`      | `upstream`   | `prod-apac-upstream`   | `dc.77`      | `qwer-pd-2`  | `s_c`         | `ip.172.16.7.2`  | `ccc,sss`            | Y                |                                   |
+|                | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | -------------------- | ---------------- |                                   |
+| `prod`         | `apac`      | `downstream` | `prod-apac-downstream` | `dc.07`      | `wert-pd-1`  | `tt1`         | `ip.192.168.7.3` | `rrr`                | Y                |                                   |
+| `prod`         | `apac`      | `downstream` | `prod-apac-downstream` | `dc.07`      | `wert-pd-2`  | `tt2`         | `ip.192.168.7.4` | `rrr`                | Y                |                                   |
+| `prod`         | `apac`      | `downstream` | `prod-apac-downstream` | `dc.07`      | `wert-pd-2`  | `xx`          | `ip.192.168.7.4` | `rrr,hhh`            | Y                |                                   |
+| -------------- | ----------- | ------------ | ---------------------- | ------------ | ------------ | ------------- | ---------------- | -------------------- | ---------------- | ------------------------------    |
+|                |             |              |                        |              |              |               |                  |                      |                  |                                   |
 
 There is no purpose to cover all special cases (other `test_data` is supposed to cover that) -
 the intention is to provide enough data to play with (without overwhelming manual maintenance).

--- a/src/argrelay/custom_integ/ServiceArgType.py
+++ b/src/argrelay/custom_integ/ServiceArgType.py
@@ -11,19 +11,29 @@ class ServiceArgType(Enum):
     """
 
     # ---
+
     CodeMaturity = auto()
     GeoRegion = auto()
     FlowStage = auto()
+
     # ---
+
     ClusterName = auto()
+
     # ---
+
     DataCenter = auto()
     HostName = auto()
     IpAddress = auto()
+    GroupLabel = auto()
     ServiceName = auto()
+
     # ---
+
     AccessType = auto()
+
     # ---
+
     LiveStatus = auto()
     """
     TODO: Currently `LiveStatus` is not used - it can be thought of as manually or dynamically assigned to the resource.

--- a/src/argrelay/custom_integ/ServiceLoader.py
+++ b/src/argrelay/custom_integ/ServiceLoader.py
@@ -66,6 +66,7 @@ service_search_control = {
         {"region": ServiceArgType.GeoRegion.name},
         {"cluster": ServiceArgType.ClusterName.name},
         # ClassService:
+        {"group": ServiceArgType.GroupLabel.name},
         {"service": ServiceArgType.ServiceName.name},
         # ClassHost:
         {"host": ServiceArgType.HostName.name},
@@ -703,6 +704,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "zxcv-du",
                 ServiceArgType.IpAddress.name: "ip.192.168.1.1",
                 ServiceArgType.ServiceName.name: "s_a",
+                ServiceArgType.GroupLabel.name: [
+                    "aaa",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -717,6 +722,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "zxcv-du",
                 ServiceArgType.IpAddress.name: "ip.192.168.1.1",
                 ServiceArgType.ServiceName.name: "s_b",
+                ServiceArgType.GroupLabel.name: [
+                    "bbb",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -731,6 +740,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "zxcv-du",
                 ServiceArgType.IpAddress.name: "ip.192.168.1.1",
                 ServiceArgType.ServiceName.name: "s_c",
+                ServiceArgType.GroupLabel.name: [
+                    "ccc",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -745,6 +758,8 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "zxcv-dd",
                 ServiceArgType.IpAddress.name: "ip.172.16.1.2",
                 ServiceArgType.ServiceName.name: "tt",
+                # FS_06_99_43_60 providing scalar value for list/array field is also possible:
+                ServiceArgType.GroupLabel.name: "rrr",
             },
             {
                 envelope_payload_: {
@@ -759,6 +774,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "poiu-dd",
                 ServiceArgType.IpAddress.name: "ip.192.168.1.3",
                 ServiceArgType.ServiceName.name: "xx",
+                ServiceArgType.GroupLabel.name: [
+                    "rrr",
+                    "hhh",
+                ],
             },
             {
                 envelope_payload_: {
@@ -773,6 +792,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "asdf-du",
                 ServiceArgType.IpAddress.name: "ip.172.16.2.1",
                 ServiceArgType.ServiceName.name: "s_a",
+                ServiceArgType.GroupLabel.name: [
+                    "aaa",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -787,6 +810,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "asdf-du",
                 ServiceArgType.IpAddress.name: "ip.172.16.2.1",
                 ServiceArgType.ServiceName.name: "s_b",
+                ServiceArgType.GroupLabel.name: [
+                    "bbb",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -801,6 +828,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "xcvb-dd",
                 ServiceArgType.IpAddress.name: "ip.192.168.2.2",
                 ServiceArgType.ServiceName.name: "xx",
+                ServiceArgType.GroupLabel.name: [
+                    "rrr",
+                    "hhh",
+                ],
             },
             {
                 envelope_payload_: {
@@ -815,6 +846,11 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "xcvb-dd",
                 ServiceArgType.IpAddress.name: "ip.192.168.2.2",
                 ServiceArgType.ServiceName.name: "zz",
+                ServiceArgType.GroupLabel.name: [
+                    "rrr",
+                    "hhh",
+                    "odd",
+                ],
             },
             {
                 envelope_payload_: {
@@ -829,6 +865,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "qwer-du",
                 ServiceArgType.IpAddress.name: "ip.192.168.3.1",
                 ServiceArgType.ServiceName.name: "s_a",
+                ServiceArgType.GroupLabel.name: [
+                    "aaa",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -843,6 +883,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "hjkl-qu",
                 ServiceArgType.IpAddress.name: "ip.192.168.4.1",
                 ServiceArgType.ServiceName.name: "s_a",
+                ServiceArgType.GroupLabel.name: [
+                    "aaa",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -857,6 +901,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "hjkl-qu",
                 ServiceArgType.IpAddress.name: "ip.192.168.4.1",
                 ServiceArgType.ServiceName.name: "s_b",
+                ServiceArgType.GroupLabel.name: [
+                    "bbb",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -871,6 +919,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "poiu-qu",
                 ServiceArgType.IpAddress.name: "ip.172.16.4.2",
                 ServiceArgType.ServiceName.name: "s_c",
+                ServiceArgType.GroupLabel.name: [
+                    "ccc",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -885,6 +937,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "rtyu-qu",
                 ServiceArgType.IpAddress.name: "ip.192.168.6.1",
                 ServiceArgType.ServiceName.name: "s_a",
+                ServiceArgType.GroupLabel.name: [
+                    "aaa",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -899,6 +955,8 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "sdfgh-qd",
                 ServiceArgType.IpAddress.name: "ip.192.168.6.3",
                 ServiceArgType.ServiceName.name: "tt1",
+                # FS_06_99_43_60 providing scalar value for list/array field is also possible:
+                ServiceArgType.GroupLabel.name: "rrr",
             },
             {
                 envelope_payload_: {
@@ -913,6 +971,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "sdfgb-qd",
                 ServiceArgType.IpAddress.name: "ip.192.168.6.4",
                 ServiceArgType.ServiceName.name: "xx",
+                ServiceArgType.GroupLabel.name: [
+                    "rrr",
+                    "hhh",
+                ],
             },
             {
                 envelope_payload_: {
@@ -927,6 +989,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "qwer-pd-1",
                 ServiceArgType.IpAddress.name: "ip.192.168.7.1",
                 ServiceArgType.ServiceName.name: "s_a",
+                ServiceArgType.GroupLabel.name: [
+                    "aaa",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -941,6 +1007,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "qwer-pd-1",
                 ServiceArgType.IpAddress.name: "ip.192.168.7.1",
                 ServiceArgType.ServiceName.name: "s_b",
+                ServiceArgType.GroupLabel.name: [
+                    "bbb",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -955,6 +1025,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "qwer-pd-3",
                 ServiceArgType.IpAddress.name: "ip.192.168.7.2",
                 ServiceArgType.ServiceName.name: "s_c",
+                ServiceArgType.GroupLabel.name: [
+                    "ccc",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -969,6 +1043,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "qwer-pd-2",
                 ServiceArgType.IpAddress.name: "ip.172.16.7.2",
                 ServiceArgType.ServiceName.name: "s_a",
+                ServiceArgType.GroupLabel.name: [
+                    "aaa",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -983,6 +1061,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "qwer-pd-2",
                 ServiceArgType.IpAddress.name: "ip.172.16.7.2",
                 ServiceArgType.ServiceName.name: "s_b",
+                ServiceArgType.GroupLabel.name: [
+                    "bbb",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -997,6 +1079,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "qwer-pd-2",
                 ServiceArgType.IpAddress.name: "ip.172.16.7.2",
                 ServiceArgType.ServiceName.name: "s_c",
+                ServiceArgType.GroupLabel.name: [
+                    "ccc",
+                    "sss",
+                ],
             },
             {
                 envelope_payload_: {
@@ -1011,6 +1097,8 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "wert-pd-1",
                 ServiceArgType.IpAddress.name: "ip.192.168.7.3",
                 ServiceArgType.ServiceName.name: "tt1",
+                # FS_06_99_43_60 providing scalar value for list/array field is also possible:
+                ServiceArgType.GroupLabel.name: "rrr",
             },
             {
                 envelope_payload_: {
@@ -1025,6 +1113,8 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "wert-pd-2",
                 ServiceArgType.IpAddress.name: "ip.192.168.7.4",
                 ServiceArgType.ServiceName.name: "tt2",
+                # FS_06_99_43_60 providing scalar value for list/array field is also possible:
+                ServiceArgType.GroupLabel.name: "rrr",
             },
             {
                 envelope_payload_: {
@@ -1039,6 +1129,10 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.HostName.name: "wert-pd-2",
                 ServiceArgType.IpAddress.name: "ip.192.168.7.4",
                 ServiceArgType.ServiceName.name: "xx",
+                ServiceArgType.GroupLabel.name: [
+                    "rrr",
+                    "hhh",
+                ],
             },
         ])
 

--- a/src/argrelay/enum_desc/TermColor.py
+++ b/src/argrelay/enum_desc/TermColor.py
@@ -14,6 +14,7 @@ class TermColor(Enum):
     # Direct colors:
     # do not use them directly, use semantic colors instead (below).
 
+    back_dark_blue = "\033[44m"
     back_dark_yellow = "\033[43m"
 
     fore_dark_red = "\033[31m"
@@ -25,11 +26,12 @@ class TermColor(Enum):
     fore_bright_yellow = "\033[93m"
     fore_bright_blue = "\033[94m"
     fore_bright_cyan = "\033[96m"
+    fore_bright_white = "\033[97m"
 
     ###################################################################################################################
     # Semantic colors:
 
-    prefix_highlight = back_dark_yellow
+    prefix_highlight = back_dark_blue
 
     known_envelope_id = fore_dark_gray
     unknown_envelope_id = fore_dark_red
@@ -38,12 +40,12 @@ class TermColor(Enum):
 
     help_hint = fore_dark_green
 
-    tangent_token_l_part = fore_bright_cyan
+    tangent_token_l_part = fore_bright_white
     """
     See `ParsedContext.tan_token_l_part`
     """
 
-    tangent_token_r_part = fore_dark_cyan
+    tangent_token_r_part = fore_bright_cyan
     """
     See `ParsedContext.tangent_token_r_part`
     """

--- a/src/argrelay/schema_config_core_server/QueryCacheConfigSchema.py
+++ b/src/argrelay/schema_config_core_server/QueryCacheConfigSchema.py
@@ -9,6 +9,10 @@ query_cache_max_size_bytes_ = "query_cache_max_size_bytes"
 
 
 class QueryCacheConfigSchema(Schema):
+    """
+    Config schema for FS_39_58_01_91 query cache.
+    """
+
     class Meta:
         unknown = RAISE
         strict = True

--- a/tests/env_tests/MongoClientTest.py
+++ b/tests/env_tests/MongoClientTest.py
@@ -1,16 +1,51 @@
 from unittest import TestCase
 
 from pymongo.collection import Collection
+from pymongo.database import Database
+
+from argrelay.mongo_data.MongoClientWrapper import get_mongo_client
+from argrelay.schema_config_core_server.MongoConfigSchema import mongo_config_desc
+
+object_name_ = "object_name"
 
 
 class MongoClientTest(TestCase):
 
     @staticmethod
-    def show_all_envelopes(col_proxy: Collection):
+    def create_collection_proxy(
+        col_name: str,
+    ):
+        # To connect to real mongo server, change this to False:
+        # mongo_config_desc.dict_example[use_mongomock_only_] = False
+
+        mongo_config = mongo_config_desc.from_input_dict(mongo_config_desc.dict_example)
+        mongo_client = get_mongo_client(mongo_config)
+        print("list_database_names: ", mongo_client.list_database_names())
+        mongo_db: Database = mongo_client[mongo_config.mongo_server.database_name]
+        print("list_collection_names: ", mongo_db.list_collection_names())
+
+        col_proxy: Collection = mongo_db[col_name]
+        return col_proxy
+
+    @staticmethod
+    def show_all_envelopes(
+        col_proxy: Collection,
+    ):
         print("show_all_envelopes:")
         for data_envelope in col_proxy.find():
             print("data_envelope: ", data_envelope)
 
     @staticmethod
-    def remove_all_envelopes(col_proxy):
+    def remove_all_envelopes(
+        col_proxy: Collection,
+    ):
         col_proxy.delete_many({})
+        col_proxy.drop_indexes()
+
+    @staticmethod
+    def index_fields(
+        col_proxy: Collection,
+        known_arg_types: list[str],
+    ):
+        for index_field in known_arg_types:
+            col_proxy.create_index(index_field)

--- a/tests/env_tests/test_MongoClient_distinc_values_search.py
+++ b/tests/env_tests/test_MongoClient_distinc_values_search.py
@@ -1,31 +1,18 @@
-from pymongo.collection import Collection
-from pymongo.database import Database
-
 from argrelay.custom_integ.ServiceArgType import ServiceArgType
-from argrelay.mongo_data.MongoClientWrapper import get_mongo_client
-from argrelay.schema_config_core_server.MongoConfigSchema import mongo_config_desc
 from argrelay.schema_config_interp.DataEnvelopeSchema import envelope_payload_, mongo_id_
-from env_tests.MongoClientTest import MongoClientTest
+from env_tests.MongoClientTest import MongoClientTest, object_name_
 
 
 class ThisTestCase(MongoClientTest):
 
     # noinspection PyMethodMayBeStatic
-    def test_live_envelope_searched_by_multiple_typed_vals(self):
+    def test_live_query_distinct_values_for_each_indexed_field(self):
         """
         Example to search distinct values for each field individually in single query:
         https://stackoverflow.com/q/63592489/441652
         """
 
-        mongo_config = mongo_config_desc.from_input_dict(mongo_config_desc.dict_example)
-        mongo_client = get_mongo_client(mongo_config)
-        print("list_database_names: ", mongo_client.list_database_names())
-
-        mongo_db: Database = mongo_client[mongo_config.mongo_server.database_name]
-        print("list_collection_names: ", mongo_db.list_collection_names())
-
-        col_name = "argrelay"
-        col_proxy: Collection = mongo_db[col_name]
+        col_proxy = self.create_collection_proxy("argrelay")
 
         self.remove_all_envelopes(col_proxy)
 
@@ -37,7 +24,7 @@ class ThisTestCase(MongoClientTest):
 
         envelope_001 = {
             envelope_payload_: {
-                "object_name": "envelope_001",
+                object_name_: "envelope_001",
             },
             ServiceArgType.AccessType.name: "ro",
             ServiceArgType.CodeMaturity.name: "prod",
@@ -45,7 +32,7 @@ class ThisTestCase(MongoClientTest):
 
         envelope_002 = {
             envelope_payload_: {
-                "object_name": "envelope_002",
+                object_name_: "envelope_002",
             },
             ServiceArgType.AccessType.name: "rw",
             ServiceArgType.LiveStatus.name: "red",
@@ -53,7 +40,7 @@ class ThisTestCase(MongoClientTest):
 
         envelope_003 = {
             envelope_payload_: {
-                "object_name": "envelope_003",
+                object_name_: "envelope_003",
             },
             ServiceArgType.AccessType.name: "rw",
             ServiceArgType.LiveStatus.name: "blue",
@@ -61,7 +48,7 @@ class ThisTestCase(MongoClientTest):
 
         envelope_004 = {
             envelope_payload_: {
-                "object_name": "envelope_004",
+                object_name_: "envelope_004",
             },
             ServiceArgType.AccessType.name: "rw",
             ServiceArgType.LiveStatus.name: "red",
@@ -75,8 +62,7 @@ class ThisTestCase(MongoClientTest):
             envelope_004,
         ])
 
-        for index_field in known_arg_types:
-            col_proxy.create_index(index_field)
+        self.index_fields(col_proxy, known_arg_types)
 
         print("query 1:")
         for result_item in col_proxy.aggregate([

--- a/tests/env_tests/test_MongoClient_envelope_list.py
+++ b/tests/env_tests/test_MongoClient_envelope_list.py
@@ -1,8 +1,3 @@
-from pymongo.collection import Collection
-from pymongo.database import Database
-
-from argrelay.mongo_data.MongoClientWrapper import get_mongo_client
-from argrelay.schema_config_core_server.MongoConfigSchema import mongo_config_desc
 from argrelay.schema_config_core_server.StaticDataSchema import data_envelopes_
 from env_tests.MongoClientTest import MongoClientTest
 
@@ -11,17 +6,9 @@ class ThisTestCase(MongoClientTest):
 
     def test_list_all_envelopes(self):
         """
-        Does not test anything, just lists envelopes in current database collection:
+        Does not test anything, just lists envelopes in current database collection.
         """
 
-        mongo_config = mongo_config_desc.from_input_dict(mongo_config_desc.dict_example)
-        mongo_client = get_mongo_client(mongo_config)
-        print("list_database_names: ", mongo_client.list_database_names())
-
-        mongo_db: Database = mongo_client[mongo_config.mongo_server.database_name]
-        print("list_collection_names: ", mongo_db.list_collection_names())
-
-        col_name = data_envelopes_
-        col_proxy: Collection = mongo_db[col_name]
+        col_proxy = self.create_collection_proxy(data_envelopes_)
 
         self.show_all_envelopes(col_proxy)

--- a/tests/env_tests/test_MongoClient_envelope_search.py
+++ b/tests/env_tests/test_MongoClient_envelope_search.py
@@ -1,33 +1,21 @@
-from pymongo.collection import Collection
-from pymongo.database import Database
-
 from argrelay.custom_integ.ServiceArgType import ServiceArgType
-from argrelay.mongo_data.MongoClientWrapper import get_mongo_client
-from argrelay.schema_config_core_server.MongoConfigSchema import mongo_config_desc
 from argrelay.schema_config_interp.DataEnvelopeSchema import envelope_payload_
-from env_tests.MongoClientTest import MongoClientTest
+from env_tests.MongoClientTest import MongoClientTest, object_name_
 
 
 class ThisTestCase(MongoClientTest):
 
     # noinspection PyMethodMayBeStatic
-    def test_live_envelope_searched_by_multiple_typed_vals(self):
+    def test_live_envelope_searched_by_multiple_typed_key_value_pairs(self):
         """
-        Example with data searched by multiple { type: value } pairs
+        Example with data searched by multiple { type: value } pairs = typical search feature `argrelay` relies on.
         """
 
-        mongo_config = mongo_config_desc.from_input_dict(mongo_config_desc.dict_example)
-        mongo_client = get_mongo_client(mongo_config)
-        print("list_database_names: ", mongo_client.list_database_names())
-
-        mongo_db: Database = mongo_client[mongo_config.mongo_server.database_name]
-        print("list_collection_names: ", mongo_db.list_collection_names())
-
-        col_name = "argrelay"
-        col_proxy: Collection = mongo_db[col_name]
+        col_proxy = self.create_collection_proxy("argrelay")
 
         self.remove_all_envelopes(col_proxy)
 
+        # Fields which will be indexed:
         known_arg_types = [
             ServiceArgType.AccessType.name,
             ServiceArgType.LiveStatus.name,
@@ -36,14 +24,14 @@ class ThisTestCase(MongoClientTest):
 
         envelope_001 = {
             envelope_payload_: {
-                "object_name": "envelope_001",
+                object_name_: "envelope_001",
             },
             ServiceArgType.AccessType.name: "ro",
         }
 
         envelope_002 = {
             envelope_payload_: {
-                "object_name": "envelope_002",
+                object_name_: "envelope_002",
             },
             ServiceArgType.AccessType.name: "rw",
             ServiceArgType.LiveStatus.name: "red",
@@ -51,7 +39,7 @@ class ThisTestCase(MongoClientTest):
 
         envelope_003 = {
             envelope_payload_: {
-                "object_name": "envelope_003",
+                object_name_: "envelope_003",
             },
             ServiceArgType.AccessType.name: "rw",
             ServiceArgType.LiveStatus.name: "blue",
@@ -59,7 +47,7 @@ class ThisTestCase(MongoClientTest):
 
         envelope_004 = {
             envelope_payload_: {
-                "object_name": "envelope_004",
+                object_name_: "envelope_004",
             },
             ServiceArgType.AccessType.name: "rw",
             ServiceArgType.LiveStatus.name: "red",
@@ -73,8 +61,7 @@ class ThisTestCase(MongoClientTest):
             envelope_004,
         ])
 
-        for index_field in known_arg_types:
-            col_proxy.create_index(index_field)
+        self.index_fields(col_proxy, known_arg_types)
 
         print("query 1:")
         for data_envelope in col_proxy.find(

--- a/tests/env_tests/test_MongoClient_envelope_search_with_array_fields.py
+++ b/tests/env_tests/test_MongoClient_envelope_search_with_array_fields.py
@@ -1,0 +1,216 @@
+from pymongo.collection import Collection
+
+from argrelay.custom_integ.ServiceArgType import ServiceArgType
+from argrelay.schema_config_interp.DataEnvelopeSchema import envelope_payload_
+from env_tests.MongoClientTest import MongoClientTest, object_name_
+
+
+class ThisTestCase(MongoClientTest):
+
+    # noinspection PyMethodMayBeStatic
+    def test_live_envelope_searched_by_multiple_typed_key_value_pairs(self):
+        """
+        Example with data searched by multiple { type: value } pairs
+        where some fields contain array of values.
+        See: FS_06_99_43_60.list_arg_value.md
+        """
+
+        col_proxy = self.create_collection_proxy("argrelay")
+
+        self.remove_all_envelopes(col_proxy)
+
+        # Fields which will be indexed:
+        known_arg_types = [
+            ServiceArgType.AccessType.name,
+            ServiceArgType.LiveStatus.name,
+            ServiceArgType.CodeMaturity.name,
+        ]
+
+        envelope_001 = {
+            envelope_payload_: {
+                object_name_: "envelope_001",
+            },
+            ServiceArgType.AccessType.name: "ro",
+        }
+
+        envelope_002 = {
+            envelope_payload_: {
+                object_name_: "envelope_002",
+            },
+            ServiceArgType.AccessType.name: "rw",
+            ServiceArgType.LiveStatus.name: [
+                "red",
+                "blue",
+            ],
+        }
+
+        envelope_003 = {
+            envelope_payload_: {
+                object_name_: "envelope_003",
+            },
+            ServiceArgType.AccessType.name: "rw",
+            # NOTE: some of the envelopes have scalar value for the same field which has arrays in other envelopes:
+            ServiceArgType.LiveStatus.name: "blue",
+        }
+
+        envelope_004 = {
+            envelope_payload_: {
+                object_name_: "envelope_004",
+            },
+            ServiceArgType.AccessType.name: "rw",
+            ServiceArgType.LiveStatus.name: [
+                "red",
+                "yellow",
+            ],
+            ServiceArgType.CodeMaturity.name: "prod",
+        }
+
+        envelope_005 = {
+            envelope_payload_: {
+                object_name_: "envelope_005",
+            },
+            ServiceArgType.AccessType.name: "rw",
+            ServiceArgType.LiveStatus.name: [
+                "blue",
+                "green",
+            ],
+            ServiceArgType.CodeMaturity.name: "prod",
+        }
+
+        envelope_006 = {
+            envelope_payload_: {
+                object_name_: "envelope_006",
+            },
+            ServiceArgType.AccessType.name: "rw",
+            # NOTE: some of the envelopes have scalar value for the same field which has arrays in other envelopes:
+            ServiceArgType.LiveStatus.name: "green",
+            ServiceArgType.CodeMaturity.name: "prod",
+        }
+
+        envelope_007 = {
+            envelope_payload_: {
+                object_name_: "envelope_007",
+            },
+            ServiceArgType.AccessType.name: "rw",
+            ServiceArgType.LiveStatus.name: [
+                "red",
+                "green",
+                "blue",
+                "yellow",
+            ],
+            ServiceArgType.CodeMaturity.name: "prod",
+        }
+
+        col_proxy.insert_many([
+            envelope_001,
+            envelope_002,
+            envelope_003,
+            envelope_004,
+            envelope_005,
+            envelope_006,
+            envelope_007,
+        ])
+
+        self.index_fields(col_proxy, known_arg_types)
+
+        print("query 1: red")
+        self.find_and_assert(
+            col_proxy,
+            {
+                ServiceArgType.LiveStatus.name: "red",
+            },
+            [
+                "envelope_002",
+                "envelope_004",
+                "envelope_007",
+            ],
+        )
+
+        print("query 2: yellow")
+        self.find_and_assert(
+            col_proxy,
+            {
+                ServiceArgType.LiveStatus.name: "yellow",
+            },
+            [
+                "envelope_004",
+                "envelope_007",
+            ],
+        )
+
+        print("query 3: blue")
+        self.find_and_assert(
+            col_proxy,
+            {
+                ServiceArgType.LiveStatus.name: "blue",
+            },
+            [
+                "envelope_002",
+                "envelope_003",
+                "envelope_005",
+                "envelope_007",
+            ],
+        )
+
+        print("query 4: green")
+        self.find_and_assert(
+            col_proxy,
+            {
+                ServiceArgType.LiveStatus.name: "green",
+            },
+            [
+                "envelope_005",
+                "envelope_006",
+                "envelope_007",
+            ],
+        )
+
+        print("query 5: green and blue")
+        self.find_and_assert(
+            col_proxy,
+            {
+                ServiceArgType.LiveStatus.name: [
+                    "green",
+                    "blue",
+                ]
+            },
+            # NOTE: query with array of values does not work:
+            [
+            ],
+        )
+
+        print("query 5: blue and green")
+        self.find_and_assert(
+            col_proxy,
+            {
+                ServiceArgType.LiveStatus.name: [
+                    "green",
+                    "blue",
+                ]
+            },
+            # NOTE: query with array of values does not work:
+            [
+            ],
+        )
+
+        self.remove_all_envelopes(col_proxy)
+
+    def find_and_assert(
+        self,
+        col_proxy: Collection,
+        query_dict: dict,
+        expected_object_names: list[str],
+    ):
+        data_envelopes = list(col_proxy.find(query_dict))
+        for data_envelope in data_envelopes:
+            print("data_envelope: ", data_envelope)
+        self.assertTrue(len(data_envelopes) == len(expected_object_names))
+        actual_object_names = self.extract_object_names(data_envelopes)
+        for expected_object_name in expected_object_names:
+            self.assertTrue(expected_object_name in actual_object_names)
+
+    @staticmethod
+    def extract_object_names(
+        data_envelopes: list[dict],
+    ):
+        return [data_envelope[envelope_payload_][object_name_] for data_envelope in data_envelopes]

--- a/tests/env_tests/test_MongoClient_index_limits.py
+++ b/tests/env_tests/test_MongoClient_index_limits.py
@@ -1,0 +1,219 @@
+from enum import Enum, auto
+
+from env_tests.MongoClientTest import MongoClientTest
+
+
+class TestSize(Enum):
+    SmallSize = auto()
+    """
+    Works for both `pymongo` and `mongomock`.
+    """
+
+    MediumSize = auto()
+    """
+    Works for both `pymongo` and `mongomock`.
+    But it is maximum size for `pymongo`.
+    """
+
+    LargeSize = auto()
+    """
+    Works only for `mongomock`.
+    """
+
+
+# TODO: Run this test in `offline_tests` with override to use `mongomock` and here without that override:
+class ThisTestCase(MongoClientTest):
+
+    def __init__(self, *args, **kwargs):
+        super(MongoClientTest, self).__init__(*args, **kwargs)
+
+        self.test_size = TestSize.SmallSize
+
+        if self.test_size == TestSize.SmallSize:
+            self.field_count = 17
+            self.envelope_count = 163
+            self.max_value_ordinal = 11
+            self.max_array_size = 19
+
+            self.col_query = {
+                "field_8": "scalar_value_8",
+                "field_11": "array_value_1",
+                "field_3": "array_value_3",
+            }
+
+        if self.test_size == TestSize.MediumSize:
+            # Maximum number of indexes in MongoDB = 64:
+            # https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Number-of-Indexes-per-Collection
+            self.field_count = 63
+            self.envelope_count = 7057
+            self.max_value_ordinal = 379
+            self.max_array_size = 113
+
+            self.col_query = {
+                "field_3": "array_value_3",
+                "field_7": "array_value_56",
+                "field_31": "array_value_46",
+                "field_51": "array_value_26",
+            }
+
+        if self.test_size == TestSize.LargeSize:
+            self.field_count = 263
+            self.envelope_count = 7057
+            self.max_value_ordinal = 379
+            self.max_array_size = 113
+
+            self.col_query = {
+                "field_3": "array_value_3",
+                "field_11": "array_value_259",
+                "field_83": "array_value_343",
+            }
+
+        self.assertTrue(
+            self.field_count * self.envelope_count * self.max_array_size < 1_000_000_000,
+            "estimated (roughly) mem size should not exceed 1 G"
+        )
+
+        self.curr_value_ordinal = 1
+        self.curr_array_size = 1
+        # the other one is "array"
+        self.curr_array_field_value_type = "scalar"
+
+    # noinspection PyMethodMayBeStatic
+    def test_live_index_limits(self):
+        """
+        Test mongodb index limits:
+        *   generates field names to be indexed
+        *   decides which field will contain array values or not
+        *   generates `data_envelope`-s with generated values
+        *   array fields of `data_envelope`-s are populated with either scalar or array
+        *   runs few queries
+
+        Note:
+        These limitation to have multiple fields with array values actually
+        *   apply for `pymongo`
+        *   do not apply for `mongomock`
+        # https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Number-of-Indexes-per-Collection
+        Real MongoDB (`pymongo`) fails for larger numbers with this:
+        ```
+        pymongo.errors.OperationFailure: add index fails, too many indexes for argrelay.argrelay key:{ field_61: 1 }, full error: {'ok': 0.0, 'errmsg': 'add index fails, too many indexes for argrelay.argrelay key:{ field_61: 1 }', 'code': 67, 'codeName': 'CannotCreateIndex'}
+        ```
+        """
+
+        col_proxy = self.create_collection_proxy("argrelay")
+
+        self.remove_all_envelopes(col_proxy)
+
+        # Fields which will be indexed:
+        known_arg_types = self.generate_field_names()
+
+        array_field_names = self.decide_array_field_names(known_arg_types)
+
+        data_envelopes = self.generate_data_envelopes(known_arg_types, array_field_names)
+
+        col_proxy.insert_many(data_envelopes)
+
+        self.index_fields(col_proxy, known_arg_types)
+
+        # noinspection PyUnreachableCode
+        if False:
+            self.show_all_envelopes(col_proxy)
+
+        print("query 1:")
+        for data_envelope in col_proxy.find(self.col_query):
+            print("data_envelope: ", data_envelope)
+
+    def generate_field_names(self) -> list[str]:
+        field_names = []
+        for field_n in range(1, self.field_count + 1):
+            field_names.append(f"field_{field_n}")
+        return field_names
+
+    # noinspection PyMethodMayBeStatic
+    def decide_array_field_names(
+        self,
+        field_names,
+    ):
+        """
+        even = scalar fields
+        odd = array fields
+        """
+        array_field_names = []
+        for field_n in range(1, len(field_names) + 1):
+            if field_n % 2 != 0:
+                array_field_names.append(field_names[field_n - 1])
+        return array_field_names
+
+    def generate_data_envelopes(
+        self,
+        field_names: list[str],
+        array_field_names: list[str],
+    ) -> list[dict]:
+        data_envelopes = []
+        for envelope_n in range(1, self.envelope_count + 1):
+            data_envelope = self.generate_data_envelope(field_names, array_field_names)
+            data_envelopes.append(data_envelope)
+            if envelope_n % 1_000 == 0:
+                print(f"{envelope_n}/{self.envelope_count}")
+        return data_envelopes
+
+    def generate_data_envelope(
+        self,
+        field_names: list[str],
+        array_field_names: list[str],
+    ) -> dict:
+        data_envelope = {}
+        for field_name in field_names:
+            if field_name in array_field_names:
+                self.generate_array_field_values(data_envelope, field_name)
+            else:
+                self.generate_field_scalar_value(data_envelope, field_name)
+        return data_envelope
+
+    def generate_array_field_values(
+        self,
+        data_envelope: dict,
+        array_field_name: str,
+    ) -> None:
+        if self.curr_array_field_value_type == "array":
+            self.generate_field_array_values(data_envelope, array_field_name)
+        else:
+            self.generate_field_scalar_value(data_envelope, array_field_name)
+        self.increment_curr_array_field_value_type()
+
+    def generate_field_array_values(
+        self,
+        data_envelope: dict,
+        field_name: str,
+    ) -> None:
+        array_values = []
+        for i in range(self.curr_array_size):
+            array_value = f"array_value_{self.curr_value_ordinal}"
+            self.increment_curr_value_ordinal()
+            array_values.append(array_value)
+        self.increment_curr_array_size()
+        data_envelope[field_name] = array_values
+
+    def generate_field_scalar_value(
+        self,
+        data_envelope: dict,
+        field_name: str,
+    ) -> None:
+        scalar_value = f"scalar_value_{self.curr_value_ordinal}"
+        self.increment_curr_value_ordinal()
+        data_envelope[field_name] = scalar_value
+
+    def increment_curr_value_ordinal(self):
+        self.curr_value_ordinal += 1
+        if self.curr_value_ordinal > self.max_value_ordinal:
+            self.curr_value_ordinal = 1
+
+    def increment_curr_array_size(self):
+        self.curr_array_size += 1
+        if self.curr_array_size > self.max_array_size:
+            self.curr_array_size = 1
+
+    def increment_curr_array_field_value_type(self):
+        if self.curr_array_field_value_type == "scalar":
+            self.curr_array_field_value_type = "array"
+        else:
+            self.curr_array_field_value_type = "scalar"

--- a/tests/env_tests/test_MongoClient_tutorial.py
+++ b/tests/env_tests/test_MongoClient_tutorial.py
@@ -1,8 +1,3 @@
-from pymongo.collection import Collection
-from pymongo.database import Database
-
-from argrelay.mongo_data.MongoClientWrapper import get_mongo_client
-from argrelay.schema_config_core_server.MongoConfigSchema import mongo_config_desc
 from argrelay.schema_config_interp.DataEnvelopeSchema import mongo_id_
 from env_tests.MongoClientTest import MongoClientTest
 
@@ -15,15 +10,7 @@ class ThisTestCase(MongoClientTest):
         Borrowed from: https://www.mongodb.com/languages/python
         """
 
-        mongo_config = mongo_config_desc.from_input_dict(mongo_config_desc.dict_example)
-        mongo_client = get_mongo_client(mongo_config)
-        print("list_database_names: ", mongo_client.list_database_names())
-
-        mongo_db: Database = mongo_client[mongo_config.mongo_server.database_name]
-        print("list_collection_names: ", mongo_db.list_collection_names())
-
-        col_name = "user_1_envelopes"
-        col_proxy: Collection = mongo_db[col_name]
+        col_proxy = self.create_collection_proxy("user_1_envelopes")
 
         self.show_all_envelopes(col_proxy)
 

--- a/tests/offline_tests/plugin_delegator/test_InterceptorDelegator.py
+++ b/tests/offline_tests/plugin_delegator/test_InterceptorDelegator.py
@@ -31,7 +31,7 @@ class ThisTestCase(InOutTestCase):
                 line_no(),
                 "some_command intercept goto service s_b prod |",
                 CompType.PrefixShown,
-                ["qwer-pd-1", "qwer-pd-2"],
+                ["bbb", "sss"],
                 None,
                 None,
                 "Completion continues to be driven by function selected via `goto` and `service`.",

--- a/tests/offline_tests/relay_demo/test_relay_demo.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo.py
@@ -468,7 +468,8 @@ class ThisTestCase(InOutTestCase):
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}FlowStage: upstream [{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}GeoRegion: emea [{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}ClusterName: dev-emea-upstream [{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.remaining_value.value}*ServiceName: ?{TermColor.reset_style.value} {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}s_{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}a{TermColor.reset_style.value} {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}s_{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}b{TermColor.reset_style.value} 
+{" " * indent_size}{TermColor.remaining_value.value}*GroupLabel: ?{TermColor.reset_style.value} aaa sss bbb 
+{" " * indent_size}{TermColor.remaining_value.value}ServiceName: ?{TermColor.reset_style.value} {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}s_{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}a{TermColor.reset_style.value} {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}s_{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}b{TermColor.reset_style.value} 
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}HostName: asdf-du [{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.no_option_to_suggest.value}LiveStatus: [none]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}DataCenter: dc.22 [{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
@@ -512,7 +513,8 @@ class ThisTestCase(InOutTestCase):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}FlowStage: upstream [{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}GeoRegion: apac [{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}ClusterName: prod-apac-upstream [{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.remaining_value.value}*ServiceName: ?{TermColor.reset_style.value} s_a s_b 
+{" " * indent_size}{TermColor.remaining_value.value}*GroupLabel: ?{TermColor.reset_style.value} aaa sss bbb 
+{" " * indent_size}{TermColor.remaining_value.value}ServiceName: ?{TermColor.reset_style.value} s_a s_b 
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}HostName: {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}qwer-p{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}d-1{TermColor.reset_style.value} [{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.no_option_to_suggest.value}LiveStatus: [none]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}DataCenter: dc.07 [{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}

--- a/tests/offline_tests/relay_server/test_QueryEngine.py
+++ b/tests/offline_tests/relay_server/test_QueryEngine.py
@@ -13,6 +13,9 @@ from argrelay.test_helper.EnvMockBuilder import ServerOnlyEnvMockBuilder
 
 
 class ThisTestCase(TestCase):
+    """
+    Tests FS_39_58_01_91 query cache.
+    """
 
     def test_enable_query_cache(self):
         """

--- a/tests/offline_tests/test_helper/test_TD_63_37_05_36_default.py
+++ b/tests/offline_tests/test_helper/test_TD_63_37_05_36_default.py
@@ -8,6 +8,7 @@ from argrelay.custom_integ.ServiceArgType import ServiceArgType
 from argrelay.custom_integ.ServiceEnvelopeClass import ServiceEnvelopeClass
 from argrelay.enum_desc.ReservedArgType import ReservedArgType
 from argrelay.relay_server.LocalServer import LocalServer
+from argrelay.relay_server.QueryEngine import scalar_to_list_values
 from argrelay.schema_config_core_server.ServerConfigSchema import server_config_desc
 from argrelay.schema_config_core_server.StaticDataSchema import data_envelopes_
 from argrelay.test_helper import change_to_known_repo_path, test_data_
@@ -96,6 +97,8 @@ class ThisTestCase(TestCase):
                     ip_address = table_row[f"`{ServiceArgType.IpAddress}`"].strip().strip("`")
                     data_center = table_row[f"`{ServiceArgType.DataCenter}`"].strip().strip("`")
 
+                    group_label: str = table_row[f"`{ServiceArgType.GroupLabel}`"].strip().strip("`")
+
                     # Whether `ServiceName` specified:
                     is_cluster = host_name == ""
                     # Whether `ServiceName` specified:
@@ -179,6 +182,15 @@ class ThisTestCase(TestCase):
                             self.assertEquals(
                                 data_center,
                                 service_data_envelope[ServiceArgType.DataCenter.name],
+                            )
+
+                            # GroupLabel is specified in doc as CSV:
+                            group_label_values = group_label.split(",")
+                            actual_values = service_data_envelope[ServiceArgType.GroupLabel.name]
+                            actual_values = scalar_to_list_values(actual_values)
+                            self.assertEquals(
+                                group_label_values,
+                                actual_values,
                             )
 
     def find_single_data_envelope(self, mongo_col, query_dict) -> dict:


### PR DESCRIPTION
*   Implement scalar to list conversion on data query.
*   Add `GroupLabel` for service search to demo indexes with array|list values.
*   Add `test_MongoClient_envelope_search_with_array_fields.py` to test MongoDB queries for objects with array fields.
*   Add `test_MongoClient_index_limits.py` to test limitations on index fields in MongoDB.
*   Update `FS_06_99_43_60.list_arg_value.md`.
*   Add skeleton `FS_39_58_01_91.query_cache.md` to explain retroactively LRU query cache.
*   Change colors for prefix highlight.
