### PR TITLE
Show options hidden by defaults

### DIFF
--- a/docs/feature_stories/FS_02_25_41_81.query_enum_items_func.md
+++ b/docs/feature_stories/FS_02_25_41_81.query_enum_items_func.md
@@ -4,6 +4,8 @@ feature_title: query_enum_items_func
 feature_status: TEST
 ---
 
+Keywords: `describe`, `query`, `enum`
+
 The feature provides a func to enumerate available arg options (based on existing arg values).
 
 This is one of the funcs listed in FS_80_45_89_81 integrated functions.

--- a/docs/feature_stories/FS_72_53_55_13.show_non_default_options.md
+++ b/docs/feature_stories/FS_72_53_55_13.show_non_default_options.md
@@ -1,7 +1,7 @@
 ---
 feature_story: FS_72_53_55_13
 feature_title: show non-default options
-feature_status: TODO
+feature_status: TEST
 ---
 
 FS_72_40_53_00 fill control automatically sets default values (possibly based on some logic)<br/>

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def list_dir(
 setuptools.setup(
     name = "argrelay",
     # See `docs/dev_notes/version_format.md`:
-    version = "0.6.6",
+    version = "0.6.7",
     author = "uvsmtid",
     author_email = "uvsmtid@gmail.com",
     description = "Tab-completion & data search server = total recall for Bash shell",

--- a/src/argrelay/custom_integ/BaseConfigDelegator.py
+++ b/src/argrelay/custom_integ/BaseConfigDelegator.py
@@ -132,14 +132,19 @@ class BaseConfigDelegator(AbstractDelegator):
             for func_config in self.plugin_config_dict[func_configs_].values()
         ]
 
+    def has_fill_control(
+        self,
+    ) -> bool:
+        return True
+
     def run_fill_control(
         self,
         interp_ctx: InterpContext,
-    ) -> None:
+    ) -> bool:
         """
         TODO_54_68_18_12: Support defaults for config-only delegator
         """
-        super().run_fill_control(interp_ctx)
+        return super().run_fill_control(interp_ctx)
 
     def run_invoke_control(
         self,

--- a/src/argrelay/custom_integ/ServiceDelegator.py
+++ b/src/argrelay/custom_integ/ServiceDelegator.py
@@ -260,10 +260,15 @@ class ServiceDelegator(AbstractDelegator):
         ]
         return func_envelopes
 
+    def has_fill_control(
+        self,
+    ) -> bool:
+        return True
+
     def run_fill_control(
         self,
         interp_ctx: "InterpContext",
-    ):
+    ) -> bool:
         func_id = get_func_id_from_interp_ctx(interp_ctx)
         if func_id in [
             goto_host_func_,
@@ -291,6 +296,7 @@ class ServiceDelegator(AbstractDelegator):
                         set_default_to(ServiceArgType.AccessType.name, "ro", access_container)
                     else:
                         set_default_to(ServiceArgType.AccessType.name, "rw", access_container)
+                    return True
 
         elif func_id in [
             list_host_func_,
@@ -299,6 +305,8 @@ class ServiceDelegator(AbstractDelegator):
             pass
         else:
             raise RuntimeError
+
+        return False
 
     def run_invoke_control(
         self,

--- a/src/argrelay/enum_desc/TermColor.py
+++ b/src/argrelay/enum_desc/TermColor.py
@@ -25,15 +25,18 @@ class TermColor(Enum):
 
     fore_dark_red = "\033[31m"
     fore_dark_green = "\033[32m"
+    fore_dark_yellow = "\033[33m"
     fore_dark_cyan = "\033[36m"
     fore_dark_magenta = "\033[35m"
     fore_dark_gray = "\033[90m"
 
+    fore_bright_gray = "\033[90m"
     fore_bright_red = "\033[91m"
     fore_bright_green = "\033[92m"
     fore_bright_yellow = "\033[93m"
     fore_bright_blue = "\033[94m"
     fore_bright_cyan = "\033[96m"
+    fore_bright_magenta = "\033[95m"
     fore_bright_white = "\033[97m"
 
     fore_bold_dark_red = "\033[1;31m"
@@ -89,6 +92,16 @@ class TermColor(Enum):
     """
 
     no_option_to_suggest = fore_dark_gray
+
+    caption_hidden_by_default = fore_bright_magenta
+    """
+    FS_72_53_55_13: Caption for values hidden by default.
+    """
+
+    value_hidden_by_default = fore_dark_yellow
+    """
+    FS_72_53_55_13: Option hidden by default.
+    """
 
     found_count_0 = back_dark_red
     found_count_1 = fore_dark_green

--- a/src/argrelay/handler_response/DescribeLineArgsClientResponseHandler.py
+++ b/src/argrelay/handler_response/DescribeLineArgsClientResponseHandler.py
@@ -31,11 +31,15 @@ class DescribeLineArgsClientResponseHandler(AbstractClientResponseHandler):
     def render_result(
         interp_result: InterpResult,
     ):
+        """
+        FS_02_25_41_81: Renders results `query_enum_items_func` (Alt+Shift+Q)
+        """
 
         # TODO_11_77_28_50: print suggestions in `InterpResult.arg_values`
 
         print()
 
+        # Print command line:
         for i in range(len(interp_result.all_tokens)):
             if i == interp_result.tan_token_ipos:
                 DescribeLineArgsClientResponseHandler.render_tangent_token(interp_result, interp_result.all_tokens[i])
@@ -120,6 +124,24 @@ class DescribeLineArgsClientResponseHandler(AbstractClientResponseHandler):
                         end = ""
                     )
                     print(TermColor.reset_style.value, end = "")
+
+                    # FS_72_53_55_13: Renders options hidden by default:
+                    if len(envelope_container.filled_types_to_values_hidden_by_defaults) != 0:
+
+                        print(" ", end = "")
+                        print(TermColor.caption_hidden_by_default.value, end = "")
+                        print("options:", end = "")
+                        print(TermColor.reset_style.value, end = " ")
+
+                        if arg_type in envelope_container.filled_types_to_values_hidden_by_defaults:
+                            values_hidden_by_defaults = envelope_container.filled_types_to_values_hidden_by_defaults[
+                                arg_type
+                            ]
+                            DescribeLineArgsClientResponseHandler.highlight_prefix(
+                                values_hidden_by_defaults,
+                                value_prefix,
+                                TermColor.value_hidden_by_default,
+                            )
 
                 elif arg_type in envelope_container.remaining_types_to_values:
                     print(" " * indent_size, end = "")

--- a/src/argrelay/plugin_delegator/AbstractDelegator.py
+++ b/src/argrelay/plugin_delegator/AbstractDelegator.py
@@ -93,14 +93,31 @@ class AbstractDelegator(AbstractPlugin):
             curr_container_ipos,
         )
 
+    def has_fill_control(
+        self,
+    ) -> bool:
+        """
+        FS_72_53_55_13: Optimization for showing values hidden by defaults.
+
+        *   If returns True, `run_fill_control` will be called subsequently
+            (and one more query will be run with populated values).
+        *   If returns False, `run_fill_control` will not be called
+            (and extra query is not necessary since there were no change of values by `run_fill_control`).
+        """
+        return False
+
     def run_fill_control(
         self,
         interp_ctx: "InterpContext",
-    ) -> None:
+    ) -> bool:
         """
         Implements FS_72_40_53_00 `fill_control`.
+
+        FS_72_53_55_13: Optimization for showing values hidden by defaults:
+        *   If returns True, it means at least one value was populated = one more query is necessary.
+        *   If returns False, no values were changed = extra query with populated values is not necessary.
         """
-        pass
+        return False
 
     def run_interp_control(
         self,

--- a/src/argrelay/plugin_delegator/QueryEnumDelegator.py
+++ b/src/argrelay/plugin_delegator/QueryEnumDelegator.py
@@ -20,6 +20,9 @@ subsequent_function_container_ipos_ = function_container_ipos_ + 1
 # TODO: Currently, QueryEnumDelegator is implemented by deriving from InterceptDelegator - this is strange.
 #       Use common base class instead, but don't make "QueryEnumDelegator is a InterceptDelegator".
 class QueryEnumDelegator(InterceptDelegator):
+    """
+    FS_02_25_41_81: Implements `query_enum_items_func`.
+    """
 
     def get_supported_func_envelopes(
         self,

--- a/src/argrelay/plugin_interp/AbstractInterp.py
+++ b/src/argrelay/plugin_interp/AbstractInterp.py
@@ -48,8 +48,21 @@ class AbstractInterp:
     def try_iterate(self) -> InterpStep:
         pass
 
-    def delegate_fill_control(self) -> None:
-        pass
+    def has_fill_control(
+        self,
+    ) -> bool:
+        """
+        FS_72_53_55_13: See `AbstractDelegator.has_fill_control` for more information.
+        """
+        return False
+
+    def delegate_fill_control(
+        self,
+    ) -> bool:
+        """
+        FS_72_53_55_13: See `AbstractDelegator.run_fill_control` for more information.
+        """
+        return False
 
     def propose_arg_completion(self) -> None:
         pass

--- a/src/argrelay/plugin_interp/FuncTreeInterp.py
+++ b/src/argrelay/plugin_interp/FuncTreeInterp.py
@@ -182,12 +182,21 @@ class FuncTreeInterp(AbstractInterp):
             self.interp_ctx.curr_container_ipos,
         )
 
-    def delegate_fill_control(self):
+    def has_fill_control(
+        self,
+    ) -> bool:
+        return True
+
+    def delegate_fill_control(
+        self,
+    ) -> bool:
         delegator_plugin = self.get_func_delegator()
         if delegator_plugin:
-            delegator_plugin.run_fill_control(
+            return delegator_plugin.run_fill_control(
                 self.interp_ctx,
             )
+        else:
+            return False
 
     def get_found_func_data_envelope(self) -> Union[dict, None]:
         func_envelope = self.interp_ctx.envelope_containers[(

--- a/src/argrelay/runtime_context/EnvelopeContainer.py
+++ b/src/argrelay/runtime_context/EnvelopeContainer.py
@@ -53,13 +53,27 @@ class EnvelopeContainer:
     When arg value from command line matches one of the values, this arg type moves to `assigned_types_to_values`.
     """
 
-    def populate_implicit_arg_values(self):
+    filled_types_to_values_hidden_by_defaults: dict[str, list[str]] = field(default_factory = lambda: {})
+    """
+    FS_72_53_55_13: values hidden by defaults:
+    This dict stores values which were hidden by applying defaults (see FS_72_40_53_00 fill control).
+    Only keys for those `arg_type`-s which have `ArgSource.InitValue` in `assigned_types_to_values` are listed here.
+    """
+
+    def populate_implicit_arg_values(
+        self,
+    ) -> bool:
         """
         When `data_envelope` is singled out, all remaining single-value `arg_type`-s become `ArgSource.ImplicitValue`.
 
         Implements FS_13_51_07_97 singled out implicit values.
+
+        Return:
+        *   True if any value was assigned.
+        *   False otherwise.
         """
 
+        any_assigned = False
         # Filter as in: FS_31_70_49_15 search control:
         for arg_type in self.search_control.keys_to_types_dict.values():
             if arg_type not in self.assigned_types_to_values:
@@ -70,7 +84,7 @@ class EnvelopeContainer:
                     # When a `data_envelope` is singled out, its array arg value will not be set as
                     # singled out via `ArgSource.ImplicitValue` (user can still select them explicitly).
                     # This is deliberate for now as the selection of specific value out of the array can be used
-                    # by delegators to implement difference in behavior.
+                    # by delegators to implement different in behavior.
 
                     if len(arg_values) == 1:
                         del self.remaining_types_to_values[arg_type]
@@ -79,3 +93,5 @@ class EnvelopeContainer:
                             arg_values[0],
                             ArgSource.ImplicitValue,
                         )
+                        any_assigned = True
+        return any_assigned

--- a/src/argrelay/schema_response/EnvelopeContainerSchema.py
+++ b/src/argrelay/schema_response/EnvelopeContainerSchema.py
@@ -17,7 +17,7 @@ data_envelopes_ = "data_envelopes"
 found_count_ = "found_count"
 assigned_types_to_values_ = "assigned_types_to_values"
 remaining_types_to_values_ = "remaining_types_to_values"
-
+filled_types_to_values_hidden_by_defaults_ = "filled_types_to_values_hidden_by_defaults"
 
 class EnvelopeContainerSchema(Schema):
     class Meta:
@@ -52,6 +52,14 @@ class EnvelopeContainerSchema(Schema):
         required = True,
     )
 
+    filled_types_to_values_hidden_by_defaults = fields.Dict(
+        keys = fields.String(),
+        values = fields.List(
+            fields.String(),
+        ),
+        required = True,
+    )
+
     @post_load
     def make_object(
         self,
@@ -64,6 +72,7 @@ class EnvelopeContainerSchema(Schema):
             found_count = input_dict[found_count_],
             assigned_types_to_values = input_dict[assigned_types_to_values_],
             remaining_types_to_values = input_dict[remaining_types_to_values_],
+            filled_types_to_values_hidden_by_defaults = input_dict[filled_types_to_values_hidden_by_defaults_],
         )
 
 
@@ -88,6 +97,8 @@ envelope_container_desc = TypeDesc(
                 "C_value_3",
                 "C_value_9",
             ],
+        },
+        filled_types_to_values_hidden_by_defaults_: {
         },
     },
     default_file_path = "",

--- a/src/argrelay/test_infra/LocalTestClass.py
+++ b/src/argrelay/test_infra/LocalTestClass.py
@@ -7,6 +7,7 @@ from argrelay.enum_desc.CompType import CompType
 from argrelay.plugin_delegator.AbstractDelegator import AbstractDelegator
 from argrelay.relay_client import __main__
 from argrelay.runtime_context.InterpContext import InterpContext
+from argrelay.runtime_data.AssignedValue import AssignedValue
 from argrelay.schema_response.ArgValuesSchema import arg_values_
 from argrelay.server_spec.CallContext import CallContext
 from argrelay.test_infra import parse_line_and_cpos
@@ -40,7 +41,7 @@ class LocalTestClass(InOutTestClass):
         test_line: str,
         comp_type: CompType,
         expected_suggestions: Union[list[str], None],
-        container_ipos_to_expected_assignments: Union[dict[int, dict[str, str]], None],
+        container_ipos_to_expected_assignments: Union[dict[int, dict[str, AssignedValue]], None],
         delegator_class: Union[Type[AbstractDelegator], None],
         envelope_ipos_to_field_values: Union[dict[int, dict[str, str]], None],
     ):
@@ -50,6 +51,7 @@ class LocalTestClass(InOutTestClass):
             comp_type,
             expected_suggestions,
             container_ipos_to_expected_assignments,
+            None,
             delegator_class,
             envelope_ipos_to_field_values,
             LocalClientEnvMockBuilder(),
@@ -61,7 +63,8 @@ class LocalTestClass(InOutTestClass):
         test_line: str,
         comp_type: CompType,
         expected_suggestions: Union[list[str], None],
-        container_ipos_to_expected_assignments: Union[dict[int, dict[str, str]], None],
+        container_ipos_to_expected_assignments: Union[dict[int, dict[str, AssignedValue]], None],
+        container_ipos_to_options_hidden_by_default_value: Union[dict[int, dict[str, list[str]]], None],
         delegator_class: Union[Type[AbstractDelegator], None],
         envelope_ipos_to_field_values: Union[dict[int, dict[str, str]], None],
         init_env_mock_builder: EnvMockBuilder,
@@ -107,6 +110,7 @@ class LocalTestClass(InOutTestClass):
                 call_ctx,
                 actual_suggestions,
                 container_ipos_to_expected_assignments,
+                container_ipos_to_options_hidden_by_default_value,
                 delegator_class,
                 envelope_ipos_to_field_values,
                 expected_suggestions,

--- a/src/argrelay/test_infra/RemoteTestClass.py
+++ b/src/argrelay/test_infra/RemoteTestClass.py
@@ -8,6 +8,7 @@ from argrelay.client_command_remote.AbstractRemoteClientCommand import AbstractR
 from argrelay.enum_desc.CompType import CompType
 from argrelay.plugin_delegator.AbstractDelegator import AbstractDelegator
 from argrelay.relay_client import __main__
+from argrelay.runtime_data.AssignedValue import AssignedValue
 from argrelay.schema_response.ArgValuesSchema import arg_values_
 from argrelay.test_infra import parse_line_and_cpos
 from argrelay.test_infra.ClientServerTestClass import ClientServerTestClass
@@ -28,7 +29,7 @@ class RemoteTestClass(ClientServerTestClass):
         test_line: str,
         comp_type: CompType,
         expected_suggestions: Union[list[str], None],
-        container_ipos_to_expected_assignments: Union[dict[int, dict[str, str]], None],
+        container_ipos_to_expected_assignments: Union[dict[int, dict[str, AssignedValue]], None],
         delegator_class: Union[Type[AbstractDelegator], None],
         envelope_ipos_to_field_values: Union[dict[int, dict[str, str]], None],
         init_env_mock_builder: EnvMockBuilder,
@@ -88,6 +89,7 @@ class RemoteTestClass(ClientServerTestClass):
                 call_ctx,
                 actual_suggestions,
                 container_ipos_to_expected_assignments,
+                None,
                 delegator_class,
                 envelope_ipos_to_field_values,
                 expected_suggestions,

--- a/tests/offline_tests/config_only_plugins/test_config_only_plugins.py
+++ b/tests/offline_tests/config_only_plugins/test_config_only_plugins.py
@@ -65,6 +65,7 @@ class ThisTestClass(LocalTestClass):
                     None,
                     None,
                     None,
+                    None,
                     LocalClientEnvMockBuilder().set_reset_local_server(False),
                 )
 
@@ -141,6 +142,7 @@ exit 1
                             self.__class__.same_test_data_per_class,
                             test_line,
                             comp_type,
+                            None,
                             None,
                             None,
                             None,

--- a/tests/offline_tests/plugin_delegator/test_HelpDelegator.py
+++ b/tests/offline_tests/plugin_delegator/test_HelpDelegator.py
@@ -5,6 +5,7 @@ from typing import Union
 from argrelay.client_command_local.AbstractLocalClientCommand import AbstractLocalClientCommand
 from argrelay.enum_desc.CompType import CompType
 from argrelay.relay_client import __main__
+from argrelay.runtime_data.AssignedValue import AssignedValue
 from argrelay.schema_request.CallContextSchema import call_context_desc
 from argrelay.test_infra import line_no_from_ctor
 from argrelay.test_infra.CustomTestCase import ShellInputTestCase
@@ -97,7 +98,7 @@ class ThisTestCase(ShellInputTestCase):
         case_comment: str,
         test_line: str,
         comp_type: CompType,
-        container_ipos_to_expected_assignments: dict[int, dict[str, str]],
+        container_ipos_to_expected_assignments: dict[int, dict[str, AssignedValue]],
         sever_action_verifier: ServerActionVerifier,
     ):
         super().__init__(

--- a/tests/offline_tests/relay_demo/test_relay_demo_TD_43_24_76_58_single.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_TD_43_24_76_58_single.py
@@ -67,5 +67,6 @@ class ThisTestClass(LocalTestClass):
                     },
                     None,
                     None,
+                    None,
                     LocalClientEnvMockBuilder().set_reset_local_server(False),
                 )

--- a/tests/offline_tests/relay_demo/test_relay_demo_TD_76_09_29_31_overlapped.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_TD_76_09_29_31_overlapped.py
@@ -100,6 +100,7 @@ class ThisTestClass(LocalTestClass):
                     comp_type,
                     expected_suggestions,
                     container_ipos_to_expected_assignments,
+                    None,
                     delegator_class,
                     None,
                     LocalClientEnvMockBuilder().set_reset_local_server(False),

--- a/tests/offline_tests/relay_demo/test_relay_demo_trees.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_trees.py
@@ -80,6 +80,7 @@ tree_path_selector_2: ? intercept help goto desc list host service repo commit
                     None,
                     None,
                     None,
+                    None,
                     LocalClientEnvMockBuilder().set_reset_local_server(False),
                 )
 

--- a/tests/slow_tests/relay_demo/test_relay_demo_TD_38_03_48_51_large_generated.py
+++ b/tests/slow_tests/relay_demo/test_relay_demo_TD_38_03_48_51_large_generated.py
@@ -68,5 +68,6 @@ class ThisTestClass(LocalTestClass):
                     container_ipos_to_expected_assignments,
                     None,
                     None,
+                    None,
                     LocalClientEnvMockBuilder().set_reset_local_server(False),
                 )


### PR DESCRIPTION
*   If `ArgSource.DefaultValue` is assigned, print all other options which would otherwise possible on `Alt+Shift+Q`.
*   Optimize: skip query if no changes made since the prev one.