### PR TITLE
Fix: consume all singled out args as `ArgSource.ExplicitPosArg`

### DIFF
--- a/docs/feature_stories/FS_97_64_39_94.arg_buckets.md
+++ b/docs/feature_stories/FS_97_64_39_94.arg_buckets.md
@@ -1,0 +1,36 @@
+---
+feature_story: FS_97_64_39_94
+feature_title: arg buckets
+feature_status: TBD
+---
+
+# In short
+
+There should be a way to:
+*   limit consumption of args by the prev `envelope_container`
+*   while specifying search for the next `envelope_container`
+
+# Idea
+
+When 1st `data_envelope` is already singled out, user can place a delimiter char on the command line.
+
+This delimiter should instruct:
+> If envelope could be singled out by all the args until that delimiter,
+> it should not consume args beyond that delimiter.
+
+# Detailed description
+
+If two `data_envelope`-s of the same class is required, there will be two sets of args from the same value spaces
+(each instance will require same arg types). Values consumable by the 1st `data_envelope` will also be
+consumable by the 2nd `data_envelope`.
+
+This is almost like TD_76_09_29_31 overlapped arg vals from diff arg types
+except that they are not from different arg types.
+
+This may actually not be a problem because each `data_envelope` will be singled out sequentially
+eating args only until it can consume them (and combination of these args stays compatible).
+
+The problem happens when search uses many defaults (via FS_72_40_53_00 `fill_control`) -
+all these defaults applied on the 1st data envelope
+will be overridable by args destined for the 2nd data envelope.
+

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def list_dir(
 setuptools.setup(
     name = "argrelay",
     # See `docs/dev_notes/version_format.md`:
-    version = "0.6.9",
+    version = "0.6.10",
     author = "uvsmtid",
     author_email = "uvsmtid@gmail.com",
     description = "Tab-completion & data search server = total recall for Bash shell",

--- a/src/argrelay/enum_desc/DistinctValuesQuery.py
+++ b/src/argrelay/enum_desc/DistinctValuesQuery.py
@@ -21,9 +21,9 @@ class DistinctValuesQuery(Enum):
                        object_multiplier         3         4         5         6         7         8         9
                             object_count       243      1024      3125      7776     16807     32768     59049
         --------------------------------
-                  original_find_and_loop     0.011     0.035     0.122     0.461     1.650     5.945    27.836
-                         native_distinct     0.062     0.192     0.576     1.455     2.993     6.287    10.603
-                        native_aggregate     0.084     0.212     0.909     3.650    15.173    58.340   326.188
+                  original_find_and_loop     0.012     0.044     0.134     0.459     1.715     6.159    28.553
+                         native_distinct     0.077     0.209     0.581     1.538     3.186     6.295    11.231
+                        native_aggregate     0.077     0.227     0.913     3.717    15.944    63.955   375.196
         ================================
         use_mongomock: True
         use_single_collection: False
@@ -31,9 +31,9 @@ class DistinctValuesQuery(Enum):
                        object_multiplier         3         4         5         6         7         8         9
                             object_count       243      1024      3125      7776     16807     32768     59049
         --------------------------------
-                  original_find_and_loop     0.007     0.028     0.096     0.439     1.672     5.939    27.561
-                         native_distinct     0.048     0.159     0.465     1.224     2.725     5.539     9.572
-                        native_aggregate     0.031     0.109     0.398     1.758     7.802    28.463   126.566
+                  original_find_and_loop     0.011     0.031     0.102     0.431     1.750     6.061    35.473
+                         native_distinct     0.057     0.172     0.468     1.247     2.938     5.556    10.528
+                        native_aggregate     0.037     0.116     0.401     1.725     7.852    27.517   169.423
         ```
 
         *   The fastest on small collections is `original_find_and_loop`.
@@ -49,9 +49,9 @@ class DistinctValuesQuery(Enum):
                        object_multiplier         3         4         5         6         7         8         9
                             object_count       243      1024      3125      7776     16807     32768     59049
         --------------------------------
-                  original_find_and_loop     0.022     0.031     0.065     0.115     0.222     0.505     0.748
-                         native_distinct     0.063     0.102     0.195     0.435     0.857     1.493     2.591
-                        native_aggregate     0.022     0.038     0.064     0.109     0.165     0.324     0.469
+                  original_find_and_loop     0.028     0.034     0.070     0.147     0.255     0.493     1.040
+                         native_distinct     0.070     0.137     0.264     0.550     0.976     1.896     3.452
+                        native_aggregate     0.028     0.046     0.070     0.115     0.207     0.354     0.550
         ================================
         use_mongomock: False
         use_single_collection: False
@@ -59,9 +59,9 @@ class DistinctValuesQuery(Enum):
                        object_multiplier         3         4         5         6         7         8         9
                             object_count       243      1024      3125      7776     16807     32768     59049
         --------------------------------
-                  original_find_and_loop     0.020     0.025     0.048     0.144     0.175     0.383     0.590
-                         native_distinct     0.048     0.067     0.123     0.228     0.365     0.594     0.991
-                        native_aggregate     0.022     0.027     0.040     0.067     0.109     0.176     0.271
+                  original_find_and_loop     0.033     0.027     0.055     0.141     0.197     0.342     0.744
+                         native_distinct     0.047     0.088     0.158     0.285     0.479     0.821     1.389
+                        native_aggregate     0.023     0.030     0.054     0.073     0.120     0.191     0.326
         ```
 
         The fastest is `native_aggregate`.

--- a/src/argrelay/enum_desc/TermColor.py
+++ b/src/argrelay/enum_desc/TermColor.py
@@ -26,8 +26,9 @@ class TermColor(Enum):
     fore_dark_red = "\033[31m"
     fore_dark_green = "\033[32m"
     fore_dark_yellow = "\033[33m"
-    fore_dark_cyan = "\033[36m"
+    fore_dark_blue = "\033[34m"
     fore_dark_magenta = "\033[35m"
+    fore_dark_cyan = "\033[36m"
     fore_dark_gray = "\033[90m"
 
     fore_bright_gray = "\033[90m"
@@ -35,8 +36,8 @@ class TermColor(Enum):
     fore_bright_green = "\033[92m"
     fore_bright_yellow = "\033[93m"
     fore_bright_blue = "\033[94m"
-    fore_bright_cyan = "\033[96m"
     fore_bright_magenta = "\033[95m"
+    fore_bright_cyan = "\033[96m"
     fore_bright_white = "\033[97m"
 
     fore_bold_dark_red = "\033[1;31m"
@@ -85,7 +86,7 @@ class TermColor(Enum):
     *   `BaseResponse.consumed_tokens`
     """
 
-    unconsumed_token = fore_dark_magenta
+    unconsumed_token = fore_bright_magenta
     """
     See:
     *   `InterpContext.unconsumed_tokens`
@@ -96,7 +97,7 @@ class TermColor(Enum):
     When none of the relevant `data_envelope`-s has values for the given prop.
     """
 
-    caption_hidden_by_default = fore_bright_magenta
+    caption_hidden_by_default = fore_dark_magenta
     """
     FS_72_53_55_13: Caption for values hidden by default.
     """

--- a/tests/offline_tests/plugin_interp/test_FuncTreeInterp.py
+++ b/tests/offline_tests/plugin_interp/test_FuncTreeInterp.py
@@ -1,0 +1,98 @@
+from argrelay.custom_integ.GitRepoArgType import GitRepoArgType
+from argrelay.custom_integ.GitRepoEnvelopeClass import GitRepoEnvelopeClass
+from argrelay.enum_desc.ArgSource import ArgSource
+from argrelay.enum_desc.CompType import CompType
+from argrelay.enum_desc.ReservedArgType import ReservedArgType
+from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.plugin_interp.FuncTreeInterpFactory import func_envelope_path_step_prop_name
+from argrelay.runtime_data.AssignedValue import AssignedValue
+from argrelay.test_infra import line_no
+
+from argrelay.test_infra.LocalTestClass import LocalTestClass
+
+
+class ThisTestClass(LocalTestClass):
+    same_test_data_per_class = "TD_63_37_05_36"  # demo
+
+    def test_FS_26_43_73_72_func_tree(self):
+        """
+        Test arg values suggestion with FS_26_43_73_72 func tree
+        """
+
+        test_cases = [
+            (
+                line_no(),
+                "some_command desc tag |",
+                CompType.DescribeArgs,
+                [],
+                {
+                    0: {
+                        ReservedArgType.EnvelopeClass.name: AssignedValue(
+                            ReservedEnvelopeClass.ClassFunction.name,
+                            ArgSource.InitValue,
+                        ),
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("desc", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("tag", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ReservedArgType.EnvelopeClass.name: AssignedValue(
+                            GitRepoEnvelopeClass.ClassGitTag.name,
+                            ArgSource.InitValue,
+                        ),
+                        GitRepoArgType.git_repo_alias.name: AssignedValue("argrelay", ArgSource.ImplicitValue),
+                    },
+                    3: None,
+                },
+                "Step 1: FS_44_36_84_88: both `tag` and `desc` are assigned `ArgSource.ExplicitPosArg` regardless of the order "
+                "FS_26_43_73_72 interp tree: the ordered path to func `desc_git_tag_func` is `desc tag` ",
+            ),
+            (
+                line_no(),
+                "some_command tag desc |",
+                CompType.DescribeArgs,
+                [],
+                {
+                    0: {
+                        ReservedArgType.EnvelopeClass.name: AssignedValue(
+                            ReservedEnvelopeClass.ClassFunction.name,
+                            ArgSource.InitValue,
+                        ),
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("desc", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("tag", ArgSource.ExplicitPosArg),
+                    },
+                    1: {
+                        ReservedArgType.EnvelopeClass.name: AssignedValue(
+                            GitRepoEnvelopeClass.ClassGitTag.name,
+                            ArgSource.InitValue,
+                        ),
+                        GitRepoArgType.git_repo_alias.name: AssignedValue("argrelay", ArgSource.ImplicitValue),
+                    },
+                    3: None,
+                },
+                "Step 1: FS_44_36_84_88: both `tag` and `desc` are assigned `ArgSource.ExplicitPosArg` regardless of the order "
+                "FS_26_43_73_72 interp tree: the ordered path to func `desc_git_tag_func` is `desc tag` ",
+            ),
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case):
+                (
+                    line_number,
+                    test_line,
+                    comp_type,
+                    expected_suggestions,
+                    container_ipos_to_expected_assignments,
+                    case_comment,
+                ) = test_case
+
+                self.verify_output_with_new_server_via_local_client(
+                    self.__class__.same_test_data_per_class,
+                    test_line,
+                    comp_type,
+                    expected_suggestions,
+                    container_ipos_to_expected_assignments,
+                    None,
+                    None,
+                )

--- a/tests/offline_tests/plugin_interp/test_FuncTreeInterp.py
+++ b/tests/offline_tests/plugin_interp/test_FuncTreeInterp.py
@@ -71,7 +71,7 @@ class ThisTestClass(LocalTestClass):
                     },
                     3: None,
                 },
-                "Step 1: FS_44_36_84_88: both `tag` and `desc` are assigned `ArgSource.ExplicitPosArg` regardless of the order "
+                "Step 2: FS_44_36_84_88: both `tag` and `desc` are assigned `ArgSource.ExplicitPosArg` regardless of the order "
                 "FS_26_43_73_72 interp tree: the ordered path to func `desc_git_tag_func` is `desc tag` ",
             ),
         ]

--- a/tests/offline_tests/plugin_interp/test_InterpTreeInterp.py
+++ b/tests/offline_tests/plugin_interp/test_InterpTreeInterp.py
@@ -10,7 +10,7 @@ class ThisTestClass(LocalTestClass):
 
     def test_FS_01_89_09_24_fetch_tree_node(self):
         """
-        Tests part of FS_01_89_09_24
+        Tests part of FS_01_89_09_24 interp tree
         """
         empty_tree = {}
         full_tree = {
@@ -47,7 +47,7 @@ class ThisTestClass(LocalTestClass):
                     fetch_tree_node(tree_dict, node_coord),
                 )
 
-    def test_FS_01_89_09_24_tree(self):
+    def test_FS_01_89_09_24_interp_tree(self):
         """
         Test arg values suggestion with FS_01_89_09_24 # interp tree
         """
@@ -69,7 +69,6 @@ class ThisTestClass(LocalTestClass):
                     "list",
                 ],
                 {},
-                None,
                 "FS_01_89_09_24: `intercept` and `help` are suggested via data search via props "
                 "generated via interp tree",
             ),
@@ -81,7 +80,6 @@ class ThisTestClass(LocalTestClass):
                     "intercept",
                 ],
                 {},
-                None,
                 "FS_01_89_09_24: prefix suggestion also works for `intercept` (`help` is filtered out).",
             ),
             (
@@ -90,7 +88,6 @@ class ThisTestClass(LocalTestClass):
                 CompType.PrefixShown,
                 ["amer", "emea", "host-3-amer"],
                 {},
-                None,
                 "FS_01_89_09_24: Even if `intercept` is not specified in the beginning, "
                 "`InterpTreeInterp` does not suggest it",
             ),
@@ -103,7 +100,6 @@ class ThisTestClass(LocalTestClass):
                 #                       but also internal functions available for that position (e.g. `intercept`)
                 ["amer", "emea", "host-3-amer"],
                 {},
-                None,
                 "FS_01_89_09_24: Suggest functions available for this position "
                 "even if the rest of the command line is populated.",
             ),
@@ -117,7 +113,6 @@ class ThisTestClass(LocalTestClass):
                     comp_type,
                     expected_suggestions,
                     container_ipos_to_expected_assignments,
-                    delegator_class,
                     case_comment,
                 ) = test_case
 
@@ -127,6 +122,6 @@ class ThisTestClass(LocalTestClass):
                     comp_type,
                     expected_suggestions,
                     container_ipos_to_expected_assignments,
-                    delegator_class,
+                    None,
                     None,
                 )

--- a/tests/offline_tests/relay_demo/test_relay_demo_TD_76_09_29_31_overlapped.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_TD_76_09_29_31_overlapped.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from argrelay.custom_integ.ServiceArgType import ServiceArgType
+from argrelay.custom_integ.ServiceEnvelopeClass import ServiceEnvelopeClass
 from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.CompType import CompType
+from argrelay.enum_desc.ReservedArgType import ReservedArgType
+from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.plugin_delegator.ErrorDelegator import ErrorDelegator
 from argrelay.plugin_interp.FuncTreeInterpFactory import func_envelope_path_step_prop_name
 from argrelay.runtime_data.AssignedValue import AssignedValue
@@ -30,16 +33,27 @@ class ThisTestClass(LocalTestClass):
                 ["amer", "emea"],
                 {
                     0: {
+                        ReservedArgType.EnvelopeClass.name: AssignedValue(
+                            ReservedEnvelopeClass.ClassFunction.name,
+                            ArgSource.InitValue,
+                        ),
                         f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
                         f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
                         f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
                     },
                     1: {
+                        ReservedArgType.EnvelopeClass.name: AssignedValue(
+                            ServiceEnvelopeClass.ClassHost.name,
+                            ArgSource.InitValue,
+                        ),
                         ServiceArgType.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
                         ServiceArgType.geo_region.name: None,
                         ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ExplicitPosArg),
                         ServiceArgType.cluster_name.name: None,
                         ServiceArgType.host_name.name: None,
+                    },
+                    2: {
+                        # ServiceEnvelopeClass.ClassAccessType.name
                     },
                     3: None,
                 },
@@ -53,16 +67,27 @@ class ThisTestClass(LocalTestClass):
                 ["amer", "emea", "host-3-amer"],
                 {
                     0: {
+                        ReservedArgType.EnvelopeClass.name: AssignedValue(
+                            ReservedEnvelopeClass.ClassFunction.name,
+                            ArgSource.InitValue,
+                        ),
                         f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
                         f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
                         f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
                     },
                     1: {
+                        ReservedArgType.EnvelopeClass.name: AssignedValue(
+                            ServiceEnvelopeClass.ClassHost.name,
+                            ArgSource.InitValue,
+                        ),
                         ServiceArgType.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
                         ServiceArgType.geo_region.name: AssignedValue("amer", ArgSource.ExplicitPosArg),
                         ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ExplicitPosArg),
                         ServiceArgType.cluster_name.name: AssignedValue("dev-amer-downstream", ArgSource.ImplicitValue),
                         ServiceArgType.host_name.name: None,
+                    },
+                    2: {
+                        # ServiceEnvelopeClass.ClassAccessType.name
                     },
                     3: None,
                 },
@@ -87,6 +112,9 @@ class ThisTestClass(LocalTestClass):
                         ServiceArgType.cluster_name.name: AssignedValue("dev-amer-downstream", ArgSource.ImplicitValue),
                         ServiceArgType.host_name.name: None,
                     },
+                    2: {
+                        # ServiceEnvelopeClass.ClassAccessType.name
+                    },
                     3: None,
                 },
                 "TD_76_09_29_31 overlapped: Step 1: one of the explicit value matches more than one type, "
@@ -110,6 +138,9 @@ class ThisTestClass(LocalTestClass):
                         ServiceArgType.cluster_name.name: AssignedValue("dev-amer-downstream", ArgSource.ImplicitValue),
                         ServiceArgType.host_name.name: None,
                     },
+                    2: {
+                        # ServiceEnvelopeClass.ClassAccessType.name
+                    },
                     3: None,
                 },
                 "TD_76_09_29_31 overlapped: Step 1: one of the explicit value matches more than one type, "
@@ -132,6 +163,9 @@ class ThisTestClass(LocalTestClass):
                         ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ExplicitPosArg),
                         ServiceArgType.cluster_name.name: AssignedValue("dev-amer-downstream", ArgSource.ImplicitValue),
                         ServiceArgType.host_name.name: AssignedValue("amer", ArgSource.ExplicitPosArg),
+                    },
+                    2: {
+                        # ServiceEnvelopeClass.ClassAccessType.name
                     },
                     3: None,
                 },

--- a/tests/offline_tests/relay_demo/test_relay_demo_TD_99_99_88_75_mutually_exclusive.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_TD_99_99_88_75_mutually_exclusive.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from argrelay.custom_integ.ServiceArgType import ServiceArgType
+from argrelay.custom_integ.ServiceEnvelopeClass import ServiceEnvelopeClass
 from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.CompType import CompType
+from argrelay.enum_desc.ReservedArgType import ReservedArgType
+from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.plugin_delegator.ErrorDelegator import ErrorDelegator
 from argrelay.plugin_interp.FuncTreeInterpFactory import func_envelope_path_step_prop_name
 from argrelay.runtime_data.AssignedValue import AssignedValue
@@ -31,15 +34,26 @@ class ThisTestClass(LocalTestClass):
                 ["host-a-1", "host-a-2"],
                 {
                     0: {
+                        ReservedArgType.EnvelopeClass.name: AssignedValue(
+                            ReservedEnvelopeClass.ClassFunction.name,
+                            ArgSource.InitValue,
+                        ),
                         f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
                         f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
                         f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
                     },
                     1: {
+                        ReservedArgType.EnvelopeClass.name: AssignedValue(
+                            ServiceEnvelopeClass.ClassHost.name,
+                            ArgSource.InitValue,
+                        ),
                         ServiceArgType.code_maturity.name: AssignedValue("qa", ArgSource.ImplicitValue),
                         ServiceArgType.geo_region.name: AssignedValue("apac", ArgSource.ExplicitPosArg),
                         ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
                         ServiceArgType.cluster_name.name: AssignedValue("qa-apac-downstream", ArgSource.ImplicitValue),
+                    },
+                    2: {
+                        # ServiceEnvelopeClass.ClassAccessType.name
                     },
                     3: None,
                 },
@@ -52,15 +66,26 @@ class ThisTestClass(LocalTestClass):
                 ["host-a-1", "host-a-2"],
                 {
                     0: {
+                        ReservedArgType.EnvelopeClass.name: AssignedValue(
+                            ReservedEnvelopeClass.ClassFunction.name,
+                            ArgSource.InitValue,
+                        ),
                         f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
                         f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
                         f"{func_envelope_path_step_prop_name(2)}": AssignedValue("host", ArgSource.ExplicitPosArg),
                     },
                     1: {
+                        ReservedArgType.EnvelopeClass.name: AssignedValue(
+                            ServiceEnvelopeClass.ClassHost.name,
+                            ArgSource.InitValue,
+                        ),
                         ServiceArgType.code_maturity.name: AssignedValue("qa", ArgSource.ExplicitPosArg),
                         ServiceArgType.geo_region.name: AssignedValue("apac", ArgSource.ImplicitValue),
                         ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
                         ServiceArgType.cluster_name.name: AssignedValue("qa-apac-downstream", ArgSource.ImplicitValue),
+                    },
+                    2: {
+                        # ServiceEnvelopeClass.ClassAccessType.name
                     },
                     3: None,
                 },
@@ -83,6 +108,9 @@ class ThisTestClass(LocalTestClass):
                         ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
                         ServiceArgType.cluster_name.name: AssignedValue("dev-emea-downstream", ArgSource.ImplicitValue),
                     },
+                    2: {
+                        # ServiceEnvelopeClass.ClassAccessType.name
+                    },
                     3: None,
                 },
                 "TD_99_99_88_75: `host-b-*` are suggested as there is only them envelope matching `emea`",
@@ -104,6 +132,9 @@ class ThisTestClass(LocalTestClass):
                         ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
                         ServiceArgType.cluster_name.name: AssignedValue("dev-emea-downstream", ArgSource.ImplicitValue),
                     },
+                    2: {
+                        # ServiceEnvelopeClass.ClassAccessType.name
+                    },
                     3: None,
                 },
                 "TD_99_99_88_75: `host-b-*` are suggested as there is only them envelope matching `dev`",
@@ -124,6 +155,9 @@ class ThisTestClass(LocalTestClass):
                         ServiceArgType.geo_region.name: AssignedValue("emea", ArgSource.ExplicitPosArg),
                         ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
                         ServiceArgType.cluster_name.name: AssignedValue("dev-emea-downstream", ArgSource.ImplicitValue),
+                    },
+                    2: {
+                        # ServiceEnvelopeClass.ClassAccessType.name
                     },
                     3: None,
                 },
@@ -150,6 +184,9 @@ class ThisTestClass(LocalTestClass):
                         ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
                         ServiceArgType.cluster_name.name: AssignedValue("qa-apac-downstream", ArgSource.ImplicitValue),
                     },
+                    2: {
+                        # ServiceEnvelopeClass.ClassAccessType.name
+                    },
                     3: None,
                 },
                 "TD_99_99_88_75: `host-a-*` are suggested as according to "
@@ -175,6 +212,9 @@ class ThisTestClass(LocalTestClass):
                         ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
                         ServiceArgType.cluster_name.name: AssignedValue("qa-apac-downstream", ArgSource.ImplicitValue),
                     },
+                    2: {
+                        # ServiceEnvelopeClass.ClassAccessType.name
+                    },
                     3: None,
                 },
                 "TD_99_99_88_75: `host-a-*` are suggested as according to "
@@ -199,6 +239,9 @@ class ThisTestClass(LocalTestClass):
                         ServiceArgType.geo_region.name: AssignedValue("emea", ArgSource.ImplicitValue),
                         ServiceArgType.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
                         ServiceArgType.cluster_name.name: AssignedValue("dev-emea-downstream", ArgSource.ImplicitValue),
+                    },
+                    2: {
+                        # ServiceEnvelopeClass.ClassAccessType.name
                     },
                     3: None,
                 },


### PR DESCRIPTION
Do not leave args for assignment as `ArgSource.ImplicitValue`
as long as they can be consumed as `ArgSource.ExplicitPosArg` (regardless of the order).

*   Spec `FS_97_64_39_94.arg_buckets.md`.
*   Update `DistinctValuesQuery` stats.