### PR TITLE
Consume ambiguous args one by one

### DIFF
--- a/docs/feature_stories/FS_11_87_76_73.highlight_tangent_prefix.md
+++ b/docs/feature_stories/FS_11_87_76_73.highlight_tangent_prefix.md
@@ -39,7 +39,7 @@ But, logically, we can decide whether to highlight each `ArgSource`:
 
     The implicit values are debatable: if it is already selected, should we highlight it of user to override?
 
-    Solution: yes, highlight for now because override is possible - see FS_90_48_11_45 (force-assignment).
+    Solution: yes, highlight for now because override is possible - see FS_90_48_11_45 (forced assignment).
 
 *   `ArgSource.ExplicitPosArg`: Yes
 

--- a/docs/feature_stories/FS_15_79_76_85.line_processor.md
+++ b/docs/feature_stories/FS_15_79_76_85.line_processor.md
@@ -10,7 +10,7 @@ As of now, there is a single implementation:
 
 *   FS_55_57_45_04 enum selector
 
-    Use has to select a function and its args as enum items.
+    User has to select a function and its args as enum items.
 
 TODO: Factor out abstract `LineProcessor` with their individual implementations.
 

--- a/docs/feature_stories/FS_24_50_40_64.arg_types_without_envelope_classes.md
+++ b/docs/feature_stories/FS_24_50_40_64.arg_types_without_envelope_classes.md
@@ -1,8 +1,14 @@
 ---
 feature_story: FS_24_50_40_64
 feature_title: arg types without envelope classes
-feature_status: TEST
+feature_status: OBSOLETE
 ---
+
+TODO: This is obsolete as it seems to be better to stick with creating an `envelope_class`.
+      It is a bit of an overhead, but keeps things consistent.
+      It is especially noticeable after using snake_case style for `data_envelope` prop names while still
+      using CamelCase style for `envelope_class` names.
+      Clean this up in the future.
 
 Some arg types do not have meaningful associated `data_envelope`.
 
@@ -11,4 +17,4 @@ For example, `access_type` (`ro` or `rw`) - it is just a mode of operation
 
 To keep reusing the same suggestion search mechanism,
 it is easier to create as many surrogate `data_envelope` with `envelope_class` = `access_type`
-as there are discrete arg values within that arg type (2, in case of `access_type`: `ro` and `rw`).
+as there are discrete arg values within that arg type (just 2, in case of `access_type`: `ro` and `rw`).

--- a/docs/feature_stories/FS_44_36_84_88.consume_args_one_by_one.md
+++ b/docs/feature_stories/FS_44_36_84_88.consume_args_one_by_one.md
@@ -1,0 +1,22 @@
+---
+feature_story: FS_44_36_84_88
+feature_title: consume args one by one
+feature_status: TEST
+---
+
+This feature trades performance for consistency:
+*   instead of consuming as many user input args matching enums obtained in a previous query,
+*   consume only one user input arg at a time and re-query before next consumption.
+
+The feature is the opposite of these two:
+*   FS_51_67_38_37: impossible arg combinations
+*   FS_90_48_11_45: forced assignment from entire type value space
+
+It is expected that number of queries per request will grow (increasing response time),
+but the matching results are less confusing.
+
+The feature determines behavior for cases like:
+*   TD_76_09_29_31 mutually exclusive arg vals from diff arg types
+
+See also:
+*   FS_76_29_13_28: arg consumption priorities

--- a/docs/feature_stories/FS_51_67_38_37.impossible_arg_combinations.md
+++ b/docs/feature_stories/FS_51_67_38_37.impossible_arg_combinations.md
@@ -1,8 +1,11 @@
 ---
 feature_story: FS_51_67_38_37
 feature_title: impossible arg combinations
-feature_status: TEST
+feature_status: OBSOLETE
 ---
+
+NOTE: This feature is obsoleted by FS_44_36_84_88 consume args one by one.
+NOTE: This feature (or rather situation) is the result of FS_90_48_11_45 forced assignment from entire type value space.
 
 TODO: There is no a single test tagged by this feature - add existing test or create new.
 

--- a/docs/feature_stories/FS_76_29_13_28.arg_consumption_priorities.md
+++ b/docs/feature_stories/FS_76_29_13_28.arg_consumption_priorities.md
@@ -1,0 +1,30 @@
+---
+feature_story: FS_76_29_13_28
+feature_title: arg consumption priorities
+feature_status: TEST
+---
+
+There are two orders which can prioritize arg consumption:
+*   user input: the order in which args are specified on the command line
+*   user config: the order in which arg types are listed in FS_31_70_49_15 `search_control`
+
+This is different from interrogation - when there is no consume-able args anymore
+and user is given suggestion to select from.
+User interrogation is according to "user config" (FS_31_70_49_15 `search_control`) priority.
+
+For the purpose of arg consumption prioritization (at the moment):
+*   user input is used - arg values are tried to be consumed in the order they are specified
+*   user config is ignored - which arg type gets filled next is random
+    (based on dynamic order inside `remaining_types_to_values`)
+
+The feature determines behavior for cases like:
+*   TD_76_09_29_31 overlapped arg vals from diff arg types
+*   TD_76_09_29_31 mutually exclusive arg vals from diff arg types
+
+See also:
+*   FS_44_36_84_88 consume args one by one
+
+TODO: FS_76_29_13_28 Why not define the order based on FS_31_70_49_15 `search_control`
+      (instead of whatever internal order `remaining_types_to_values` has)?
+      It could already be the case that `remaining_types_to_values` are ordered as `search_control`.
+      Why not make it explicit?

--- a/docs/feature_stories/FS_80_82_13_35.option_list_on_describe_with_prefix.md
+++ b/docs/feature_stories/FS_80_82_13_35.option_list_on_describe_with_prefix.md
@@ -1,7 +1,7 @@
 ---
 feature_story: FS_80_82_13_35
 feature_title: option list on describe with prefix
-feature_status: TODO
+feature_status: TBD
 ---
 
 This feature uses tangent token (FS_23_62_89_43) to narrow down enum items listed on `ServerAction.DescribeLineArgs`
@@ -10,7 +10,7 @@ This feature uses tangent token (FS_23_62_89_43) to narrow down enum items liste
 Currently, instead of reducing options on `ServerAction.DescribeLineArgs` (as described in this feature below),
 prefix highlight (FS_11_87_76_73) is used to alleviate the need for this feature (FS_80_82_13_35).
 
-However, when arg value is incomplete (its value does not match any enum item),
+The point: when arg value is incomplete (its value does not match entirely any enum item),
 there is no reduction of options shown in description:
 
 ```sh

--- a/docs/feature_stories/FS_86_73_43_45.server_control_scripts.md
+++ b/docs/feature_stories/FS_86_73_43_45.server_control_scripts.md
@@ -4,7 +4,9 @@ feature_title: server control scripts
 feature_status: TODO
 ---
 
-This feature provides standard framework-supported server control scripts written in Python (for greater test-ability):
+TODO: Re-write the scripts in Python (for greater test-ability).
+
+This feature provides standard framework-supported server control scripts:
 *   start
 *   stop
 *   wait to start

--- a/docs/feature_stories/FS_90_48_11_45.forced_assignment_from_entire_type_value_space.md
+++ b/docs/feature_stories/FS_90_48_11_45.forced_assignment_from_entire_type_value_space.md
@@ -1,11 +1,17 @@
 ---
 feature_story: FS_90_48_11_45
-feature_title: force-assignment from entire type value space
-feature_status: TEST
+feature_title: forced assignment from entire type value space
+feature_status: OBSOLETE
 ---
+
+NOTE: This feature is obsoleted by FS_44_36_84_88 consume args one by one.
+TODO: This behavior is changed (review all the docs related to this and update):
+      Such incompatible values will not be "eaten" because
+      we eat values one-by-one narrowing down (querying) envelopes step-by-step now.
 
 TODO: This was written ahead of the implementation - fix description when implemented.
 TODO: This feature is actually special case of FS_62_25_92_06/FS_13_51_07_97 where `ArgSource.ExplicitValue` overrides `ArgSource.ImplicitValue`.
+NOTE: This feature causes FS_51_67_38_37 impossible arg combinations.
 
 When some args narrow down possible selection,
 then "incompatible" with that selection value appear on the command line,

--- a/docs/task_refs/TODO_70_48_96_29.be_able_to_assert_unconsumed_arg_vals.md
+++ b/docs/task_refs/TODO_70_48_96_29.be_able_to_assert_unconsumed_arg_vals.md
@@ -1,0 +1,7 @@
+
+TODO_70_48_96_29: be able to assert unconsumed arg vals
+
+Do it via some kind of test builder where we can list them optionally (if not specified, not asserted).
+
+See also TODO_32_99_70_35: JSONPath to verify response data.
+

--- a/docs/test_data/TD_27_59_80_86.single_data_envelope_arg_suggestion_and_consumption.md
+++ b/docs/test_data/TD_27_59_80_86.single_data_envelope_arg_suggestion_and_consumption.md
@@ -11,7 +11,7 @@ test_title: single data envelope arg suggestion and consumption
 
 See also both:
 *   `FS_13_51_07_97` for singled out implicit values.
-*   `FS_90_48_11_45` for force-assignment.
+*   `FS_90_48_11_45` for forced assignment.
     However, in case of this `test_data: TD_27_59_80_86`, there is no force assignment,
     the assignment is matching.
 

--- a/docs/test_data/TD_76_09_29_31.overlapped_arg_vals_from_diff_arg_types.md
+++ b/docs/test_data/TD_76_09_29_31.overlapped_arg_vals_from_diff_arg_types.md
@@ -3,11 +3,13 @@ test_data: TD_76_09_29_31
 test_title: overlapped arg vals from diff arg types
 ---
 
-Case: two different `arg_type`-s with some of their `arg_value`-s matching as stings.
+Case: two different `arg_type`-s with some of their `arg_value`-s matching as strings.
 
 For example, in `ServiceArgType`, imagine value `amer.us` is both:
 *   `geo_region`
 *   `host_name`
 
-If such `ArgType`-s used in a query for an object, it is important not
-to consume the same token by more than one `ArgType`.
+If such `ArgType`-s used in a query for an object, it is important:
+*   to consume args according to FS_76_29_13_28 args consumption priority
+    (in the order of arg type list in FS_31_70_49_15 `search_control`)
+*   not to consume the same token by more than one `ArgType`

--- a/docs/test_data/TD_99_99_88_75.mutually_exclusive_arg_vals_from_diff_arg_types.md
+++ b/docs/test_data/TD_99_99_88_75.mutually_exclusive_arg_vals_from_diff_arg_types.md
@@ -1,0 +1,34 @@
+---
+test_data: TD_99_99_88_75
+test_title: mutually exclusive arg vals from diff arg types
+---
+
+Case: two different `arg_type`-s where `data_envelope`-s prop values have mutually exclusive combinations.
+
+# Example
+
+Imagine 2 `ServiceArgType`-s:
+*   `geo_region`
+*   `code_maturity`
+
+Imagine 3 `data_envelope`-s:
+
+```yaml
+data_envelope_1:
+    geo_region: apac
+    code_maturity: qa
+data_envelope_2:
+    geo_region: emea
+    code_maturity: dev
+```
+There are 4 combinations of args and 2 are not mutually exclusive combinations:
+*   selects `data_envelope_1`: apac qa
+*   selects `data_envelope_2`: emea dev
+*   mutually exclusive combinations (selects no `data_envelope`): emea qa
+*   mutually exclusive combinations (selects no `data_envelope`): apac dev
+
+The behavior is governed by FS_44_36_84_88 consume args one by one.
+
+Other related features:
+*   FS_51_67_38_37 impossible arg combinations
+*   FS_90_48_11_45 forced assignment from entire type value space

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def list_dir(
 setuptools.setup(
     name = "argrelay",
     # See `docs/dev_notes/version_format.md`:
-    version = "0.6.8",
+    version = "0.6.9",
     author = "uvsmtid",
     author_email = "uvsmtid@gmail.com",
     description = "Tab-completion & data search server = total recall for Bash shell",

--- a/src/argrelay/custom_integ/BaseConfigDelegator.py
+++ b/src/argrelay/custom_integ/BaseConfigDelegator.py
@@ -164,8 +164,11 @@ class BaseConfigDelegator(AbstractDelegator):
                             # https://stackoverflow.com/a/54071505/441652
                             prop_value = eval(f'f"""{prop_value_template}"""')
 
-                            set_default_to(prop_name, prop_value, interp_ctx.curr_container)
-                            any_assignment = True
+                            any_assignment = (
+                                set_default_to(prop_name, prop_value, interp_ctx.curr_container)
+                                or
+                                any_assignment
+                            )
 
         return any_assignment
 

--- a/src/argrelay/custom_integ/ServiceEnvelopeClass.py
+++ b/src/argrelay/custom_integ/ServiceEnvelopeClass.py
@@ -5,6 +5,7 @@ class ServiceEnvelopeClass(Enum):
     ClassCluster = auto()
     ClassHost = auto()
     ClassService = auto()
+    ClassAccessType = auto()
 
     def __str__(self):
         return self.name

--- a/src/argrelay/custom_integ/ServiceLoader.py
+++ b/src/argrelay/custom_integ/ServiceLoader.py
@@ -70,7 +70,7 @@ class ServiceLoader(AbstractLoader):
             ServiceEnvelopeClass.ClassCluster.name,
             ServiceEnvelopeClass.ClassHost.name,
             ServiceEnvelopeClass.ClassService.name,
-            ServiceArgType.access_type.name,
+            ServiceEnvelopeClass.ClassAccessType.name,
         ]
 
         init_envelop_collections(
@@ -91,7 +91,7 @@ class ServiceLoader(AbstractLoader):
             class_to_collection_map[ServiceEnvelopeClass.ClassService.name]
         ].data_envelopes
         access_envelopes = static_data.envelope_collections[
-            class_to_collection_map[ServiceArgType.access_type.name]
+            class_to_collection_map[ServiceEnvelopeClass.ClassAccessType.name]
         ].data_envelopes
 
         self.populate_common_access_type(access_envelopes)
@@ -101,6 +101,11 @@ class ServiceLoader(AbstractLoader):
             service_envelopes,
         )
         self.populate_TD_76_09_29_31_overlapped(
+            cluster_envelopes,
+            host_envelopes,
+            service_envelopes,
+        )
+        self.populate_TD_99_99_88_75_mutually_exclusive(
             cluster_envelopes,
             host_envelopes,
             service_envelopes,
@@ -222,13 +227,13 @@ class ServiceLoader(AbstractLoader):
             {
                 envelope_payload_: {
                 },
-                ReservedArgType.EnvelopeClass.name: ServiceArgType.access_type.name,
+                ReservedArgType.EnvelopeClass.name: ServiceEnvelopeClass.ClassAccessType.name,
                 ServiceArgType.access_type.name: "ro",
             },
             {
                 envelope_payload_: {
                 },
-                ReservedArgType.EnvelopeClass.name: ServiceArgType.access_type.name,
+                ReservedArgType.EnvelopeClass.name: ServiceEnvelopeClass.ClassAccessType.name,
                 ServiceArgType.access_type.name: "rw",
             },
         ])
@@ -1124,8 +1129,21 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.geo_region.name: "amer",
                 ServiceArgType.flow_stage.name: "downstream",
                 ServiceArgType.cluster_name.name: "dev-amer-downstream",
-                # host_name is intentionally mathing another host_name from different geo_region (also named alike):
+                # host_name is intentionally matching another host_name from different geo_region (also named alike):
                 ServiceArgType.host_name.name: "emea",
+            },
+
+            {
+                envelope_payload_: {
+                },
+                test_data_: "TD_76_09_29_31",  # overlapped
+                ReservedArgType.EnvelopeClass.name: ServiceEnvelopeClass.ClassHost.name,
+                ServiceArgType.code_maturity.name: "dev",
+                ServiceArgType.geo_region.name: "amer",
+                ServiceArgType.flow_stage.name: "downstream",
+                ServiceArgType.cluster_name.name: "dev-amer-downstream",
+                # host_name is intentionally matching another host_name from different geo_region (also named alike):
+                ServiceArgType.host_name.name: "host-3-amer",
             },
 
             {
@@ -1151,8 +1169,110 @@ class ServiceLoader(AbstractLoader):
                 ServiceArgType.geo_region.name: "emea",
                 ServiceArgType.flow_stage.name: "downstream",
                 ServiceArgType.cluster_name.name: "dev-emea-downstream",
-                # host_name is intentionally mathing another host_name from different geo_region (also named alike):
+                # host_name is intentionally matching another host_name from different geo_region (also named alike):
                 ServiceArgType.host_name.name: "amer",
+            },
+
+            {
+                envelope_payload_: {
+                },
+                test_data_: "TD_76_09_29_31",  # overlapped
+                ReservedArgType.EnvelopeClass.name: ServiceEnvelopeClass.ClassHost.name,
+                ServiceArgType.code_maturity.name: "dev",
+                ServiceArgType.geo_region.name: "emea",
+                ServiceArgType.flow_stage.name: "downstream",
+                ServiceArgType.cluster_name.name: "dev-emea-downstream",
+                # host_name is intentionally matching another host_name from different geo_region (also named alike):
+                ServiceArgType.host_name.name: "host-3-emea",
+            },
+        ])
+
+    def populate_TD_99_99_88_75_mutually_exclusive(
+        self,
+        cluster_envelopes: list[dict],
+        host_envelopes: list[dict],
+        service_envelopes: list[dict],
+    ):
+        if not self.is_test_data_allowed("TD_99_99_88_75"):
+            return
+
+        cluster_envelopes.extend([
+
+            ############################################################################################################
+            # TD_99_99_88_75 # mutually exclusive: clusters
+
+            {
+                envelope_payload_: {
+                },
+                test_data_: "TD_99_99_88_75",  # mutually exclusive
+                ReservedArgType.EnvelopeClass.name: ServiceEnvelopeClass.ClassCluster.name,
+                ServiceArgType.code_maturity.name: "qa",
+                ServiceArgType.geo_region.name: "apac",
+                ServiceArgType.flow_stage.name: "downstream",
+                ServiceArgType.cluster_name.name: "dev-amer-downstream",
+            },
+
+            {
+                envelope_payload_: {
+                },
+                test_data_: "TD_99_99_88_75",  # mutually exclusive
+                ReservedArgType.EnvelopeClass.name: ServiceEnvelopeClass.ClassCluster.name,
+                ServiceArgType.code_maturity.name: "dev",
+                ServiceArgType.geo_region.name: "emea",
+                ServiceArgType.flow_stage.name: "downstream",
+                ServiceArgType.cluster_name.name: "dev-emea-downstream",
+            },
+        ])
+
+        host_envelopes.extend([
+
+            ############################################################################################################
+            # TD_99_99_88_75 # mutually exclusive: hosts
+
+            {
+                envelope_payload_: {
+                },
+                test_data_: "TD_99_99_88_75",  # mutually exclusive
+                ReservedArgType.EnvelopeClass.name: ServiceEnvelopeClass.ClassHost.name,
+                ServiceArgType.code_maturity.name: "qa",
+                ServiceArgType.geo_region.name: "apac",
+                ServiceArgType.flow_stage.name: "downstream",
+                ServiceArgType.cluster_name.name: "qa-apac-downstream",
+                ServiceArgType.host_name.name: "host-a-1",
+            },
+            {
+                envelope_payload_: {
+                },
+                test_data_: "TD_99_99_88_75",  # mutually exclusive
+                ReservedArgType.EnvelopeClass.name: ServiceEnvelopeClass.ClassHost.name,
+                ServiceArgType.code_maturity.name: "qa",
+                ServiceArgType.geo_region.name: "apac",
+                ServiceArgType.flow_stage.name: "downstream",
+                ServiceArgType.cluster_name.name: "qa-apac-downstream",
+                ServiceArgType.host_name.name: "host-a-2",
+            },
+
+            {
+                envelope_payload_: {
+                },
+                test_data_: "TD_99_99_88_75",  # mutually exclusive
+                ReservedArgType.EnvelopeClass.name: ServiceEnvelopeClass.ClassHost.name,
+                ServiceArgType.code_maturity.name: "dev",
+                ServiceArgType.geo_region.name: "emea",
+                ServiceArgType.flow_stage.name: "downstream",
+                ServiceArgType.cluster_name.name: "dev-emea-downstream",
+                ServiceArgType.host_name.name: "host-b-1",
+            },
+            {
+                envelope_payload_: {
+                },
+                test_data_: "TD_99_99_88_75",  # mutually exclusive
+                ReservedArgType.EnvelopeClass.name: ServiceEnvelopeClass.ClassHost.name,
+                ServiceArgType.code_maturity.name: "dev",
+                ServiceArgType.geo_region.name: "emea",
+                ServiceArgType.flow_stage.name: "downstream",
+                ServiceArgType.cluster_name.name: "dev-emea-downstream",
+                ServiceArgType.host_name.name: "host-b-2",
             },
         ])
 

--- a/src/argrelay/custom_integ_res/argrelay_common_lib.bash
+++ b/src/argrelay/custom_integ_res/argrelay_common_lib.bash
@@ -69,7 +69,7 @@ function ensure_inside_dev_shell {
 }
 
 function remove_pid_file_if_stale {
-    # Use case: clean up stale pid file.
+    # Use case (FS_86_73_43_45): clean up stale pid file.
 
     pid_file="${1}"
 
@@ -87,7 +87,7 @@ function remove_pid_file_if_stale {
 }
 
 function kill_via_pid_file_or_ensure_closed_port {
-    # Use case: trigger server shut down if pid file exists or ensure server is down otherwise.
+    # Use case (FS_86_73_43_45): trigger server shut down if pid file exists or ensure server is down otherwise.
     # Unlike `wait_for_closed_port`, this func does not wait for port to close.
     # It only ensures port is closed when there is no pid file.
 
@@ -126,7 +126,7 @@ function kill_via_pid_file_or_ensure_closed_port {
 }
 
 function exit_if_port_open {
-    # Use case: do nothing if server is up (exit current process).
+    # Use case (FS_86_73_43_45): do nothing if server is up (exit current process).
 
     server_host_name="${1}"
     server_port_number="${2}"
@@ -148,7 +148,7 @@ function exit_if_port_open {
 }
 
 function wait_for_open_port {
-    # Use case: ensure server is up before return.
+    # Use case (FS_86_73_43_45): ensure server is up before return.
 
     timeout_sec="${1}"
     pid_file="${2}"
@@ -182,7 +182,7 @@ function wait_for_open_port {
 }
 
 function wait_for_closed_port {
-    # Use case: ensure server is down before return.
+    # Use case  (FS_86_73_43_45): ensure server is down before return.
     # Unlike `kill_via_pid_file_or_ensure_closed_port`, this func does not trigger server shut down.
 
     timeout_sec="${1}"

--- a/src/argrelay/enum_desc/DistinctValuesQuery.py
+++ b/src/argrelay/enum_desc/DistinctValuesQuery.py
@@ -21,9 +21,9 @@ class DistinctValuesQuery(Enum):
                        object_multiplier         3         4         5         6         7         8         9
                             object_count       243      1024      3125      7776     16807     32768     59049
         --------------------------------
-                  original_find_and_loop     0.009     0.030     0.115     0.440     1.632     6.137    33.669
-                         native_distinct     0.038     0.122     0.363     0.969     2.183     4.740     7.102
-                        native_aggregate     0.044     0.151     0.679     2.899    13.257    49.728   292.153
+                  original_find_and_loop     0.011     0.035     0.122     0.461     1.650     5.945    27.836
+                         native_distinct     0.062     0.192     0.576     1.455     2.993     6.287    10.603
+                        native_aggregate     0.084     0.212     0.909     3.650    15.173    58.340   326.188
         ================================
         use_mongomock: True
         use_single_collection: False
@@ -31,9 +31,9 @@ class DistinctValuesQuery(Enum):
                        object_multiplier         3         4         5         6         7         8         9
                             object_count       243      1024      3125      7776     16807     32768     59049
         --------------------------------
-                  original_find_and_loop     0.006     0.018     0.113     0.414     1.662     5.831    29.375
-                         native_distinct     0.027     0.096     0.327     0.812     1.830     3.578     6.403
-                        native_aggregate     0.020     0.066     0.258     1.108     4.923    17.561    95.461
+                  original_find_and_loop     0.007     0.028     0.096     0.439     1.672     5.939    27.561
+                         native_distinct     0.048     0.159     0.465     1.224     2.725     5.539     9.572
+                        native_aggregate     0.031     0.109     0.398     1.758     7.802    28.463   126.566
         ```
 
         *   The fastest on small collections is `original_find_and_loop`.
@@ -49,9 +49,9 @@ class DistinctValuesQuery(Enum):
                        object_multiplier         3         4         5         6         7         8         9
                             object_count       243      1024      3125      7776     16807     32768     59049
         --------------------------------
-                  original_find_and_loop     0.013     0.023     0.043     0.090     0.182     0.428     0.746
-                         native_distinct     0.041     0.065     0.117     0.241     0.462     0.796     1.458
-                        native_aggregate     0.022     0.027     0.050     0.081     0.125     0.210     0.368
+                  original_find_and_loop     0.022     0.031     0.065     0.115     0.222     0.505     0.748
+                         native_distinct     0.063     0.102     0.195     0.435     0.857     1.493     2.591
+                        native_aggregate     0.022     0.038     0.064     0.109     0.165     0.324     0.469
         ================================
         use_mongomock: False
         use_single_collection: False
@@ -59,9 +59,9 @@ class DistinctValuesQuery(Enum):
                        object_multiplier         3         4         5         6         7         8         9
                             object_count       243      1024      3125      7776     16807     32768     59049
         --------------------------------
-                  original_find_and_loop     0.015     0.020     0.039     0.087     0.148     0.345     0.633
-                         native_distinct     0.044     0.048     0.087     0.173     0.299     0.512     0.903
-                        native_aggregate     0.016     0.021     0.033     0.054     0.086     0.159     0.231
+                  original_find_and_loop     0.020     0.025     0.048     0.144     0.175     0.383     0.590
+                         native_distinct     0.048     0.067     0.123     0.228     0.365     0.594     0.991
+                        native_aggregate     0.022     0.027     0.040     0.067     0.109     0.176     0.271
         ```
 
         The fastest is `native_aggregate`.

--- a/src/argrelay/plugin_delegator/InterceptDelegator.py
+++ b/src/argrelay/plugin_delegator/InterceptDelegator.py
@@ -80,6 +80,7 @@ class InterceptDelegator(AbstractJumpDelegator):
         interp_ctx: InterpContext,
     ) -> bool:
         func_id = get_func_id_from_interp_ctx(interp_ctx)
+        any_assignment = False
         if func_id in [
             SpecialFunc.intercept_invocation_func.name,
         ]:
@@ -88,9 +89,13 @@ class InterceptDelegator(AbstractJumpDelegator):
                 format_output_container = interp_ctx.envelope_containers[(
                     interp_ctx.curr_interp.base_container_ipos + format_output_container_ipos_
                 )]
-                set_default_to(output_format_prop_name, OutputFormat.json_format.name, format_output_container)
-                return True
-        return False
+                any_assignment = (
+                    set_default_to(output_format_prop_name, OutputFormat.json_format.name, format_output_container)
+                    or
+                    any_assignment
+                )
+
+        return any_assignment
 
     def run_invoke_control(
         self,

--- a/src/argrelay/plugin_interp/AbstractInterp.py
+++ b/src/argrelay/plugin_interp/AbstractInterp.py
@@ -39,11 +39,36 @@ class AbstractInterp:
     def __str__(self) -> str:
         return f"fid: {self.interp_factory_id} path: {self.interp_ctx.interp_tree_abs_path} instance: {self.instance_number}"
 
-    def consume_key_args(self) -> None:
-        pass
+    def consumes_args_at_once(self) -> bool:
+        """
+        Tell whether this interp consumes args one by one (FS_44_36_84_88) - see `consume_pos_arg` for details.
+        """
+        return False
 
-    def consume_pos_args(self) -> None:
-        pass
+    def consume_key_args(self) -> bool:
+        """
+        Same as `consume_pos_args`, but for keyword arguments.
+        """
+        # TODO: FS_20_88_05_60 named args: stub
+        return False
+
+    def consume_pos_args(self) -> bool:
+        """
+        Consume (usually) one arg at time: if consumed, return True, otherwise return False.
+
+        If interp consumes all args at once,
+        it has to override `consumes_args_at_once` to return `True`.
+
+        Whether to consume more than one arg depends on whether it causes situation like
+        FS_51_67_38_37 (impossible arg combinations). For example:
+        *   FS_26_43_73_72 (func tree)
+            All args (for func `data_container` or subsequent func `data_container` as arguments) has to be
+            consumed one by one FS_44_36_84_88) because user is allowed to specify them in any order and
+            consuming several at a time will cause FS_51_67_38_37 (impossible arg combinations).
+        *   FS_01_89_09_24 (interp tree)
+            All args can be consumed at once because user has to specify them in the order of the interp tree path.
+        """
+        return False
 
     def try_iterate(self) -> InterpStep:
         pass

--- a/src/argrelay/runtime_context/EnvelopeContainer.py
+++ b/src/argrelay/runtime_context/EnvelopeContainer.py
@@ -64,6 +64,8 @@ class EnvelopeContainer:
         self,
     ) -> bool:
         """
+        When possible arg_values are singled out, assign them as `ArgSource.ImplicitValue`.
+
         When `data_envelope` is singled out, all remaining single-value `arg_type`-s become `ArgSource.ImplicitValue`.
 
         Implements FS_13_51_07_97 singled out implicit values.

--- a/src/argrelay/schema_config_core_server/ServerConfigSchema.py
+++ b/src/argrelay/schema_config_core_server/ServerConfigSchema.py
@@ -125,7 +125,7 @@ server_config_desc = TypeDesc(
             ServiceEnvelopeClass.ClassCluster.name: ServiceEnvelopeClass.ClassCluster.name,
             ServiceEnvelopeClass.ClassHost.name: ServiceEnvelopeClass.ClassHost.name,
             ServiceEnvelopeClass.ClassService.name: ServiceEnvelopeClass.ClassService.name,
-            ServiceArgType.access_type.name: ServiceArgType.access_type.name,
+            ServiceEnvelopeClass.ClassAccessType.name: ServiceEnvelopeClass.ClassAccessType.name,
         },
         server_plugin_control_: server_plugin_control_desc.dict_example,
         plugin_instance_entries_: {

--- a/src/argrelay/test_infra/InOutTestClass.py
+++ b/src/argrelay/test_infra/InOutTestClass.py
@@ -31,7 +31,6 @@ class InOutTestClass(BaseTestClass):
         try:
 
             if expected_suggestions is not None:
-                # If `expected_suggestions`, verify them:
                 self.assertEqual(expected_suggestions, actual_suggestions)
 
             if container_ipos_to_expected_assignments is not None:
@@ -80,15 +79,12 @@ class InOutTestClass(BaseTestClass):
                 self.assertIsNone(delegator_class)
                 self.assertIsNone(envelope_ipos_to_field_values)
             elif call_ctx.server_action is ServerAction.DescribeLineArgs:
-                # TODO: TODO_11_77_28_50 suggestions are already in all responses:
-                self.assertIsNone(expected_suggestions)
                 # TODO: TODO_42_81_01_90: assert data instead of print out: there will be no delegator_class, but a mock to intercept response for enum query:
                 self.assertIsNone(delegator_class)
                 # TODO: TODO_42_81_01_90: assert data instead of print out: the data should be available:
                 self.assertIsNone(envelope_ipos_to_field_values)
             elif call_ctx.server_action is ServerAction.RelayLineArgs:
-                # TODO: TODO_11_77_28_50 suggestions are already in all responses:
-                self.assertIsNone(expected_suggestions)
+                pass
             else:
                 raise RuntimeError
 

--- a/src/argrelay/test_infra/LocalTestClass.py
+++ b/src/argrelay/test_infra/LocalTestClass.py
@@ -45,7 +45,7 @@ class LocalTestClass(InOutTestClass):
         delegator_class: Union[Type[AbstractDelegator], None],
         envelope_ipos_to_field_values: Union[dict[int, dict[str, str]], None],
     ):
-        self.verify_output_with_via_local_client(
+        self.verify_output_via_local_client(
             test_data,
             test_line,
             comp_type,
@@ -57,7 +57,7 @@ class LocalTestClass(InOutTestClass):
             LocalClientEnvMockBuilder(),
         )
 
-    def verify_output_with_via_local_client(
+    def verify_output_via_local_client(
         self,
         test_data: str,
         test_line: str,

--- a/src/argrelay/test_infra/RemoteTestClass.py
+++ b/src/argrelay/test_infra/RemoteTestClass.py
@@ -24,7 +24,7 @@ class RemoteTestClass(ClientServerTestClass):
     """
 
     # TODO: Allow intercepting subprocess.* invocation and asserting their input (e.g. whether specific command was invoked).
-    def verify_output_with_via_remote_client(
+    def verify_output_via_remote_client(
         self,
         test_line: str,
         comp_type: CompType,

--- a/tests/offline_tests/config_only_plugins/test_config_only_plugins.py
+++ b/tests/offline_tests/config_only_plugins/test_config_only_plugins.py
@@ -60,7 +60,7 @@ class ThisTestClass(LocalTestClass):
                     case_comment,
                 ) = test_case
 
-                self.verify_output_with_via_local_client(
+                self.verify_output_via_local_client(
                     self.__class__.same_test_data_per_class,
                     test_line,
                     comp_type,
@@ -120,7 +120,7 @@ class ThisTestClass(LocalTestClass):
                     expected_suggestions,
                     case_comment,
                 ) = test_case
-                self.verify_output_with_via_local_client(
+                self.verify_output_via_local_client(
                     self.__class__.same_test_data_per_class,
                     test_line,
                     comp_type,
@@ -201,7 +201,7 @@ exit 1
 
                 with mock_subprocess_popen(popen_mock_config) as popen_mock:
                     with self.assertRaises(SystemExit) as cm:
-                        self.verify_output_with_via_local_client(
+                        self.verify_output_via_local_client(
                             self.__class__.same_test_data_per_class,
                             test_line,
                             comp_type,

--- a/tests/offline_tests/plugin_interp/test_InterpTreeInterp.py
+++ b/tests/offline_tests/plugin_interp/test_InterpTreeInterp.py
@@ -88,7 +88,7 @@ class ThisTestClass(LocalTestClass):
                 line_no(),
                 "some_command host qa upstream amer qw goto ro s_c green rtyu-qu |",
                 CompType.PrefixShown,
-                ["amer", "emea"],
+                ["amer", "emea", "host-3-amer"],
                 {},
                 None,
                 "FS_01_89_09_24: Even if `intercept` is not specified in the beginning, "
@@ -101,7 +101,7 @@ class ThisTestClass(LocalTestClass):
                 # TODO: FS_23_62_89_43: This can be fixed to take into account cursor position
                 #                       and suggest not only missing args for already populated command line,
                 #                       but also internal functions available for that position (e.g. `intercept`)
-                ["amer", "emea"],
+                ["amer", "emea", "host-3-amer"],
                 {},
                 None,
                 "FS_01_89_09_24: Suggest functions available for this position "

--- a/tests/offline_tests/relay_demo/test_relay_demo.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo.py
@@ -183,6 +183,17 @@ class ThisTestClass(LocalTestClass):
                 "FS_92_75_93_01: Register bug that double quotes (which are used as special char in JSON format) "
                 "are at causing interpretation problem to suggest completion options for tangent arg.",
             ),
+            (
+                line_no(), "some_command goto host dev downstream amer amer|", CompType.PrefixShown,
+                [],
+                "Step 1: No suggestions because FS_23_62_89_43 tangent token narrows down selection to 0 options."
+            ),
+            (
+                line_no(), "some_command goto host dev downstream amer amer |", CompType.PrefixShown,
+                ['apac', 'emea'],
+                "Step 2: Some suggestions exists because FS_23_62_89_43 tangent token is not present and "
+                "the logic skips unconsumed args suggesting what is missing for the next arg type. ",
+            ),
         ]
         # @formatter:on
 
@@ -196,7 +207,11 @@ class ThisTestClass(LocalTestClass):
                     case_comment,
                 ) = test_case
 
-                self.verify_output_with_via_local_client(
+                # # TODO: Delete this:
+                # if line_number != 59:
+                #     continue
+
+                self.verify_output_via_local_client(
                     self.__class__.same_test_data_per_class,
                     test_line,
                     comp_type,
@@ -217,6 +232,8 @@ class ThisTestClass(LocalTestClass):
             (
                 line_no(),
                 "some_command list host dev |",
+                # For `CompType.InvokeAction`, suggestions are in payload but always empty list:
+                [],
                 {
                     0: {
                         # TODO: Use `ExplicitPosArg` for the first arg instead of `InitValue`:
@@ -269,6 +286,8 @@ class ThisTestClass(LocalTestClass):
             (
                 line_no(),
                 "some_command goto service s_b prod |",
+                # For `CompType.InvokeAction`, suggestions are in payload but always empty list:
+                [],
                 {
                     0: {
                         f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
@@ -316,17 +335,18 @@ class ThisTestClass(LocalTestClass):
                 (
                     line_number,
                     test_line,
+                    expected_suggestions,
                     container_ipos_to_expected_assignments,
                     delegator_class,
                     envelope_ipos_to_field_values,
                     case_comment,
                 ) = test_case
 
-                self.verify_output_with_via_local_client(
+                self.verify_output_via_local_client(
                     self.__class__.same_test_data_per_class,
                     test_line,
                     CompType.InvokeAction,
-                    None,
+                    expected_suggestions,
                     container_ipos_to_expected_assignments,
                     None,
                     delegator_class,
@@ -382,7 +402,7 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: [none]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}data_center: dc.22 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}ip_address: ip.172.16.2.1 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
-{ServiceArgType.access_type.name}: {TermColor.found_count_0.value}0{TermColor.reset_style.value}
+{ServiceEnvelopeClass.ClassAccessType.name}: {TermColor.found_count_0.value}0{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.no_option_to_suggest.value}access_type: [none]{TermColor.reset_style.value}
 """,
             ),
@@ -403,7 +423,7 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.remaining_value.value}cluster_name: ?{TermColor.reset_style.value} dev-amer-upstream dev-apac-upstream dev-emea-upstream prod-apac-upstream qa-amer-upstream qa-apac-upstream 
 {" " * indent_size}{TermColor.remaining_value.value}host_name: ?{TermColor.reset_style.value} asdf-du hjkl-qu poiu-qu qwer-du qwer-pd-1 qwer-pd-2 qwer-pd-3 rt-qu rtyu-qu zxcv-du 
 {" " * indent_size}{TermColor.remaining_value.value}ip_address: ?{TermColor.reset_style.value} ip.172.16.2.1 ip.172.16.4.2 ip.172.16.7.2 ip.192.168.1.1 ip.192.168.3.1 ip.192.168.4.1 ip.192.168.6.1 ip.192.168.6.2 ip.192.168.7.1 ip.192.168.7.2 
-{ServiceArgType.access_type.name}: {TermColor.found_count_0.value}0{TermColor.reset_style.value}
+{ServiceEnvelopeClass.ClassAccessType.name}: {TermColor.found_count_0.value}0{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.no_option_to_suggest.value}access_type: [none]{TermColor.reset_style.value}
 """,
             ),
@@ -427,7 +447,7 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: [none]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}data_center: dc.07 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}ip_address: ip.192.168.7.1 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
-{ServiceArgType.access_type.name}: {TermColor.found_count_0.value}0{TermColor.reset_style.value}
+{ServiceEnvelopeClass.ClassAccessType.name}: {TermColor.found_count_0.value}0{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.no_option_to_suggest.value}access_type: [none]{TermColor.reset_style.value}
 """,
             ),
@@ -588,7 +608,7 @@ class ThisTestClass(LocalTestClass):
                     expected_assignments,
                     case_comment,
                 ) = test_case
-                self.verify_output_with_via_local_client(
+                self.verify_output_via_local_client(
                     self.__class__.same_test_data_per_class,
                     test_line,
                     comp_type,
@@ -662,7 +682,7 @@ class ThisTestClass(LocalTestClass):
                     expected_suggestions,
                     case_comment,
                 ) = test_case
-                self.verify_output_with_via_local_client(
+                self.verify_output_via_local_client(
                     self.__class__.same_test_data_per_class,
                     test_line,
                     comp_type,
@@ -722,7 +742,7 @@ class ThisTestClass(LocalTestClass):
                     envelope_ipos_to_field_values,
                     case_comment,
                 ) = test_case
-                self.verify_output_with_via_local_client(
+                self.verify_output_via_local_client(
                     self.__class__.same_test_data_per_class,
                     test_line,
                     CompType.InvokeAction,
@@ -776,7 +796,7 @@ class ThisTestClass(LocalTestClass):
                     expected_suggestions,
                     case_comment,
                 ) = test_case
-                self.verify_output_with_via_local_client(
+                self.verify_output_via_local_client(
                     self.__class__.same_test_data_per_class,
                     test_line,
                     comp_type,
@@ -811,7 +831,7 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: [none]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}data_center: dc.01 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}ip_address: ip.192.168.1.3 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
-{ServiceArgType.access_type.name}: {TermColor.found_count_1.value}1{TermColor.reset_style.value}
+{ServiceEnvelopeClass.ClassAccessType.name}: {TermColor.found_count_1.value}1{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}access_type: rw {TermColor.other_assigned_arg_value.value}[{ArgSource.DefaultValue.name}]{TermColor.reset_style.value} {TermColor.caption_hidden_by_default.value}{DescribeLineArgsClientResponseHandler.default_overrides_caption}:{TermColor.reset_style.value} {TermColor.value_hidden_by_default.value}ro{TermColor.reset_style.value} {TermColor.value_hidden_by_default.value}rw{TermColor.reset_style.value} 
 """,
             ),
@@ -835,7 +855,7 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: [none]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}data_center: dc.01 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}ip_address: ip.192.168.1.3 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
-{ServiceArgType.access_type.name}: {TermColor.found_count_1.value}1{TermColor.reset_style.value}
+{ServiceEnvelopeClass.ClassAccessType.name}: {TermColor.found_count_1.value}1{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}access_type: {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}r{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}w{TermColor.reset_style.value} {TermColor.other_assigned_arg_value.value}[{ArgSource.DefaultValue.name}]{TermColor.reset_style.value} {TermColor.caption_hidden_by_default.value}{DescribeLineArgsClientResponseHandler.default_overrides_caption}:{TermColor.reset_style.value} {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}r{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}o{TermColor.reset_style.value} {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}r{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}w{TermColor.reset_style.value} 
 """,
             ),

--- a/tests/offline_tests/relay_demo/test_relay_demo_TD_43_24_76_58_single.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_TD_43_24_76_58_single.py
@@ -57,7 +57,7 @@ class ThisTestClass(LocalTestClass):
                     case_comment,
                 ) = test_case
 
-                self.verify_output_with_via_local_client(
+                self.verify_output_via_local_client(
                     self.__class__.same_test_data_per_class,
                     test_line,
                     comp_type,

--- a/tests/offline_tests/relay_demo/test_relay_demo_TD_76_09_29_31_overlapped.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_TD_76_09_29_31_overlapped.py
@@ -17,6 +17,9 @@ class ThisTestClass(LocalTestClass):
     def test_propose_auto_comp_TD_76_09_29_31_overlapped(self):
         """
         Test arg values suggestion with TD_76_09_29_31 # overlapped
+
+        Tests:
+        *   FS_76_29_13_28 arg consumption priorities
         """
 
         test_cases = [
@@ -25,43 +28,98 @@ class ThisTestClass(LocalTestClass):
                 "some_command host dev goto downstream |",
                 CompType.PrefixShown,
                 ["amer", "emea"],
-                {},
-                None,
-                "TD_76_09_29_31: geo_region set is suggested (while host_name set is the same)",
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ServiceArgType.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
+                        ServiceArgType.geo_region.name: None,
+                        ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ExplicitPosArg),
+                        ServiceArgType.cluster_name.name: None,
+                        ServiceArgType.host_name.name: None,
+                    },
+                    3: None,
+                },
+                "TD_76_09_29_31: Step 1: geo_region is suggested "
+                "(host_name is not yet based on FS_76_29_13_28 arg consumption priorities)",
             ),
             (
                 line_no(),
                 "some_command host dev goto downstream amer |",
                 CompType.PrefixShown,
-                ["amer", "emea"],
-                {},
-                None,
-                "TD_76_09_29_31: host_name set is suggested (while geo_region set is the same)",
+                ["amer", "emea", "host-3-amer"],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ServiceArgType.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
+                        ServiceArgType.geo_region.name: AssignedValue("amer", ArgSource.ExplicitPosArg),
+                        ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ExplicitPosArg),
+                        ServiceArgType.cluster_name.name: AssignedValue("dev-amer-downstream", ArgSource.ImplicitValue),
+                        ServiceArgType.host_name.name: None,
+                    },
+                    3: None,
+                },
+                "TD_76_09_29_31: Step 2: host_name is suggested "
+                "(while geo_region is already assigned based on FS_76_29_13_28 arg consumption priorities)",
             ),
             (
                 line_no(),
                 "some_command goto host dev downstream amer am|",
                 CompType.PrefixShown,
                 ["amer"],
-                {},
-                None,
-                "TD_76_09_29_31 # overlapped: one of the explicit value matches more than one type, "
-                "but it is not assigned to all arg types => some suggestion for incomplete missing arg types",
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ServiceArgType.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
+                        ServiceArgType.geo_region.name: AssignedValue("amer", ArgSource.ExplicitPosArg),
+                        ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ExplicitPosArg),
+                        ServiceArgType.cluster_name.name: AssignedValue("dev-amer-downstream", ArgSource.ImplicitValue),
+                        ServiceArgType.host_name.name: None,
+                    },
+                    3: None,
+                },
+                "TD_76_09_29_31 overlapped: Step 1: one of the explicit value matches more than one type, "
+                "but it is not assigned to all arg types => suggest only for incomplete missing arg types",
             ),
             (
                 line_no(),
-                "some_command goto host dev downstream amer amer |",
+                "some_command goto host dev downstream amer host|",
                 CompType.PrefixShown,
-                [],
-                {},
-                None,
-                "TD_76_09_29_31 # overlapped: all values assigned - no more suggestions",
+                ["host-3-amer"],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ServiceArgType.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
+                        ServiceArgType.geo_region.name: AssignedValue("amer", ArgSource.ExplicitPosArg),
+                        ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ExplicitPosArg),
+                        ServiceArgType.cluster_name.name: AssignedValue("dev-amer-downstream", ArgSource.ImplicitValue),
+                        ServiceArgType.host_name.name: None,
+                    },
+                    3: None,
+                },
+                "TD_76_09_29_31 overlapped: Step 1: one of the explicit value matches more than one type, "
+                "but it is not assigned to all arg types => suggest only for incomplete missing arg types",
             ),
             (
                 line_no(),
                 "some_command host dev goto downstream amer amer |",
-                CompType.InvokeAction,
-                None,
+                CompType.DescribeArgs,
+                [],
                 {
                     0: {
                         f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
@@ -75,10 +133,12 @@ class ThisTestClass(LocalTestClass):
                         ServiceArgType.cluster_name.name: AssignedValue("dev-amer-downstream", ArgSource.ImplicitValue),
                         ServiceArgType.host_name.name: AssignedValue("amer", ArgSource.ExplicitPosArg),
                     },
+                    3: None,
                 },
-                # TODO: add verification of consumed and unconsumed tokens
-                ErrorDelegator,
-                "TD_76_09_29_31: Both geo_region and host_name are correctly assigned",
+                # TODO_70_48_96_29: add verification of consumed and unconsumed tokens
+                "TD_76_09_29_31 overlapped: "
+                "Both geo_region and host_name are correctly assigned. "
+                "All values assigned - no more suggestions. ",
             ),
         ]
 
@@ -90,18 +150,17 @@ class ThisTestClass(LocalTestClass):
                     comp_type,
                     expected_suggestions,
                     container_ipos_to_expected_assignments,
-                    delegator_class,
                     case_comment,
                 ) = test_case
 
-                self.verify_output_with_via_local_client(
+                self.verify_output_via_local_client(
                     self.__class__.same_test_data_per_class,
                     test_line,
                     comp_type,
                     expected_suggestions,
                     container_ipos_to_expected_assignments,
                     None,
-                    delegator_class,
+                    None,
                     None,
                     LocalClientEnvMockBuilder().set_reset_local_server(False),
                 )

--- a/tests/offline_tests/relay_demo/test_relay_demo_TD_99_99_88_75_mutually_exclusive.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_TD_99_99_88_75_mutually_exclusive.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from argrelay.custom_integ.ServiceArgType import ServiceArgType
+from argrelay.enum_desc.ArgSource import ArgSource
+from argrelay.enum_desc.CompType import CompType
+from argrelay.plugin_delegator.ErrorDelegator import ErrorDelegator
+from argrelay.plugin_interp.FuncTreeInterpFactory import func_envelope_path_step_prop_name
+from argrelay.runtime_data.AssignedValue import AssignedValue
+from argrelay.test_infra import line_no
+from argrelay.test_infra.EnvMockBuilder import LocalClientEnvMockBuilder
+from argrelay.test_infra.LocalTestClass import LocalTestClass
+
+
+class ThisTestClass(LocalTestClass):
+    same_test_data_per_class = "TD_99_99_88_75"  # mutually exclusive
+
+    def test_propose_auto_comp_TD_99_99_88_75_mutually_exclusive(self):
+        """
+        Test arg values suggestion with TD_99_99_88_75 # mutually exclusive
+
+        Tests:
+        *   FS_44_36_84_88 consume args one by one
+        *   FS_76_29_13_28 arg consumption priorities
+        """
+
+        test_cases = [
+            (
+                line_no(),
+                "some_command host goto apac |",
+                CompType.PrefixShown,
+                ["host-a-1", "host-a-2"],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ServiceArgType.code_maturity.name: AssignedValue("qa", ArgSource.ImplicitValue),
+                        ServiceArgType.geo_region.name: AssignedValue("apac", ArgSource.ExplicitPosArg),
+                        ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
+                        ServiceArgType.cluster_name.name: AssignedValue("qa-apac-downstream", ArgSource.ImplicitValue),
+                    },
+                    3: None,
+                },
+                "TD_99_99_88_75: `host-a-*` are suggested as there is only them envelope matching `apac`",
+            ),
+            (
+                line_no(),
+                "some_command host goto qa |",
+                CompType.PrefixShown,
+                ["host-a-1", "host-a-2"],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ServiceArgType.code_maturity.name: AssignedValue("qa", ArgSource.ExplicitPosArg),
+                        ServiceArgType.geo_region.name: AssignedValue("apac", ArgSource.ImplicitValue),
+                        ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
+                        ServiceArgType.cluster_name.name: AssignedValue("qa-apac-downstream", ArgSource.ImplicitValue),
+                    },
+                    3: None,
+                },
+                "TD_99_99_88_75: `host-a-*` are suggested as there is only them envelope matching `qa`",
+            ),
+            (
+                line_no(),
+                "some_command host goto emea |",
+                CompType.PrefixShown,
+                ["host-b-1", "host-b-2"],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ServiceArgType.code_maturity.name: AssignedValue("dev", ArgSource.ImplicitValue),
+                        ServiceArgType.geo_region.name: AssignedValue("emea", ArgSource.ExplicitPosArg),
+                        ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
+                        ServiceArgType.cluster_name.name: AssignedValue("dev-emea-downstream", ArgSource.ImplicitValue),
+                    },
+                    3: None,
+                },
+                "TD_99_99_88_75: `host-b-*` are suggested as there is only them envelope matching `emea`",
+            ),
+            (
+                line_no(),
+                "some_command host goto dev |",
+                CompType.PrefixShown,
+                ["host-b-1", "host-b-2"],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ServiceArgType.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
+                        ServiceArgType.geo_region.name: AssignedValue("emea", ArgSource.ImplicitValue),
+                        ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
+                        ServiceArgType.cluster_name.name: AssignedValue("dev-emea-downstream", ArgSource.ImplicitValue),
+                    },
+                    3: None,
+                },
+                "TD_99_99_88_75: `host-b-*` are suggested as there is only them envelope matching `dev`",
+            ),
+            (
+                line_no(),
+                "some_command host goto emea qa |",
+                CompType.PrefixShown,
+                ["host-b-1", "host-b-2"],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ServiceArgType.code_maturity.name: AssignedValue("dev", ArgSource.ImplicitValue),
+                        ServiceArgType.geo_region.name: AssignedValue("emea", ArgSource.ExplicitPosArg),
+                        ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
+                        ServiceArgType.cluster_name.name: AssignedValue("dev-emea-downstream", ArgSource.ImplicitValue),
+                    },
+                    3: None,
+                },
+                "TD_99_99_88_75: `host-b-*` are suggested as according to "
+                "FS_76_29_13_28: user input priority, `emea` is eaten first, and "
+                # TODO_70_48_96_29: be able to assert unconsumed arg vals:
+                "FS_44_36_84_88: `qa` become unconsumed "
+                "(rather than becoming FS_51_67_38_37 impossible arg combination)",
+            ),
+            (
+                line_no(),
+                "some_command host goto qa emea |",
+                CompType.PrefixShown,
+                ["host-a-1", "host-a-2"],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ServiceArgType.code_maturity.name: AssignedValue("qa", ArgSource.ExplicitPosArg),
+                        ServiceArgType.geo_region.name: AssignedValue("apac", ArgSource.ImplicitValue),
+                        ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
+                        ServiceArgType.cluster_name.name: AssignedValue("qa-apac-downstream", ArgSource.ImplicitValue),
+                    },
+                    3: None,
+                },
+                "TD_99_99_88_75: `host-a-*` are suggested as according to "
+                "FS_76_29_13_28: user input priority, `qa` is eaten first, and "
+                # TODO_70_48_96_29: be able to assert unconsumed arg vals:
+                "FS_44_36_84_88: `emea` become unconsumed "
+                "(rather than becoming FS_51_67_38_37 impossible arg combination)",
+            ),
+            (
+                line_no(),
+                "some_command host goto apac dev |",
+                CompType.PrefixShown,
+                ["host-a-1", "host-a-2"],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ServiceArgType.code_maturity.name: AssignedValue("qa", ArgSource.ImplicitValue),
+                        ServiceArgType.geo_region.name: AssignedValue("apac", ArgSource.ExplicitPosArg),
+                        ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
+                        ServiceArgType.cluster_name.name: AssignedValue("qa-apac-downstream", ArgSource.ImplicitValue),
+                    },
+                    3: None,
+                },
+                "TD_99_99_88_75: `host-a-*` are suggested as according to "
+                "FS_76_29_13_28: user input priority, `apac` is eaten first, and "
+                # TODO_70_48_96_29: be able to assert unconsumed arg vals:
+                "FS_44_36_84_88: `dev` become unconsumed "
+                "(rather than becoming FS_51_67_38_37 impossible arg combination)",
+            ),
+            (
+                line_no(),
+                "some_command host goto dev apac |",
+                CompType.PrefixShown,
+                ["host-b-1", "host-b-2"],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ServiceArgType.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
+                        ServiceArgType.geo_region.name: AssignedValue("emea", ArgSource.ImplicitValue),
+                        ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
+                        ServiceArgType.cluster_name.name: AssignedValue("dev-emea-downstream", ArgSource.ImplicitValue),
+                    },
+                    3: None,
+                },
+                "TD_99_99_88_75: `host-b-*` are suggested as according to "
+                "FS_76_29_13_28: user input priority, `dev` is eaten first, and "
+                # TODO_70_48_96_29: be able to assert unconsumed arg vals:
+                "FS_44_36_84_88: `apac` become unconsumed "
+                "(rather than becoming FS_51_67_38_37 impossible arg combination)",
+            ),
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case):
+                (
+                    line_number,
+                    test_line,
+                    comp_type,
+                    expected_suggestions,
+                    container_ipos_to_expected_assignments,
+                    case_comment,
+                ) = test_case
+
+                self.verify_output_via_local_client(
+                    self.__class__.same_test_data_per_class,
+                    test_line,
+                    comp_type,
+                    expected_suggestions,
+                    container_ipos_to_expected_assignments,
+                    None,
+                    None,
+                    None,
+                    LocalClientEnvMockBuilder().set_reset_local_server(False),
+                )

--- a/tests/offline_tests/relay_demo/test_relay_demo_trees.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_trees.py
@@ -72,7 +72,7 @@ tree_path_selector_2: ? intercept help goto desc list host service repo commit
                     case_comment,
                 ) = test_case
 
-                self.verify_output_with_via_local_client(
+                self.verify_output_via_local_client(
                     self.__class__.same_test_data_per_class,
                     test_line,
                     comp_type,

--- a/tests/online_tests/remote_client/test_remote_relay_demo.py
+++ b/tests/online_tests/remote_client/test_remote_relay_demo.py
@@ -133,7 +133,7 @@ class ThisTestClass(RemoteTestClass):
                     case_comment,
                 ) = test_case
 
-                self.verify_output_with_via_remote_client(
+                self.verify_output_via_remote_client(
                     test_line,
                     CompType.InvokeAction,
                     None,

--- a/tests/slow_tests/relay_demo/test_relay_demo_TD_38_03_48_51_large_generated.py
+++ b/tests/slow_tests/relay_demo/test_relay_demo_TD_38_03_48_51_large_generated.py
@@ -60,7 +60,7 @@ class ThisTestClass(LocalTestClass):
                     case_comment,
                 ) = test_case
 
-                self.verify_output_with_via_local_client(
+                self.verify_output_via_local_client(
                     self.__class__.same_test_data_per_class,
                     test_line,
                     comp_type,

--- a/tests/slow_tests/relay_server/test_QueryEngine_perf.py
+++ b/tests/slow_tests/relay_server/test_QueryEngine_perf.py
@@ -136,7 +136,7 @@ class ThisTestClass(LocalTestClass):
                         ServiceEnvelopeClass.ClassCluster.name: ThisTestClass.__name__,
                         ServiceEnvelopeClass.ClassHost.name: ThisTestClass.__name__,
                         ServiceEnvelopeClass.ClassService.name: ThisTestClass.__name__,
-                        ServiceArgType.access_type.name: ThisTestClass.__name__,
+                        ServiceEnvelopeClass.ClassAccessType.name: ThisTestClass.__name__,
                         # ---
                         GitRepoEnvelopeClass.ClassGitRepo.name: ThisTestClass.__name__,
                         GitRepoEnvelopeClass.ClassGitTag.name: ThisTestClass.__name__,
@@ -153,7 +153,7 @@ class ThisTestClass(LocalTestClass):
                         ServiceEnvelopeClass.ClassCluster.name: ServiceEnvelopeClass.ClassCluster.name,
                         ServiceEnvelopeClass.ClassHost.name: ServiceEnvelopeClass.ClassHost.name,
                         ServiceEnvelopeClass.ClassService.name: ServiceEnvelopeClass.ClassService.name,
-                        ServiceArgType.access_type.name: ServiceArgType.access_type.name,
+                        ServiceEnvelopeClass.ClassAccessType.name: ServiceEnvelopeClass.ClassAccessType.name,
                         # ---
                         GitRepoEnvelopeClass.ClassGitRepo.name: GitRepoEnvelopeClass.ClassGitRepo.name,
                         GitRepoEnvelopeClass.ClassGitTag.name: GitRepoEnvelopeClass.ClassGitRepo.name,


### PR DESCRIPTION
Changes args consumption to "until first ambiguous" per query to avoid impossible arg combinations.

This will make it less confusing to user:
*   there will be no way to over-consume ags making next query return 0 results
*   instead, it leaves unconsumed args

It was expected to slow down request-response round-trip
as there will be more queries to make, but it did not change stats significantly.

*   Spec and implement `FS_44_36_84_88.consume_args_one_by_one.md`.
*   Spec and implement `FS_76_29_13_28.arg_consumption_priorities.md`.
*   Update `DistinctValuesQuery` stats.
*   Spec `TD_99_99_88_75.mutually_exclusive_arg_vals_from_diff_arg_types.md`.  
*   Spec `TODO_70_48_96_29.be_able_to_assert_unconsumed_arg_vals.md`.
*   Obsolete `FS_90_48_11_45.forced_assignment_from_entire_type_value_space.md`.
*   Obsolete `FS_51_67_38_37.impossible_arg_combinations.md`.
*   Obsolete `FS_24_50_40_64.arg_types_without_envelope_classes.md`.
*   Minor: test assertions: expect suggestions to be always available in all payloads.
