### PR TITLE
Load data to MongoDB loader by loader

### DIFF
--- a/docs/feature_stories/FS_29_54_67_86.dir_structure.md
+++ b/docs/feature_stories/FS_29_54_67_86.dir_structure.md
@@ -8,6 +8,8 @@ This features describes the directory structure (a convention):
 *   which `argrelay` uses for itself
 *   which should be used for integration projects based on `argrelay` (to make scripts re-use-able)
 
+See also `TopDir` enum.
+
 To make it unambiguous that path is relative to project root dir,
 it is referred to as `argrelay_dir` in scripts and indicated as `@/` in docs and comments,
 for example: `@/exe/bootstrap_env.bash`.

--- a/docs/task_refs/TODO_00_79_72_55.remove_static_data_from_server_config.md
+++ b/docs/task_refs/TODO_00_79_72_55.remove_static_data_from_server_config.md
@@ -7,6 +7,6 @@ Currently, all plugins write `data_envelope`-s to be indexed under `static_data`
 but then (when they are already loaded into MongoDB), they become residual there.
 Loading `static_data` into `server_config` object does not make sense as it does not configure anything.
 
-Make plug-ins use local server API (to be exposed via FS_74_69_61_79 get|set data envelope REST API)
+Make plugins use local server API (to be exposed via FS_74_69_61_79 get|set data envelope REST API)
 to load data directly into store.
 

--- a/docs/task_refs/TODO_39_25_11_76.data_envelopes_with_missing_props.md
+++ b/docs/task_refs/TODO_39_25_11_76.data_envelopes_with_missing_props.md
@@ -1,13 +1,15 @@
 
 TODO_39_25_11_76: `data_envelope`-s with missing props
 
+TODO: Move it to `feature_story`?
+
 # Scenario
 
 *   Multiple `data_envelope`-s loaded under the same `ReservedArgType.EnvelopeClass`.
 *   The `search_control` used to query them contains `some_prop_x` prop.
 *   This `some_prop_x` exists in some `data_envelope`-s and does not exist in others.
 
-# Issue
+# Original issue occurrence: data loaders
 
 Those `data_envelope`-s which have `some_prop_x` will hide those which do not while narrowing down the search.
 
@@ -21,3 +23,38 @@ Why?
 
 This is currently considered to be a data issue (not easily fix-able in `argrelay`)
 which can be easily prevented by loaders by always assigning some `UNKNOWN` value.
+
+# Another issue occurrence: func loader via delegators (framework logic)
+
+For example, consider this FS_26_43_73_72 func tree:
+
+```
+"goto":
+    "repo": func_id_1
+    "host": func_id_2
+    "sub":
+        "commit": func_id_3
+        "proc": func_id_4
+"list":
+    "repo": func_id_5
+    "host": func_id_6
+```
+
+When loaded, there will be two func envelopes with props to select funcs at 3rd sub-tree level:
+
+```
+goto sub commit
+goto sub proc
+```
+
+But the rest of funcs will only have props to select funcs at 2nd sub-tree level:
+
+```
+goto repo
+goto host
+list repo
+list host
+```
+
+Because of blank prop values for 3rd sub-tree, subsequent query (after narrowing down prop values)
+will not show the funcs with blank 3rd sub-tree prop values.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def list_dir(
 setuptools.setup(
     name = "argrelay",
     # See `docs/dev_notes/version_format.md`:
-    version = "0.7.2",
+    version = "0.7.3",
     author = "uvsmtid",
     author_email = "uvsmtid@gmail.com",
     description = "Tab-completion & data search server = total recall for Bash shell",

--- a/src/argrelay/custom_integ/ConfigOnlyLoader.py
+++ b/src/argrelay/custom_integ/ConfigOnlyLoader.py
@@ -8,6 +8,7 @@ from argrelay.custom_integ.ConfigOnlyLoaderConfigSchema import (
 from argrelay.enum_desc.ReservedArgType import ReservedArgType
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.plugin_loader.AbstractLoader import AbstractLoader
+from argrelay.relay_server.QueryEngine import QueryEngine
 from argrelay.runtime_data.ServerConfig import ServerConfig
 from argrelay.runtime_data.StaticData import StaticData
 from argrelay.schema_config_core_server.EnvelopeCollectionSchema import init_envelop_collections
@@ -51,6 +52,7 @@ class ConfigOnlyLoader(AbstractLoader):
     def update_static_data(
         self,
         static_data: StaticData,
+        query_engine: QueryEngine,
     ) -> StaticData:
 
         # Config for FS_56_43_05_79 different collections:

--- a/src/argrelay/custom_integ/GitRepoDelegator.py
+++ b/src/argrelay/custom_integ/GitRepoDelegator.py
@@ -9,6 +9,7 @@ from argrelay.custom_integ.value_constants import (
     desc_git_commit_func_,
     desc_git_tag_func_,
 )
+from argrelay.enum_desc.FuncState import FuncState
 from argrelay.enum_desc.ReservedArgType import ReservedArgType
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.misc_helper_common import eprint
@@ -117,6 +118,7 @@ class GitRepoDelegator(AbstractDelegator):
             },
             ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
             ReservedArgType.HelpHint.name: "Goto Git repository (`cd` to its path)",
+            ReservedArgType.FuncState.name: FuncState.beta.name,
             ReservedArgType.FuncId.name: goto_git_repo_func_,
         }
         func_envelopes.append(given_function_envelope)
@@ -131,6 +133,7 @@ class GitRepoDelegator(AbstractDelegator):
             },
             ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
             ReservedArgType.HelpHint.name: "Describe Git tag",
+            ReservedArgType.FuncState.name: FuncState.demo.name,
             ReservedArgType.FuncId.name: desc_git_tag_func_,
         }
         func_envelopes.append(given_function_envelope)
@@ -145,6 +148,7 @@ class GitRepoDelegator(AbstractDelegator):
             },
             ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
             ReservedArgType.HelpHint.name: "Describe Git commit",
+            ReservedArgType.FuncState.name: FuncState.demo.name,
             ReservedArgType.FuncId.name: desc_git_commit_func_,
         }
         func_envelopes.append(given_function_envelope)

--- a/src/argrelay/custom_integ/GitRepoLoader.py
+++ b/src/argrelay/custom_integ/GitRepoLoader.py
@@ -72,6 +72,7 @@ class GitRepoLoader(AbstractLoader):
     def update_static_data(
         self,
         static_data: StaticData,
+        query_engine: QueryEngine,
     ) -> StaticData:
 
         if not self.plugin_config_dict:

--- a/src/argrelay/custom_integ/ServiceDelegator.py
+++ b/src/argrelay/custom_integ/ServiceDelegator.py
@@ -14,6 +14,7 @@ from argrelay.custom_integ.value_constants import (
     desc_service_func_,
 )
 from argrelay.enum_desc.ArgSource import ArgSource
+from argrelay.enum_desc.FuncState import FuncState
 from argrelay.enum_desc.ReservedArgType import ReservedArgType
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.plugin_delegator.AbstractDelegator import (
@@ -196,6 +197,7 @@ class ServiceDelegator(AbstractDelegator):
                 },
                 ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
                 ReservedArgType.HelpHint.name: "Go (log in) to remote host",
+                ReservedArgType.FuncState.name: FuncState.demo.name,
                 ReservedArgType.FuncId.name: goto_host_func_,
             },
             {
@@ -209,6 +211,7 @@ class ServiceDelegator(AbstractDelegator):
                 },
                 ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
                 ReservedArgType.HelpHint.name: "Go (log in) to remote host and dir path with specified service",
+                ReservedArgType.FuncState.name: FuncState.demo.name,
                 ReservedArgType.FuncId.name: goto_service_func_,
             },
             {
@@ -222,6 +225,7 @@ class ServiceDelegator(AbstractDelegator):
                 },
                 ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
                 ReservedArgType.HelpHint.name: "Describe remote host",
+                ReservedArgType.FuncState.name: FuncState.demo.name,
                 ReservedArgType.FuncId.name: desc_host_func_,
             },
             {
@@ -235,6 +239,7 @@ class ServiceDelegator(AbstractDelegator):
                 },
                 ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
                 ReservedArgType.HelpHint.name: "Describe service instance",
+                ReservedArgType.FuncState.name: FuncState.demo.name,
                 ReservedArgType.FuncId.name: desc_service_func_,
             },
             {
@@ -247,6 +252,7 @@ class ServiceDelegator(AbstractDelegator):
                 },
                 ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
                 ReservedArgType.HelpHint.name: "List remote hosts matching search query",
+                ReservedArgType.FuncState.name: FuncState.demo.name,
                 ReservedArgType.FuncId.name: list_host_func_,
             },
             {
@@ -259,6 +265,7 @@ class ServiceDelegator(AbstractDelegator):
                 },
                 ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
                 ReservedArgType.HelpHint.name: "List service instances matching search query",
+                ReservedArgType.FuncState.name: FuncState.demo.name,
                 ReservedArgType.FuncId.name: list_service_func_,
             },
             {
@@ -274,6 +281,7 @@ class ServiceDelegator(AbstractDelegator):
                 },
                 ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
                 ReservedArgType.HelpHint.name: "Diff two service instances",
+                ReservedArgType.FuncState.name: FuncState.demo.name,
                 ReservedArgType.FuncId.name: diff_service_func_,
             },
         ]

--- a/src/argrelay/custom_integ/ServiceLoader.py
+++ b/src/argrelay/custom_integ/ServiceLoader.py
@@ -10,6 +10,7 @@ from argrelay.enum_desc.ReservedArgType import ReservedArgType
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.misc_helper_common import eprint
 from argrelay.plugin_loader.AbstractLoader import AbstractLoader
+from argrelay.relay_server.QueryEngine import QueryEngine
 from argrelay.runtime_data.EnvelopeCollection import EnvelopeCollection
 from argrelay.runtime_data.ServerConfig import ServerConfig
 from argrelay.runtime_data.StaticData import StaticData
@@ -49,6 +50,7 @@ class ServiceLoader(AbstractLoader):
     def update_static_data(
         self,
         static_data: StaticData,
+        query_engine: QueryEngine,
     ) -> StaticData:
 
         static_data = self.load_data_envelopes(static_data)
@@ -1532,6 +1534,7 @@ class ServiceLoader(AbstractLoader):
             # TD_39_25_11_76 # missing props: clusters
 
             {
+                # nothing missing:
                 envelope_payload_: {
                 },
                 test_data_: "TD_39_25_11_76",  # missing props
@@ -1543,6 +1546,7 @@ class ServiceLoader(AbstractLoader):
             },
 
             {
+                # nothing missing:
                 envelope_payload_: {
                 },
                 test_data_: "TD_39_25_11_76",  # missing props
@@ -1561,6 +1565,7 @@ class ServiceLoader(AbstractLoader):
             # TD_39_25_11_76 # missing props: hosts
 
             {
+                # nothing missing:
                 envelope_payload_: {
                 },
                 test_data_: "TD_39_25_11_76",  # missing props
@@ -1574,6 +1579,7 @@ class ServiceLoader(AbstractLoader):
             },
 
             {
+                # nothing missing:
                 envelope_payload_: {
                 },
                 test_data_: "TD_39_25_11_76",  # missing props
@@ -1587,6 +1593,7 @@ class ServiceLoader(AbstractLoader):
             },
 
             {
+                # missing `ServiceArgType.live_status`:
                 envelope_payload_: {
                 },
                 test_data_: "TD_39_25_11_76",  # missing props
@@ -1601,6 +1608,7 @@ class ServiceLoader(AbstractLoader):
             },
 
             {
+                # nothing missing:
                 envelope_payload_: {
                 },
                 test_data_: "TD_39_25_11_76",  # missing props
@@ -1614,6 +1622,7 @@ class ServiceLoader(AbstractLoader):
             },
 
             {
+                # nothing missing:
                 envelope_payload_: {
                 },
                 test_data_: "TD_39_25_11_76",  # missing props
@@ -1627,6 +1636,7 @@ class ServiceLoader(AbstractLoader):
             },
 
             {
+                # nothing missing:
                 envelope_payload_: {
                 },
                 test_data_: "TD_39_25_11_76",  # missing props

--- a/src/argrelay/enum_desc/FuncState.py
+++ b/src/argrelay/enum_desc/FuncState.py
@@ -1,0 +1,42 @@
+from enum import Enum, auto
+
+
+class FuncState(Enum):
+    """
+    State of the func (its readiness).
+    """
+
+    unplugged = auto()
+    """
+    Used for func that are not plugged anywhere in the tree (but they are published).
+
+    See `AbstractDelegator.get_supported_func_envelopes`.
+    """
+
+    ignorable = auto()
+    """
+    Not `unplugged`, but still not very useful.
+    """
+
+    demo = auto()
+    """
+    Not meant to work - for `argrelay` demo only.
+    """
+
+    alpha = auto()
+    """
+    In alpha testing.
+    """
+
+    beta = auto()
+    """
+    In beta testing.
+    """
+
+    gamma = auto()
+    """
+    GA (general availability)
+    """
+
+    def __str__(self):
+        return self.name

--- a/src/argrelay/enum_desc/InterpStep.py
+++ b/src/argrelay/enum_desc/InterpStep.py
@@ -2,6 +2,10 @@ from enum import Enum, auto
 
 
 class InterpStep(Enum):
+    """
+    Step decision in interpretation loop - see `InterpContext.interpret_command`.
+    """
+
     StopAll = auto()
     """
     No way to continue interpretation - no enough info.

--- a/src/argrelay/enum_desc/PluginType.py
+++ b/src/argrelay/enum_desc/PluginType.py
@@ -2,6 +2,10 @@ from enum import Enum, auto
 
 
 class PluginType(Enum):
+    """
+    See `AbstractPlugin.get_plugin_type`.
+    """
+
     LoaderPlugin = auto()
     """
     See classes derived from `AbstractLoader`.

--- a/src/argrelay/enum_desc/ReservedArgType.py
+++ b/src/argrelay/enum_desc/ReservedArgType.py
@@ -20,3 +20,5 @@ class ReservedArgType(Enum):
     ArgValue = auto()
 
     HelpHint = auto()
+
+    FuncState = auto()

--- a/src/argrelay/enum_desc/ReservedEnvelopeClass.py
+++ b/src/argrelay/enum_desc/ReservedEnvelopeClass.py
@@ -2,8 +2,14 @@ from enum import Enum, auto
 
 
 class ReservedEnvelopeClass(Enum):
+    """
+    Names of the `data_envelope` classes reserved by `argrelay`.
+    """
+
     ClassUnknown = auto()
+
     ClassFunction = auto()
+
     ClassHelp = auto()
 
     def __str__(self):

--- a/src/argrelay/enum_desc/TopDir.py
+++ b/src/argrelay/enum_desc/TopDir.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class TopDir(Enum):
+    """
+    Top-level directories for `argrelay` - see also `argrelay_dir`.
+
+    See also FS_29_54_67_86 project `dir_structure`.
+    """
+
+    BinDir = "bin"
+
+    ConfDir = "conf"
+
+    DataDir = "data"
+
+    DocsDir = "docs"
+
+    DstDir = "dst"
+
+    ExeDir = "exe"
+
+    SrcDir = "src"
+
+    TestDir = "test"
+
+    def __str__(self):
+        return self.name

--- a/src/argrelay/plugin_delegator/EchoDelegator.py
+++ b/src/argrelay/plugin_delegator/EchoDelegator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from argrelay.enum_desc.FuncState import FuncState
 from argrelay.enum_desc.ReservedArgType import ReservedArgType
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.enum_desc.SpecialFunc import SpecialFunc
@@ -34,6 +35,7 @@ class EchoDelegator(AbstractDelegator):
             ReservedArgType.HelpHint.name: (
                 f"Print command line args `{InvocationInput.__name__}`"
             ),
+            ReservedArgType.FuncState.name: FuncState.beta.name,
             ReservedArgType.FuncId.name: SpecialFunc.echo_args_func.name,
         }]
         return func_envelopes

--- a/src/argrelay/plugin_delegator/HelpDelegator.py
+++ b/src/argrelay/plugin_delegator/HelpDelegator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from argrelay.custom_integ.ServiceDelegator import redirect_to_no_func_error
+from argrelay.enum_desc.FuncState import FuncState
 from argrelay.enum_desc.ReservedArgType import ReservedArgType
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.enum_desc.SpecialFunc import SpecialFunc
@@ -36,6 +37,7 @@ class HelpDelegator(AbstractJumpDelegator):
             },
             ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
             ReservedArgType.HelpHint.name: "List defined function matching search criteria with their help hints",
+            ReservedArgType.FuncState.name: FuncState.gamma.name,
             ReservedArgType.FuncId.name: SpecialFunc.help_hint_func.name,
         }]
         return func_envelopes

--- a/src/argrelay/plugin_delegator/InterceptDelegator.py
+++ b/src/argrelay/plugin_delegator/InterceptDelegator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from enum import Enum, auto
 
 from argrelay.custom_integ.ServiceDelegator import set_default_to
+from argrelay.enum_desc.FuncState import FuncState
 from argrelay.enum_desc.ReservedArgType import ReservedArgType
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.enum_desc.SpecialFunc import SpecialFunc
@@ -66,6 +67,7 @@ class InterceptDelegator(AbstractJumpDelegator):
                 f"Intercept and print `{InvocationInput.__name__}` "
                 "for specified function and its args"
             ),
+            ReservedArgType.FuncState.name: FuncState.alpha.name,
             ReservedArgType.FuncId.name: SpecialFunc.intercept_invocation_func.name,
         }]
         return func_envelopes

--- a/src/argrelay/plugin_delegator/QueryEnumDelegator.py
+++ b/src/argrelay/plugin_delegator/QueryEnumDelegator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from argrelay.enum_desc.FuncState import FuncState
 from argrelay.enum_desc.ReservedArgType import ReservedArgType
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.enum_desc.SpecialFunc import SpecialFunc
@@ -34,6 +35,7 @@ class QueryEnumDelegator(AbstractJumpDelegator):
             },
             ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
             ReservedArgType.HelpHint.name: "Enumerate available arg options (based on existing arg values)",
+            ReservedArgType.FuncState.name: FuncState.alpha.name,
             ReservedArgType.FuncId.name: SpecialFunc.query_enum_items_func.name,
         }]
         return func_envelopes

--- a/src/argrelay/plugin_interp/FuncTreeInterpFactory.py
+++ b/src/argrelay/plugin_interp/FuncTreeInterpFactory.py
@@ -209,7 +209,7 @@ class FuncTreeInterpFactory(AbstractInterpFactory):
         interp_tree_node_config_dict,
     ):
         """
-        Provide search control based on `func_ids_to_func_rel_paths`.
+        Provide `func_search_control` based on `func_ids_to_func_rel_paths`.
         """
 
         class_to_collection_map: dict = self.server_config.class_to_collection_map
@@ -239,6 +239,14 @@ class FuncTreeInterpFactory(AbstractInterpFactory):
             keys_to_types_list.append({
                 f"{path_step_key_arg_name(sel_ipos)}": f"{func_envelope_path_step_prop_name(sel_ipos)}"
             })
+
+        # Include other fields:
+        keys_to_types_list.append({
+            "state": ReservedArgType.FuncState.name
+        })
+        keys_to_types_list.append({
+            "id": ReservedArgType.FuncId.name
+        })
 
     def populate_func_tree_props(
         self,

--- a/src/argrelay/plugin_loader/AbstractLoader.py
+++ b/src/argrelay/plugin_loader/AbstractLoader.py
@@ -1,4 +1,5 @@
 from argrelay.enum_desc.PluginType import PluginType
+from argrelay.relay_server.QueryEngine import QueryEngine
 from argrelay.runtime_context.AbstractPlugin import AbstractPlugin
 from argrelay.runtime_data.StaticData import StaticData
 
@@ -13,5 +14,6 @@ class AbstractLoader(AbstractPlugin):
     def update_static_data(
         self,
         static_data: StaticData,
+        query_engine: QueryEngine,
     ) -> StaticData:
         pass

--- a/src/argrelay/plugin_loader/NoopLoader.py
+++ b/src/argrelay/plugin_loader/NoopLoader.py
@@ -1,4 +1,5 @@
 from argrelay.plugin_loader.AbstractLoader import AbstractLoader
+from argrelay.relay_server.QueryEngine import QueryEngine
 from argrelay.runtime_data.StaticData import StaticData
 
 
@@ -7,5 +8,6 @@ class NoopLoader(AbstractLoader):
     def update_static_data(
         self,
         static_data: StaticData,
+        query_engine: QueryEngine,
     ) -> StaticData:
         return static_data

--- a/src/argrelay/sample_conf/argrelay_plugin.yaml
+++ b/src/argrelay/sample_conf/argrelay_plugin.yaml
@@ -64,7 +64,6 @@ plugin_instance_entries:
             -   ConfigOnlyDelegator.default
             #   Interps for `interp_tree` per command (zero-arg):
             -   InterpTreeInterpFactory.default
-            -   InterpTreeInterpFactory.service
             #   Interps for normal funcs:
             -   FuncTreeInterpFactory.default
             #   Interps for special funcs:
@@ -78,7 +77,7 @@ plugin_instance_entries:
                 # Another equivalent binding
                 # (if `some_command` is configured, it will behave as `relay_demo` above):
                 "some_command": InterpTreeInterpFactory.default
-                "service_relay_demo": InterpTreeInterpFactory.service
+                "service_relay_demo": InterpTreeInterpFactory.default
             ignored_func_ids_list:
                 -   desc_git_tag_func
                 -   desc_git_commit_func
@@ -91,6 +90,7 @@ plugin_instance_entries:
             -   FuncTreeInterpFactory.help_hint_func
             -   FuncTreeInterpFactory.query_enum_items_func
             -   FuncTreeInterpFactory.default
+            -   FuncTreeInterpFactory.service
         plugin_config:
             interp_selector_tree:
                 "relay_demo": &default_interp_selector_tree
@@ -104,15 +104,6 @@ plugin_instance_entries:
                         "help": FuncTreeInterpFactory.help_hint_func
                         "": FuncTreeInterpFactory.default
                 "some_command": *default_interp_selector_tree
-
-    InterpTreeInterpFactory.service:
-        plugin_module_name: argrelay.plugin_interp.InterpTreeInterpFactory
-        plugin_class_name: InterpTreeInterpFactory
-        plugin_dependencies:
-            -   FuncTreeInterpFactory.help_hint_func
-            -   FuncTreeInterpFactory.service
-        plugin_config:
-            interp_selector_tree:
                 "service_relay_demo":
                     "help": FuncTreeInterpFactory.help_hint_func
                     "": FuncTreeInterpFactory.service
@@ -298,7 +289,7 @@ plugin_instance_entries:
                     "duplicates":
                         "help": InterpTreeInterpFactory.default
                 "service_relay_demo":
-                    "help": InterpTreeInterpFactory.service
+                    "help": InterpTreeInterpFactory.default
 
     QueryEnumDelegator.default:
         plugin_module_name: argrelay.plugin_delegator.QueryEnumDelegator

--- a/src/argrelay/sample_conf/argrelay_server.yaml
+++ b/src/argrelay/sample_conf/argrelay_server.yaml
@@ -278,21 +278,21 @@ server_plugin_control:
                                     plugin_instance_id: InterpTreeInterpFactory.default
             "service_relay_demo":
                 node_type: zero_arg_node
-                plugin_instance_id: InterpTreeInterpFactory.service
+                plugin_instance_id: InterpTreeInterpFactory.default
                 sub_tree:
                     "help":
                         <<: *help_hint_func_interp_tree_node
                         next_interp:
                             jump_path:
                                 -   "service_relay_demo"
-                            plugin_instance_id: InterpTreeInterpFactory.service
+                            plugin_instance_id: InterpTreeInterpFactory.default
                     "":
                         node_type: interp_tree_node
                         plugin_instance_id: FuncTreeInterpFactory.service
                         next_interp:
                             jump_path:
                                 -   "service_relay_demo"
-                            plugin_instance_id: InterpTreeInterpFactory.service
+                            plugin_instance_id: InterpTreeInterpFactory.default
                         sub_tree:
                             "goto":
                                 node_type: func_tree_node

--- a/src/argrelay/schema_config_interp/FuncEnvelopeSchema.py
+++ b/src/argrelay/schema_config_interp/FuncEnvelopeSchema.py
@@ -1,5 +1,6 @@
 from marshmallow import fields, validates_schema, INCLUDE
 
+from argrelay.enum_desc.FuncState import FuncState
 from argrelay.enum_desc.ReservedArgType import ReservedArgType
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.misc_helper_common.TypeDesc import TypeDesc
@@ -50,6 +51,7 @@ func_envelope_desc = TypeDesc(
         sample_field_type_C_: "C_value_1",
         ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
         ReservedArgType.HelpHint.name: f"Some help hint",
+        ReservedArgType.FuncState.name: FuncState.demo.name,
         ReservedArgType.FuncId.name: func_id_some_func_,
     },
     default_file_path = "",

--- a/src/argrelay/test_infra/InOutTestClass.py
+++ b/src/argrelay/test_infra/InOutTestClass.py
@@ -122,7 +122,7 @@ class InOutTestClass(BaseTestClass):
                                 )
                             elif isinstance(assigned_value, list):
                                 # A bit of hack: if `list`, then check if it matches `remaining_types_to_values`:
-                                self.assertTrue(
+                                self.assertEqual(
                                     assigned_value,
                                     envelope_containers
                                     [container_ipos].remaining_types_to_values

--- a/tests/offline_tests/composite_tree/test_CompositeTreeWalker.py
+++ b/tests/offline_tests/composite_tree/test_CompositeTreeWalker.py
@@ -155,7 +155,7 @@ class ThisTestClass(LocalTestClass):
                         },
                     },
                     "service_relay_demo": {
-                        "help": f"{InterpTreeInterpFactory.__name__}.service",
+                        "help": f"{InterpTreeInterpFactory.__name__}.default",
                     },
                 },
                 SpecialFunc.help_hint_func.name,
@@ -204,7 +204,7 @@ class ThisTestClass(LocalTestClass):
                 {
                     "relay_demo": "InterpTreeInterpFactory.default",
                     "some_command": "InterpTreeInterpFactory.default",
-                    "service_relay_demo": "InterpTreeInterpFactory.service",
+                    "service_relay_demo": "InterpTreeInterpFactory.default",
                 },
             ),
         ]
@@ -352,18 +352,12 @@ class ThisTestClass(LocalTestClass):
                             "": "FuncTreeInterpFactory.default",
                         },
                     },
-                },
-                f"{InterpTreeInterpFactory.__name__}.default",
-            ),
-            (
-                line_no(),
-                {
                     "service_relay_demo": {
                         "help": "FuncTreeInterpFactory.help_hint_func",
                         "": "FuncTreeInterpFactory.service",
                     },
                 },
-                f"{InterpTreeInterpFactory.__name__}.service",
+                f"{InterpTreeInterpFactory.__name__}.default",
             ),
         ]
 

--- a/tests/offline_tests/plugin_interp/test_FuncArgsInterpFactory.py
+++ b/tests/offline_tests/plugin_interp/test_FuncArgsInterpFactory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 
 from argrelay.enum_desc.CompType import CompType
+from argrelay.enum_desc.FuncState import FuncState
 from argrelay.enum_desc.ReservedArgType import ReservedArgType
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.plugin_delegator.NoopDelegator import NoopDelegator
@@ -98,6 +99,7 @@ class ThisTestClass(BaseTestClass):
                 search_control_list_: [],
             },
             ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
+            ReservedArgType.FuncState.name: FuncState.demo.name,
             ReservedArgType.FuncId.name: "func_1",
             type_1: "type_1_value_1",
             type_2: "type_2_value_1",
@@ -110,6 +112,7 @@ class ThisTestClass(BaseTestClass):
                 search_control_list_: [],
             },
             ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
+            ReservedArgType.FuncState.name: FuncState.demo.name,
             ReservedArgType.FuncId.name: "func_2",
             type_1: "type_1_value_2",
             type_2: "type_2_value_2",
@@ -137,6 +140,7 @@ class ThisTestClass(BaseTestClass):
                 search_control_list_: [],
             },
             ReservedArgType.EnvelopeClass.name: ReservedEnvelopeClass.ClassFunction.name,
+            ReservedArgType.FuncState.name: FuncState.demo.name,
             ReservedArgType.FuncId.name: "func_3",
             type_1: "type_1_value_1",
             type_2: "type_2_value_1",

--- a/tests/offline_tests/relay_demo/test_relay_demo.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo.py
@@ -4,8 +4,10 @@ from argrelay.client_command_local.AbstractLocalClientCommand import AbstractLoc
 from argrelay.custom_integ.ServiceArgType import ServiceArgType
 from argrelay.custom_integ.ServiceDelegator import ServiceDelegator
 from argrelay.custom_integ.ServiceEnvelopeClass import ServiceEnvelopeClass
+from argrelay.custom_integ.value_constants import goto_service_func_, goto_host_func_
 from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.CompType import CompType
+from argrelay.enum_desc.FuncState import FuncState
 from argrelay.enum_desc.ReservedArgType import ReservedArgType
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.enum_desc.TermColor import TermColor
@@ -140,13 +142,13 @@ class ThisTestClass(LocalTestClass):
                 "FS_13_51_07_97: Suggestion for a value from other spaces which do not have \"coordinate\" specified yet.",
             ),
             (
-                line_no(), "some_command q| dev", CompType.PrefixHidden,
+                line_no(), "some_command pro|", CompType.PrefixHidden,
                 [],
-                "Do not suggest a value from other spaces until "
-                "they are available for query for current envelope to search",
+                "Do not suggest a value (prod) from other spaces until "
+                "they are available for query for next envelope to search (current one is func).",
             ),
             (
-                line_no(), "some_command pro| dev", CompType.PrefixHidden,
+                line_no(), "some_command goto host pro| dev", CompType.PrefixHidden,
                 [],
                 "FS_13_51_07_97: No suggestion for another value from a space which already have \"coordinate\" specified, "
                 "and this value still do not force itself (FS_90_48_11_45) yet as it is incomplete.",
@@ -539,6 +541,8 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: some_command {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.remaining_value.value}*{func_envelope_path_step_prop_name(1)}: ?{TermColor.reset_style.value} config desc diff duplicates echo enum goto help intercept list 
 {" " * indent_size}{TermColor.remaining_value.value}{func_envelope_path_step_prop_name(2)}: ?{TermColor.reset_style.value} commit config desc diff double_execution echo goto help host intercept list print_with_exit print_with_io_redirect print_with_level repo service tag 
+{" " * indent_size}{TermColor.remaining_value.value}{ReservedArgType.FuncState.name}: ?{TermColor.reset_style.value} alpha beta demo gamma 
+{" " * indent_size}{TermColor.remaining_value.value}{ReservedArgType.FuncId.name}: ?{TermColor.reset_style.value} desc_git_commit_func desc_git_tag_func desc_host_func desc_service_func diff_service_func echo_args_func funct_id_double_execution funct_id_print_with_exit_code funct_id_print_with_io_redirect funct_id_print_with_severity_level goto_git_repo_func goto_host_func goto_service_func help_hint_func intercept_invocation_func list_host_func list_service_func query_enum_items_func 
 """,
             ),
             (
@@ -551,6 +555,8 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: some_command {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(2)}: service {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedArgType.FuncState.name}: {FuncState.demo.name} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedArgType.FuncId.name}: {goto_service_func_} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassService.name}: {TermColor.found_count_n.value}2{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}code_maturity: dev {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}flow_stage: upstream {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
@@ -577,6 +583,8 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: some_command {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(2)}: host {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedArgType.FuncState.name}: {FuncState.demo.name} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedArgType.FuncId.name}: {goto_host_func_} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassHost.name}: {TermColor.found_count_n.value}10{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.remaining_value.value}*code_maturity: ?{TermColor.reset_style.value} dev prod qa 
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}flow_stage: upstream {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
@@ -598,6 +606,8 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: some_command {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(2)}: service {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedArgType.FuncState.name}: {FuncState.demo.name} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedArgType.FuncId.name}: {goto_service_func_} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassService.name}: {TermColor.found_count_n.value}2{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}code_maturity: prod {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}flow_stage: upstream {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
@@ -1058,6 +1068,8 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: relay_demo {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(2)}: service {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedArgType.FuncState.name}: {FuncState.demo.name} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedArgType.FuncId.name}: {goto_service_func_} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassService.name}: {TermColor.found_count_1.value}1{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}code_maturity: dev {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}flow_stage: downstream {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
@@ -1083,6 +1095,8 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}r{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}elay_demo{TermColor.reset_style.value} {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(2)}: service {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedArgType.FuncState.name}: {FuncState.demo.name} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedArgType.FuncId.name}: {goto_service_func_} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassService.name}: {TermColor.found_count_1.value}1{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}code_maturity: dev {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}flow_stage: downstream {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
@@ -1108,6 +1122,8 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: some_command {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(2)}: service {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedArgType.FuncState.name}: {FuncState.demo.name} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedArgType.FuncId.name}: {goto_service_func_} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassService.name}: {TermColor.found_count_n.value}3{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}code_maturity: prod {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}flow_stage: downstream {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}

--- a/tests/offline_tests/relay_demo/test_relay_demo_TD_43_24_76_58_missing_props.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_TD_43_24_76_58_missing_props.py
@@ -13,15 +13,24 @@ class ThisTestClass(LocalTestClass):
     same_test_data_per_class = "TD_39_25_11_76"  # missing props
 
     def test_arg_assignments_and_suggestions_for_TD_39_25_11_76_missing_props(self):
+        """
+        NOTE: These test cases do not work at the level of details originally specified for them.
+              Now, there is a validation to prevent TODO_39_25_11_76 missing props
+              Therefore, they are failed with exception on server start and the test cases were changed to
+              simply assert that.
+        """
+
         test_cases = [
             (
                 line_no(), "relay_demo goto host zxcv |", CompType.PrefixShown,
+                ValueError,
                 [],
                 None,
                 "See Step 1 in the next test case."
             ),
             (
                 line_no(), "relay_demo goto host zxcv |", CompType.DescribeArgs,
+                ValueError,
                 # `CompType.DescribeArgs`: does not provide suggestion:
                 None,
                 {
@@ -55,6 +64,7 @@ class ThisTestClass(LocalTestClass):
             ),
             (
                 line_no(), "relay_demo goto host asdf |", CompType.PrefixShown,
+                ValueError,
                 [
                     "apac",
                     "emea",
@@ -64,6 +74,7 @@ class ThisTestClass(LocalTestClass):
             ),
             (
                 line_no(), "relay_demo goto host asdf |", CompType.DescribeArgs,
+                ValueError,
                 # `CompType.DescribeArgs`: does not provide suggestion:
                 None,
                 {
@@ -97,19 +108,26 @@ class ThisTestClass(LocalTestClass):
                     line_number,
                     test_line,
                     comp_type,
+                    expected_exception,
                     expected_suggestions,
                     container_ipos_to_expected_assignments,
                     case_comment,
                 ) = test_case
-                self.verify_output_via_local_client(
-                    self.__class__.same_test_data_per_class,
-                    test_line,
-                    comp_type,
-                    expected_suggestions,
-                    container_ipos_to_expected_assignments,
-                    None,
-                    None,
-                    None,
-                    None,
-                    LocalClientEnvMockBuilder().set_reset_local_server(False),
+
+                with self.assertRaises(ValueError) as exc_context:
+                    self.verify_output_via_local_client(
+                        self.__class__.same_test_data_per_class,
+                        test_line,
+                        comp_type,
+                        expected_suggestions,
+                        container_ipos_to_expected_assignments,
+                        None,
+                        None,
+                        None,
+                        None,
+                        LocalClientEnvMockBuilder(),
+                    )
+                self.assertEqual(
+                    expected_exception,
+                    type(exc_context.exception),
                 )

--- a/tests/offline_tests/relay_demo/test_relay_demo_hidden_funcs.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_hidden_funcs.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from argrelay.composite_tree.CompositeForestSchema import tree_roots_
+from argrelay.composite_tree.CompositeNodeSchema import sub_tree_, node_type_, func_id_
+from argrelay.composite_tree.CompositeNodeType import CompositeNodeType
+from argrelay.custom_integ.value_constants import desc_git_tag_func_
+from argrelay.enum_desc.ArgSource import ArgSource
+from argrelay.enum_desc.CompType import CompType
+from argrelay.plugin_interp.FuncTreeInterpFactory import FuncTreeInterpFactory, tree_path_selector_prefix_
+from argrelay.plugin_interp.FuncTreeInterpFactoryConfigSchema import func_selector_tree_
+from argrelay.runtime_data.AssignedValue import AssignedValue
+from argrelay.schema_config_core_server.ServerConfigSchema import server_config_desc, server_plugin_control_
+from argrelay.schema_config_core_server.ServerPluginControlSchema import composite_forest_
+from argrelay.schema_config_plugin.PluginConfigSchema import plugin_config_desc, plugin_instance_entries_
+from argrelay.schema_config_plugin.PluginEntrySchema import plugin_config_
+from argrelay.test_infra import line_no
+from argrelay.test_infra.EnvMockBuilder import LocalClientEnvMockBuilder
+from argrelay.test_infra.LocalTestClass import LocalTestClass
+
+
+class ThisTestClass(LocalTestClass):
+    same_test_data_per_class = "TD_63_37_05_36"  # demo
+
+    def test_arg_assignments_and_suggestions_hidde_funcs(self):
+        test_cases = [
+            (
+                line_no(), "relay_demo desc |", CompType.DescribeArgs,
+                # `CompType.DescribeArgs`: does not provide suggestion:
+                None,
+                {
+                    0: {
+                        f"{tree_path_selector_prefix_}{0}": AssignedValue("relay_demo", ArgSource.InitValue),
+                        f"{tree_path_selector_prefix_}{1}": AssignedValue("desc", ArgSource.ExplicitPosArg),
+                        f"{tree_path_selector_prefix_}{2}": [
+                            "commit",
+                            "host",
+                            "service",
+                            "tag",
+                        ],
+                    },
+                    1: None,
+                },
+                False,
+                "TODO_39_25_11_76: Step 1: funcs are not hidden",
+            ),
+            (
+                line_no(), "relay_demo desc |", CompType.DescribeArgs,
+                # `CompType.DescribeArgs`: does not provide suggestion:
+                None,
+                {
+                    0: {
+                        f"{tree_path_selector_prefix_}{0}": AssignedValue("relay_demo", ArgSource.InitValue),
+                        f"{tree_path_selector_prefix_}{1}": AssignedValue("desc", ArgSource.ExplicitPosArg),
+                        # NOTE: even if it is single value, it is not assigned:
+                        f"{tree_path_selector_prefix_}{2}": [
+                            "retag",
+                        ],
+                        f"{tree_path_selector_prefix_}{3}": AssignedValue("qwer", ArgSource.ImplicitValue),
+                    },
+                    1: {},
+                    2: None,
+                },
+                True,
+                "TODO_39_25_11_76: Step 2: funcs are hidden",
+            ),
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case):
+                (
+                    line_number,
+                    test_line,
+                    comp_type,
+                    expected_suggestions,
+                    container_ipos_to_expected_assignments,
+                    is_func_hidden,
+                    case_comment,
+                ) = test_case
+
+                server_config_dict = server_config_desc.dict_from_default_file()
+                plugin_config_dict = plugin_config_desc.dict_from_default_file()
+
+                if is_func_hidden:
+                    # Patch existing config with extra level:
+                    server_config_dict[
+                        server_plugin_control_
+                    ][
+                        composite_forest_
+                    ][tree_roots_]["relay_demo"][sub_tree_][""][sub_tree_]["desc"][sub_tree_]["retag"] = {
+                        node_type_: CompositeNodeType.tree_path_node.name,
+                        sub_tree_: {
+                            "qwer": {
+                                node_type_: CompositeNodeType.func_tree_node.name,
+                                func_id_: desc_git_tag_func_,
+                            },
+                        },
+                    }
+
+                    # TODO: FS_33_76_82_84 composite tree:
+                    #       once composite tree is complete,
+                    #       this extra (duplicated) config will not be required:
+                    plugin_config_dict[plugin_instance_entries_][
+                        f"{FuncTreeInterpFactory.__name__}.default"
+                    ][plugin_config_][func_selector_tree_]["desc"]["retag"] = {
+                        "qwer": desc_git_tag_func_,
+                    }
+
+                self.verify_output_via_local_client(
+                    self.__class__.same_test_data_per_class,
+                    test_line,
+                    comp_type,
+                    expected_suggestions,
+                    container_ipos_to_expected_assignments,
+                    None,
+                    None,
+                    None,
+                    None,
+                    LocalClientEnvMockBuilder()
+                    .set_reset_local_server(True)
+                    .set_server_config_dict(server_config_dict)
+                    .set_plugin_config_dict(plugin_config_dict),
+                )


### PR DESCRIPTION
*   Instead of invoking all loaders and then loading data to MongoDB, invoke loader by loader.

    This is required to allow each next loader to depend on data loaded by prev loaders.

*   Clean Mongo collections only once per server start.
*   Propagate `QueryEngine` to `AbstractLoader`-s so that they can query loaded data.

TODO_39_25_11_76: missing props:
*   Capture behavior of hidden funcs with extra levels of tree path selector.
*   Implement validation for missing props (except func envelopes for now).

Others:
*   Use single instance of `InterpTreeInterpFactory` (relying on composite tree).
*   Add `FuncState` and `FuncId` to func `search_control`.
*   Introduce `TopDir` enum.