### PR TITLE
Fix `DefaultConfigurator` link to `@/conf/` destination URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def list_dir(
 setuptools.setup(
     name = "argrelay",
     # See `docs/dev_notes/version_format.md`:
-    version = "0.6.1",
+    version = "0.6.2",
     author = "uvsmtid",
     author_email = "uvsmtid@gmail.com",
     description = "Tab-completion & data search server = total recall for Bash shell",

--- a/src/argrelay/plugin_config/DefaultConfigurator.py
+++ b/src/argrelay/plugin_config/DefaultConfigurator.py
@@ -94,11 +94,10 @@ class DefaultConfigurator(AbstractConfigurator):
     def provide_project_git_repo_relative_argrelay_dir(
         self,
     ) -> Union[str, None]:
-        argrelay_dir_abs_path = os.path.abspath(get_argrelay_dir())
-        git_repo_root_abs_path = os.path.abspath(get_git_repo_root_path(get_argrelay_dir()))
+        argrelay_dir_abs_path = os.path.realpath(os.path.abspath(get_argrelay_dir()))
+        git_repo_root_abs_path = os.path.realpath(os.path.abspath(get_git_repo_root_path(get_argrelay_dir())))
+        # Make sure argrelay_dir is not outside the git repo:
         if not argrelay_dir_abs_path.startswith(git_repo_root_abs_path):
-            return None
-        if get_git_repo_root_path(get_argrelay_dir()) != git_repo_root_abs_path:
             return None
         argrelay_dir_rel_path = os.path.relpath(argrelay_dir_abs_path, git_repo_root_abs_path)
         if argrelay_dir_rel_path == ".":

--- a/src/argrelay/relay_server/CustomFlaskApp.py
+++ b/src/argrelay/relay_server/CustomFlaskApp.py
@@ -251,11 +251,24 @@ def configure_project_git_conf_dir_url(
         project_current_config_path is None
     ):
         return ""
-    argrelay_dir_abs_path = os.path.abspath(get_argrelay_dir())
-    project_current_config_abs_path = os.path.abspath(os.path.join(argrelay_dir_abs_path, project_current_config_path))
+
+    argrelay_dir_abs_path = os.path.realpath(os.path.abspath(get_argrelay_dir()))
+    project_current_config_abs_path = os.path.realpath(os.path.abspath(os.path.join(
+        argrelay_dir_abs_path,
+        project_current_config_path
+    )))
+
+    # This may happen even if paths were joined
+    # if `project_current_config_path` is a symlink pointing outside `argrelay_dir_abs_path`:
     if not project_current_config_abs_path.startswith(argrelay_dir_abs_path):
         return ""
-    if get_git_repo_root_path(argrelay_dir_abs_path) != get_git_repo_root_path(project_current_config_abs_path):
+
+    # This may happen if `@/conf` is a sub-dir, and it is another git repo:
+    if (
+        os.path.realpath(get_git_repo_root_path(argrelay_dir_abs_path))
+        !=
+        os.path.realpath(get_git_repo_root_path(project_current_config_abs_path))
+    ):
         return ""
 
     # Compose URL:


### PR DESCRIPTION
Use `os.path.realpath` to normlize paths before comparisons.