### PR TITLE
Populate all path selector props on function load

### DIFF
--- a/docs/dev_notes/term_dictionary.md
+++ b/docs/dev_notes/term_dictionary.md
@@ -69,7 +69,7 @@ See also FS_37_57_36_29 (containers, envelopes, payloads).
 ### `envelope_collection`
 
 A wrapper providing data for a MongoDB collection:
-*   list of `index_field`-s
+*   list of `index_prop`-s
 *   set of `data_envelope`-s
 
 See also:
@@ -85,12 +85,12 @@ See also FS_37_57_36_29 (containers, envelopes, payloads).
 
 # I
 
-### `index_field`
+### `index_prop`
 
-MongoDB allows declaring `index_field`-s per collection to make `data_envelope` search faster.
+MongoDB allows declaring `index_prop`-s per collection to make `data_envelope` search faster.
 There are some limits - see FS_56_43_05_79 search in different collection.
 
-List of `index_field`-s per collection is defined in `EnvelopeCollection`.
+List of `index_prop`-s per collection is defined in `EnvelopeCollection`.
 
 ### `interp`
 

--- a/docs/feature_stories/FS_00_13_77_97.plugin_framework.md
+++ b/docs/feature_stories/FS_00_13_77_97.plugin_framework.md
@@ -41,7 +41,7 @@ Data is loaded once on restart.
 
 When func `AbstractLoader.update_static_data` is called, it:
 *   Populates `dict`-s into `EnvelopeCollection.data_envelopes` - the data to be searched.
-*   Lists field names into `EnvelopeCollection.index_fields` - the fields to be indexed by MongoDB.
+*   Lists field names into `EnvelopeCollection.index_props` - the fields to be indexed by MongoDB.
 
 # `InterpFactoryPlugin` / `AbstractInterpFactory`
 

--- a/docs/feature_stories/FS_15_79_76_85.line_processor.md
+++ b/docs/feature_stories/FS_15_79_76_85.line_processor.md
@@ -12,7 +12,7 @@ As of now, there is a single implementation:
 
     User has to select a function and its args as enum items.
 
-TODO: Factor out abstract `LineProcessor` with their individual implementations.
+    TODO: TODO_18_51_46_14: refactor FS_42_76_93_51 zero_arg_interp into FS_15_79_76_85 line processor
 
 TODO: Select (command) line processor via FS_42_76_93_51 first arg (zero arg interp).
       Effectively, any new implementation of line processor will have to be selected via zero arg interp.

--- a/docs/feature_stories/FS_33_76_82_84.composite_tree.md
+++ b/docs/feature_stories/FS_33_76_82_84.composite_tree.md
@@ -1,7 +1,7 @@
 ---
 feature_story: FS_33_76_82_84
 feature_title: composite tree
-feature_status: TODO
+feature_status: TEST
 ---
 Keywords: `composite`, `tree`, `composite_tree`
 

--- a/docs/feature_stories/FS_80_82_13_35.option_list_on_describe_with_prefix.md
+++ b/docs/feature_stories/FS_80_82_13_35.option_list_on_describe_with_prefix.md
@@ -66,7 +66,7 @@ ClassService: 1
   group_label: rrr [ImplicitValue]
   service_name: tt [ExplicitPosArg]
   host_name: zxcv-dd [ImplicitValue]
-  live_status: [none]
+  live_status: ~ [ImplicitValue]
   data_center: dc.11 [ImplicitValue]
   ip_address: ip.172.16.1.2 [ImplicitValue]
 ```

--- a/docs/task_refs/TODO_18_51_46_14.refactor_zero_arg_interp_into_line_processor.md
+++ b/docs/task_refs/TODO_18_51_46_14.refactor_zero_arg_interp_into_line_processor.md
@@ -1,0 +1,10 @@
+
+TODO: TODO_18_51_46_14: refactor FS_42_76_93_51 zero_arg_interp into FS_15_79_76_85 line processor
+
+Factor out abstract `LineProcessor` with their individual implementations.
+
+And the first individual implementation should be FS_55_57_45_04 enum selector.
+
+Plugin `FirstArgInterpFactory` with `first_arg_vals_to_next_interp_factory_ids` config
+should (probably) be selecting line processors instead of interps.
+In this case `InterpTreeInterpFactory.default` instance is the line processor.

--- a/docs/task_refs/TODO_48_38_59_64.remove_interp_tree_abs_paths_to_node_configs.md
+++ b/docs/task_refs/TODO_48_38_59_64.remove_interp_tree_abs_paths_to_node_configs.md
@@ -1,0 +1,6 @@
+
+TODO: TODO_48_38_59_64: remove `interp_tree_abs_paths_to_node_configs`
+
+Apparently, all entries of this `dict` simply contain `plugin_config_dict`.
+
+Then, why do we need them? Use single `plugin_config_dict` directly.

--- a/docs/task_refs/TODO_99_87_25_42.next_incompatible_changes.md
+++ b/docs/task_refs/TODO_99_87_25_42.next_incompatible_changes.md
@@ -9,12 +9,6 @@ TODO:
     *   `propose_arg_values` -> `complete_line`
     *   `relay_line_args` -> `invoke_line`
 
-*   DONE: Rename: `ReservedArgType` to `ReservedPropName`
-    *   DONE: Rename: items inside `ReservedPropName.*` to `camel_case`.
-
-*   DONE: Rename: `ServiceArgType` to `ServicePropName`
-*   DONE: Rename: `GitRepoArgType` to `GitRepoPropName`
-
 *   TODO: Rename: `arg_type` to `prop_name`
 
 *   TODO: Rename: `relay_demo` to something not cut-off `relay`, at least, both `a` and `r` (something `*ar*`) should be included.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def list_dir(
 setuptools.setup(
     name = "argrelay",
     # See `docs/dev_notes/version_format.md`:
-    version = "0.7.3",
+    version = "0.7.4",
     author = "uvsmtid",
     author_email = "uvsmtid@gmail.com",
     description = "Tab-completion & data search server = total recall for Bash shell",

--- a/src/argrelay/composite_tree/CompositeNodeType.py
+++ b/src/argrelay/composite_tree/CompositeNodeType.py
@@ -12,6 +12,8 @@ class CompositeNodeType(Enum):
 
     It is also related to FS_15_79_76_85 line processor
     (which may potentially be merged with FS_42_76_93_51 zero arg interp).
+
+    TODO: TODO_18_51_46_14: refactor FS_42_76_93_51 zero_arg_interp into FS_15_79_76_85 line processor
     """
 
     interp_tree_node = auto()

--- a/src/argrelay/composite_tree/CompositeTreeWalker.py
+++ b/src/argrelay/composite_tree/CompositeTreeWalker.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from enum import Enum, auto
 from typing import Union
 
@@ -188,7 +187,8 @@ class _CompositeTreeWalker_zero_arg_interp_tree(AbstractCompositeTreeWalker):
         if self.curr_node.node_type is CompositeNodeType.zero_arg_node:
             assert len(self.curr_path) == 1
             _put_value_into_dict_path(
-                # TODO: There could be multiple `zero_arg_node`-s each with its own interp,
+                # TODO: TODO_18_51_46_14: refactor FS_42_76_93_51 zero_arg_interp into FS_15_79_76_85 line processor:
+                #       There could be multiple `zero_arg_node`-s each with its own interp,
                 #       but now, there is only one interp selected by `first_interp_factory_id`.
                 #       In fact, `first_interp_factory_id` must be per zero arg - see FS_15_79_76_85 line processor.
                 self.curr_node.plugin_instance_id,
@@ -262,7 +262,7 @@ class _CompositeTreeWalker_interp_tree(AbstractCompositeTreeWalker):
         self.plugin_instance_id: Union[str, None] = plugin_instance_id
 
         # internal trackers:
-        self.curr_parent_plugin_instance_id: Union[InterpTreeNode.NextInterp, None] = None
+        self.curr_parent_plugin_instance_id: Union[str, None] = None
 
         # results:
         self.interp_tree: dict = {}
@@ -311,8 +311,7 @@ class _CompositeTreeWalker_func_tree(AbstractCompositeTreeWalker):
         self.plugin_instance_id: Union[str, None] = plugin_instance_id
 
         # internal trackers:
-        self.curr_parent_plugin_instance_id: Union[InterpTreeNode.NextInterp, None] = None
-        self.curr_parent_plugin_instance_path: Union[list[str], None] = None
+        self.curr_parent_plugin_instance_id: Union[str, None] = None
 
         # results:
         self.func_tree: dict = {}
@@ -326,7 +325,6 @@ class _CompositeTreeWalker_func_tree(AbstractCompositeTreeWalker):
         elif self.curr_node.node_type is CompositeNodeType.interp_tree_node:
             if self.curr_node.plugin_instance_id == self.plugin_instance_id:
                 self.curr_parent_plugin_instance_id = self.plugin_instance_id
-                self.curr_parent_plugin_instance_path = deepcopy(self.curr_path)
                 return TraverseDecision.walk_sub_tree
             else:
                 return TraverseDecision.skip_sub_tree
@@ -336,8 +334,7 @@ class _CompositeTreeWalker_func_tree(AbstractCompositeTreeWalker):
             if self.curr_parent_plugin_instance_id == self.plugin_instance_id:
                 _put_value_into_dict_path(
                     self.curr_node.func_id,
-                    # skip head path steps leading to `curr_parent_plugin_instance_id`:
-                    self.curr_path[len(self.curr_parent_plugin_instance_path):],
+                    self.curr_path,
                     self.func_tree,
                 )
             return TraverseDecision.skip_sub_tree

--- a/src/argrelay/composite_tree/DictTreeWalker.py
+++ b/src/argrelay/composite_tree/DictTreeWalker.py
@@ -71,7 +71,7 @@ def _normalize_tree(
     input_tree: Union[dict, str],
     tree_depth: int,
 ) -> Union[dict, str]:
-    output_tree: dict = {}
+    output_tree: Union[dict, str] = {}
 
     if isinstance(input_tree, str):
         if input_tree == surrogate_tree_leaf_:
@@ -86,7 +86,8 @@ def _normalize_tree(
                 output_tree[surrogate_node_id_] = input_tree
     elif isinstance(input_tree, dict):
         if len(input_tree) == 1 and surrogate_node_id_ in input_tree:
-            output_tree.update(_normalize_tree(input_tree[surrogate_node_id_], tree_depth + 1))
+            # collapse `dict` to `str`:
+            output_tree = input_tree[surrogate_node_id_]
         else:
             for node_id in input_tree:
                 output_tree[node_id] = _normalize_tree(input_tree[node_id], tree_depth + 1)

--- a/src/argrelay/custom_integ/BaseConfigDelegator.py
+++ b/src/argrelay/custom_integ/BaseConfigDelegator.py
@@ -4,8 +4,8 @@ from argrelay.custom_integ.BaseConfigDelegatorConfigSchema import BaseConfigDele
 from argrelay.custom_integ.ConfigOnlyDelegatorConfigSchema import func_configs_
 from argrelay.custom_integ.FuncConfigSchema import func_envelope_, fill_control_list_
 from argrelay.custom_integ.ServiceDelegator import set_default_to
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.misc_helper_common.TypeDesc import TypeDesc
 from argrelay.plugin_delegator.AbstractDelegator import AbstractDelegator, get_func_id_from_interp_ctx
 from argrelay.relay_server.LocalServer import LocalServer

--- a/src/argrelay/custom_integ/ConfigOnlyLoader.py
+++ b/src/argrelay/custom_integ/ConfigOnlyLoader.py
@@ -3,10 +3,10 @@ from copy import deepcopy
 from argrelay.custom_integ.ConfigOnlyLoaderConfigSchema import (
     config_only_loader_config_desc,
     data_envelopes_,
-    collection_name_to_index_fields_map_,
+    collection_name_to_index_props_map_,
 )
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.plugin_loader.AbstractLoader import AbstractLoader
 from argrelay.relay_server.QueryEngine import QueryEngine
 from argrelay.runtime_data.ServerConfig import ServerConfig
@@ -59,9 +59,9 @@ class ConfigOnlyLoader(AbstractLoader):
         class_to_collection_map: dict = self.server_config.class_to_collection_map
 
         # FS_49_96_50_77 config_only_loader plugin:
-        # *   `collection_name_to_index_fields_map`:
-        collection_name_to_index_fields_map: dict[str, list[str]] = self.plugin_config_dict[
-            collection_name_to_index_fields_map_
+        # *   `collection_name_to_index_props_map`:
+        collection_name_to_index_props_map: dict[str, list[str]] = self.plugin_config_dict[
+            collection_name_to_index_props_map_
         ]
         # *   list of `data_envelope`-s (actual data):
         data_envelopes = [
@@ -77,7 +77,7 @@ class ConfigOnlyLoader(AbstractLoader):
         init_envelop_collections(
             self.server_config,
             class_names,
-            lambda _collection_name, _class_name: collection_name_to_index_fields_map[_collection_name],
+            lambda _collection_name, _class_name: collection_name_to_index_props_map[_collection_name],
         )
 
         for class_name in class_names:

--- a/src/argrelay/custom_integ/ConfigOnlyLoaderConfigSchema.py
+++ b/src/argrelay/custom_integ/ConfigOnlyLoaderConfigSchema.py
@@ -12,7 +12,7 @@ from argrelay.schema_config_interp.DataEnvelopeSchema import (
 )
 from argrelay.schema_response.EnvelopeContainerSchema import data_envelopes_
 
-collection_name_to_index_fields_map_ = "collection_name_to_index_fields_map"
+collection_name_to_index_props_map_ = "collection_name_to_index_props_map"
 
 
 class ConfigOnlyLoaderConfigSchema(Schema):
@@ -24,7 +24,7 @@ class ConfigOnlyLoaderConfigSchema(Schema):
         unknown = RAISE
         strict = True
 
-    collection_name_to_index_fields_map = fields.Dict(
+    collection_name_to_index_props_map = fields.Dict(
         keys = fields.String(),
         values = fields.List(
             fields.String(),
@@ -43,7 +43,7 @@ config_only_loader_config_desc = TypeDesc(
     dict_schema = ConfigOnlyLoaderConfigSchema(),
     ref_name = ConfigOnlyLoaderConfigSchema.__name__,
     dict_example = {
-        collection_name_to_index_fields_map_: {
+        collection_name_to_index_props_map_: {
             ReservedEnvelopeClass.ClassFunction.name: [
                 sample_field_type_A_,
                 sample_field_type_B_,

--- a/src/argrelay/custom_integ/GitRepoDelegator.py
+++ b/src/argrelay/custom_integ/GitRepoDelegator.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 import subprocess
 
-from argrelay.custom_integ.GitRepoPropName import GitRepoPropName
 from argrelay.custom_integ.GitRepoEnvelopeClass import GitRepoEnvelopeClass
+from argrelay.custom_integ.GitRepoPropName import GitRepoPropName
 from argrelay.custom_integ.value_constants import (
     goto_git_repo_func_,
     desc_git_commit_func_,
     desc_git_tag_func_,
 )
 from argrelay.enum_desc.FuncState import FuncState
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.misc_helper_common import eprint
 from argrelay.plugin_delegator.AbstractDelegator import AbstractDelegator, get_func_id_from_invocation_input
 from argrelay.relay_server.LocalServer import LocalServer

--- a/src/argrelay/custom_integ/GitRepoLoader.py
+++ b/src/argrelay/custom_integ/GitRepoLoader.py
@@ -6,7 +6,6 @@ from datetime import timezone, datetime, timedelta
 
 from git import Repo
 
-from argrelay.custom_integ.GitRepoPropName import GitRepoPropName
 from argrelay.custom_integ.GitRepoDelegator import repo_root_abs_path_
 from argrelay.custom_integ.GitRepoEntryConfigSchema import (
     repo_rel_path_,
@@ -24,6 +23,7 @@ from argrelay.custom_integ.GitRepoLoaderConfigSchema import (
     repo_entries_,
     load_git_tags_default_,
 )
+from argrelay.custom_integ.GitRepoPropName import GitRepoPropName
 from argrelay.custom_integ.git_utils import is_git_repo
 from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.misc_helper_common import eprint, get_argrelay_dir

--- a/src/argrelay/custom_integ/ServiceDelegator.py
+++ b/src/argrelay/custom_integ/ServiceDelegator.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 
-from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.custom_integ.ServiceEnvelopeClass import ServiceEnvelopeClass
+from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.custom_integ.value_constants import (
     goto_host_func_,
     goto_service_func_,
@@ -15,8 +15,8 @@ from argrelay.custom_integ.value_constants import (
 )
 from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.FuncState import FuncState
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.plugin_delegator.AbstractDelegator import (
     AbstractDelegator,
     get_func_id_from_interp_ctx,

--- a/src/argrelay/custom_integ/ServiceLoader.py
+++ b/src/argrelay/custom_integ/ServiceLoader.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.custom_integ.ServiceEnvelopeClass import ServiceEnvelopeClass
 from argrelay.custom_integ.ServiceLoaderConfigSchema import (
     service_loader_config_desc,
     test_data_ids_to_load_,
 )
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
+from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.misc_helper_common import eprint
 from argrelay.plugin_loader.AbstractLoader import AbstractLoader
 from argrelay.relay_server.QueryEngine import QueryEngine
@@ -180,23 +180,23 @@ class ServiceLoader(AbstractLoader):
         help_hint_envelope_collection = static_data.envelope_collections.setdefault(
             class_to_collection_map[ReservedEnvelopeClass.ClassHelp.name],
             EnvelopeCollection(
-                index_fields = [],
+                index_props = [],
                 data_envelopes = [],
             ),
         )
-        help_hint_index_fields = help_hint_envelope_collection.index_fields
+        help_hint_index_props = help_hint_envelope_collection.index_props
         help_hint_envelopes = help_hint_envelope_collection.data_envelopes
 
         # Init index fields (if they do not exist):
-        for help_hint_index_field in [
+        for help_hint_index_prop in [
             ReservedPropName.envelope_class.name,
             ReservedPropName.arg_type.name,
             ReservedPropName.arg_value.name,
             # `ReservedPropName.help_hint` is not indexed (and uses as search param) - instead, it is a search result:
             # ReservedPropName.help_hint.name,
         ]:
-            if help_hint_index_field not in help_hint_index_fields:
-                help_hint_index_fields.append(help_hint_index_field)
+            if help_hint_index_prop not in help_hint_index_props:
+                help_hint_index_props.append(help_hint_index_prop)
 
         # Generating
         host_envelopes = static_data.envelope_collections[

--- a/src/argrelay/enum_desc/SpecialChar.py
+++ b/src/argrelay/enum_desc/SpecialChar.py
@@ -20,3 +20,12 @@ class SpecialChar(Enum):
     """
     See FS_20_88_05_60 named args.
     """
+
+    NoPropValue = "~"
+    """
+    The choice of `~` was dictated by the two facts:
+    *   `~` is not supposed to be typed (and it expands into user name in Bash which also hides plain `~`)
+    *   `~` sorts last among alphanumeric characters
+
+    See: TODO_39_25_11_76: `data_envelope`-s with missing props.
+    """

--- a/src/argrelay/handler_response/DescribeLineArgsClientResponseHandler.py
+++ b/src/argrelay/handler_response/DescribeLineArgsClientResponseHandler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from argrelay.enum_desc.ArgSource import ArgSource
+from argrelay.enum_desc.SpecialChar import SpecialChar
 from argrelay.enum_desc.TermColor import TermColor
 from argrelay.handler_response.AbstractClientResponseHandler import AbstractClientResponseHandler
 from argrelay.misc_helper_common.ElapsedTime import ElapsedTime
@@ -177,8 +178,8 @@ class DescribeLineArgsClientResponseHandler(AbstractClientResponseHandler):
                     # any arg value assigned to such arg type would return no results.
                     print(" " * indent_size, end = "")
                     print(TermColor.no_option_to_suggest.value, end = "")
-                    print(f"{arg_type}:", end = "")
-                    print(" [none]", end = "")
+                    print(f"{arg_type}: ", end = "")
+                    print(SpecialChar.NoPropValue.value, end = "")
                     print(TermColor.reset_style.value, end = "")
 
                 print()

--- a/src/argrelay/mongo_data/MongoClientWrapper.py
+++ b/src/argrelay/mongo_data/MongoClientWrapper.py
@@ -111,6 +111,7 @@ def log_index_progress(
             f"collection: {mongo_collection}: indexed envelopes: {envelope_per_col_i}/{curr_envelope_i}/{total_envelope_n}..."
         )
 
+
 def log_validation_progress(
     mongo_collection: str,
     curr_envelope_i: int,
@@ -123,12 +124,13 @@ def log_validation_progress(
             f"collection: {mongo_collection}: validated envelopes: {curr_envelope_i}/{total_envelope_n}..."
         )
 
+
 def create_index(
     mongo_db: Database,
     collection_name: str,
-    index_fields: list[str],
+    index_props: list[str],
 ):
     col_proxy: Collection = mongo_db[collection_name]
 
-    for index_field in index_fields:
-        col_proxy.create_index(index_field)
+    for index_prop in index_props:
+        col_proxy.create_index(index_prop)

--- a/src/argrelay/plugin_delegator/AbstractJumpDelegator.py
+++ b/src/argrelay/plugin_delegator/AbstractJumpDelegator.py
@@ -40,9 +40,9 @@ class AbstractJumpDelegator(AbstractDelegator):
 
         # Reverse temporary path per id map into id per path map:
         self.tree_path_to_next_interp_plugin_instance_id: dict[tuple[str, ...], str] = {}
-        for interp_plugin_id, tree_abs_paths in temporary_id_to_paths.items():
+        for interp_factory_instance_id, tree_abs_paths in temporary_id_to_paths.items():
             for tree_abs_path in tree_abs_paths:
-                self.tree_path_to_next_interp_plugin_instance_id[tuple(tree_abs_path)] = interp_plugin_id
+                self.tree_path_to_next_interp_plugin_instance_id[tuple(tree_abs_path)] = interp_factory_instance_id
 
     # TODO_10_72_28_05: This will go away together with switch to FS_33_76_82_84 composite tree config:
     def _compare_config_with_composite_tree(

--- a/src/argrelay/plugin_delegator/EchoDelegator.py
+++ b/src/argrelay/plugin_delegator/EchoDelegator.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from argrelay.enum_desc.FuncState import FuncState
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.SpecialFunc import SpecialFunc
 from argrelay.plugin_delegator.AbstractDelegator import AbstractDelegator
 from argrelay.relay_server.LocalServer import LocalServer

--- a/src/argrelay/plugin_delegator/HelpDelegator.py
+++ b/src/argrelay/plugin_delegator/HelpDelegator.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from argrelay.custom_integ.ServiceDelegator import redirect_to_no_func_error
 from argrelay.enum_desc.FuncState import FuncState
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.SpecialFunc import SpecialFunc
 from argrelay.enum_desc.TermColor import TermColor
 from argrelay.plugin_delegator.AbstractDelegator import get_func_id_from_invocation_input

--- a/src/argrelay/plugin_delegator/InterceptDelegator.py
+++ b/src/argrelay/plugin_delegator/InterceptDelegator.py
@@ -4,8 +4,8 @@ from enum import Enum, auto
 
 from argrelay.custom_integ.ServiceDelegator import set_default_to
 from argrelay.enum_desc.FuncState import FuncState
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.SpecialFunc import SpecialFunc
 from argrelay.plugin_delegator.AbstractDelegator import get_func_id_from_invocation_input, get_func_id_from_interp_ctx
 from argrelay.plugin_delegator.AbstractJumpDelegator import AbstractJumpDelegator

--- a/src/argrelay/plugin_delegator/QueryEnumDelegator.py
+++ b/src/argrelay/plugin_delegator/QueryEnumDelegator.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from argrelay.enum_desc.FuncState import FuncState
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.SpecialFunc import SpecialFunc
 from argrelay.handler_response.DescribeLineArgsClientResponseHandler import DescribeLineArgsClientResponseHandler
 from argrelay.plugin_delegator.AbstractJumpDelegator import AbstractJumpDelegator

--- a/src/argrelay/plugin_interp/AbstractInterp.py
+++ b/src/argrelay/plugin_interp/AbstractInterp.py
@@ -28,6 +28,8 @@ class AbstractInterp:
         self.__class__.instance_counter += 1
         self.instance_number: int = self.instance_counter
 
+        self.interp_tree_abs_path = list(interp_ctx.interp_tree_abs_path)
+
         self.interp_tree_node_config_dict: dict = interp_tree_node_config_dict
         """
         The configs for individual `AbstractInterp` are called `interp_tree_node_config_dict` and cloned/populated by

--- a/src/argrelay/plugin_interp/AbstractInterpFactory.py
+++ b/src/argrelay/plugin_interp/AbstractInterpFactory.py
@@ -22,6 +22,15 @@ class AbstractInterpFactory(AbstractPlugin):
             plugin_instance_id,
             plugin_config_dict,
         )
+
+        self.interp_tree_abs_paths: list[tuple[str, ...]] = []
+        """
+        All tree paths this plugin is plugged into.
+
+        It is populated via `load_interp_tree_abs_paths`.
+        """
+
+        # TODO: TODO_48_38_59_64: remove `interp_tree_abs_paths_to_node_configs`:
         # Takes part in implementation of FS_01_89_09_24 interp tree:
         self.interp_tree_abs_paths_to_node_configs: dict[tuple[str, ...], dict] = {}
         """
@@ -37,6 +46,16 @@ class AbstractInterpFactory(AbstractPlugin):
     ) -> PluginType:
         return PluginType.InterpFactoryPlugin
 
+    def load_interp_tree_abs_paths(
+        self,
+        this_plugin_instance_interp_tree_abs_paths: list[tuple[str, ...]],
+    ):
+        """
+        This function is meant to be called prior to `load_func_envelopes` to
+        let plugins know about all paths in the FS_01_89_09_24 `interp_tree` where they are plugged into.
+        """
+        pass
+
     def load_func_envelopes(
         self,
         interp_tree_abs_path: tuple[str, ...],
@@ -49,6 +68,7 @@ class AbstractInterpFactory(AbstractPlugin):
 
         Returns list of mapped `func_id`-s.
         """
+        # TODO: TODO_48_38_59_64: remove `interp_tree_abs_paths_to_node_configs`:
         if interp_tree_abs_path in self.interp_tree_abs_paths_to_node_configs:
             raise RuntimeError(f"`{interp_tree_abs_path}` has already been loaded")
         else:

--- a/src/argrelay/plugin_interp/FirstArgInterpFactory.py
+++ b/src/argrelay/plugin_interp/FirstArgInterpFactory.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from argrelay.composite_tree.CompositeTreeWalker import extract_zero_arg_interp_tree
 from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.misc_helper_common import eprint
@@ -73,6 +75,8 @@ class FirstArgInterpFactory(InterpTreeInterpFactory):
                     )
                 func_ids_to_func_envelopes[func_id] = func_envelope
 
+        self.load_interp_tree_abs_paths([])
+
         interp_tree_abs_path: tuple[str, ...] = tuple([])
         mapped_func_ids: list[str] = self.load_func_envelopes(
             interp_tree_abs_path,
@@ -89,6 +93,19 @@ class FirstArgInterpFactory(InterpTreeInterpFactory):
                 else:
                     # Func is ignored - skip:
                     continue
+
+    def load_interp_tree_abs_paths(
+        self,
+        this_plugin_instance_interp_tree_abs_paths: list[tuple[str, ...]],
+    ):
+        # TODO: TODO_18_51_46_14: refactor FS_42_76_93_51 zero_arg_interp into FS_15_79_76_85 line processor:
+        #       At the moment, `FirstArgInterpFactory` is not plugged into any tree
+        #       (while it should be part of composite tree likely as `CompositeNodeType.zero_arg_node`).
+        #       Instead, it is selected via `first_interp_factory_id` in server config.
+        #
+        #       When this func is called for `FirstArgInterpFactory`, it cannot be found plugged anywhere
+        #       within interp tree - instead, it walks the tree and invokes this func for other interps.
+        super().load_interp_tree_abs_paths([])
 
     def create_interp(
         self,

--- a/src/argrelay/plugin_interp/FuncTreeInterp.py
+++ b/src/argrelay/plugin_interp/FuncTreeInterp.py
@@ -5,8 +5,8 @@ from typing import Union
 from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.CompScope import CompScope
 from argrelay.enum_desc.InterpStep import InterpStep
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.SpecialChar import SpecialChar
 from argrelay.misc_helper_server import insert_unique_to_sorted_list
 from argrelay.plugin_delegator.AbstractDelegator import AbstractDelegator
@@ -52,7 +52,7 @@ class FuncTreeInterp(AbstractInterp):
         interp_factory_id,
         interp_tree_node_config_dict: dict,
         interp_ctx: InterpContext,
-        func_ids_to_func_rel_paths: dict[str, list[list[str]]],
+        func_ids_to_func_abs_paths: dict[str, list[list[str]]],
         paths_to_jump: dict[tuple[str, ...], tuple[str, ...]],
     ):
         super().__init__(
@@ -70,7 +70,7 @@ class FuncTreeInterp(AbstractInterp):
         self._apply_func_init_control()
         self._apply_func_search_control()
 
-        self.func_ids_to_func_rel_paths: dict[str, list[list[str]]] = func_ids_to_func_rel_paths
+        self.func_ids_to_func_abs_paths: dict[str, list[list[str]]] = func_ids_to_func_abs_paths
 
     def _apply_func_init_control(self):
         self.interp_ctx.curr_container.assigned_types_to_values[

--- a/src/argrelay/plugin_interp/InterpTreeInterp.py
+++ b/src/argrelay/plugin_interp/InterpTreeInterp.py
@@ -30,7 +30,6 @@ class InterpTreeInterp(AbstractInterp):
         )
         self.interp_selector_tree: dict = interp_tree_node_config_dict[interp_selector_tree_]
         self.next_interp_factory_id: Union[str, None] = None
-        self.interp_tree_abs_path = list(interp_ctx.interp_tree_abs_path)
 
         # TODO: Why hard-coded? Isn't it possible for this plugin to be plugged into any depth of the tree?
         # Token with ipos = 0 is the command name eaten by `FirstArgInterp` (FS_42_76_93_51 first interp):

--- a/src/argrelay/plugin_interp/NoopInterpFactory.py
+++ b/src/argrelay/plugin_interp/NoopInterpFactory.py
@@ -22,6 +22,7 @@ class NoopInterpFactory(AbstractInterpFactory):
         self,
         interp_ctx: InterpContext,
     ) -> NoopInterp:
+        # TODO: TODO_48_38_59_64: remove `interp_tree_abs_paths_to_node_configs`:
         # `NoopInterpFactory` is not normally attached to any tree and
         # `load_func_envelopes` is not invoked to clone/populate separate configs
         # (which makes it use `plugin_config_dict` directly instead of `interp_tree_node_config_dict`) -

--- a/src/argrelay/relay_server/CustomFlaskApp.py
+++ b/src/argrelay/relay_server/CustomFlaskApp.py
@@ -46,7 +46,7 @@ class CustomFlaskApp(Flask):
         )
 
     def run_with_config(self):
-        # Use custom logging at DEBUG level - see: `log_request` and `log_response:
+        # Use custom logging at DEBUG level - see: `log_request` and `log_response`:
         self.logger.setLevel(logging.DEBUG)
         # Log only at ERROR level by default logger:
         # https://stackoverflow.com/a/18379764/441652

--- a/src/argrelay/relay_server/HelpHintCache.py
+++ b/src/argrelay/relay_server/HelpHintCache.py
@@ -1,5 +1,5 @@
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.relay_server.QueryEngine import QueryEngine
 
 

--- a/src/argrelay/relay_server/QueryEngine.py
+++ b/src/argrelay/relay_server/QueryEngine.py
@@ -70,7 +70,7 @@ class QueryEngine:
         collection_name: str,
         query_dict: dict,
     ) -> Cursor:
-         return self.mongo_db[collection_name].find(query_dict)
+        return self.mongo_db[collection_name].find(query_dict)
 
     def query_prop_values(
         self,

--- a/src/argrelay/relay_server/gui_static/argrelay_client.js
+++ b/src/argrelay/relay_server/gui_static/argrelay_client.js
@@ -786,7 +786,8 @@ function populate_envelope_containers(
                 remaining_values_elem.classList.add("suggested_arg_value");
             } else {
                 arg_type_elem.textContent = arg_type + ": ";
-                arg_value_elem.textContent = "[none]";
+                // See: SpecialChar.NoPropValue:
+                arg_value_elem.textContent = "~";
                 arg_container_elem.classList.add("no_data");
             }
 

--- a/src/argrelay/runtime_context/InterpContext.py
+++ b/src/argrelay/runtime_context/InterpContext.py
@@ -298,6 +298,8 @@ class InterpContext:
         Implements FS_55_57_45_04 enum selector version of FS_15_79_76_85 line processor.
 
         Start with initial interpreter and continue until curr interpreter returns no more next interpreter.
+
+        TODO: TODO_18_51_46_14: refactor FS_42_76_93_51 zero_arg_interp into FS_15_79_76_85 line processor.
         """
 
         interp_n: int = 0

--- a/src/argrelay/runtime_data/EnvelopeCollection.py
+++ b/src/argrelay/runtime_data/EnvelopeCollection.py
@@ -8,11 +8,12 @@ class EnvelopeCollection:
     """
     Allows distributing `data_envelope`-s across FS_56_43_05_79 different collections.
 
-    Specifies collection of `data_envelope`-s to load and associated `index_fields` to create.
+    Specifies collection of `data_envelope`-s to load and associated `index_props` to create.
 
     See also `EnvelopeCollectionSchema`.
     """
-    index_fields: list = field()
+
+    index_props: list = field()
     """
     Lists fields of `data_envelop` which are to be indexed by MongoDB for given collection.
     """

--- a/src/argrelay/sample_conf/argrelay_plugin.yaml
+++ b/src/argrelay/sample_conf/argrelay_plugin.yaml
@@ -47,6 +47,99 @@ reusable_config_data:
             "":
                 -   "service_relay_demo"
 
+    # Full func_tree, but not used in this form (saved for copying-and-pasting):
+    func_tree: &func_tree
+        "relay_demo":
+            "intercept": intercept_invocation_func
+            "help": help_hint_func
+            "enum": query_enum_items_func
+            "duplicates":
+                "intercept": intercept_invocation_func
+                "help": help_hint_func
+                "": &func_tree_main
+                    "echo": echo_args_func
+                    "goto":
+                        "repo": goto_git_repo_func
+                        "host": goto_host_func
+                        "service": goto_service_func
+                    "list":
+                        "host": list_host_func
+                        "service": list_service_func
+                    "diff":
+                        "service": diff_service_func
+                    "desc":
+                        "tag": desc_git_tag_func
+                        "commit": desc_git_commit_func
+                        "host": desc_host_func
+                        "service": desc_service_func
+                    "config":
+                        "print_with_level": funct_id_print_with_severity_level
+                        "print_with_exit": funct_id_print_with_exit_code
+                        "print_with_io_redirect": funct_id_print_with_io_redirect
+                        "double_execution": funct_id_double_execution
+            "": *func_tree_main
+        "some_command":
+            "intercept": intercept_invocation_func
+            "help": help_hint_func
+            "enum": query_enum_items_func
+            "duplicates":
+                "intercept": intercept_invocation_func
+                "help": help_hint_func
+                "": *func_tree_main
+            "": *func_tree_main
+        "service_relay_demo":
+            "help": help_hint_func
+            "":
+                "goto": goto_service_func
+                "list": list_service_func
+                "diff": diff_service_func
+                "desc": desc_service_func
+
+    func_tree_intercept_invocation_func: &func_tree_intercept_invocation_func
+        "relay_demo":
+            "intercept": intercept_invocation_func
+            "duplicates":
+                "intercept": intercept_invocation_func
+        "some_command":
+            "intercept": intercept_invocation_func
+            "duplicates":
+                "intercept": intercept_invocation_func
+
+    func_tree_help_hint_func: &func_tree_help_hint_func
+        "relay_demo":
+            "help": help_hint_func
+            "duplicates":
+                "help": help_hint_func
+        "some_command":
+            "help": help_hint_func
+            "duplicates":
+                "help": help_hint_func
+        "service_relay_demo":
+            "help": help_hint_func
+
+    func_tree_query_enum_items_func: &func_tree_query_enum_items_func
+        "relay_demo":
+            "enum": query_enum_items_func
+        "some_command":
+            "enum": query_enum_items_func
+
+    func_tree_default: &func_tree_default
+        "relay_demo":
+            "duplicates":
+                "": *func_tree_main
+            "": *func_tree_main
+        "some_command":
+            "duplicates":
+                "": *func_tree_main
+            "": *func_tree_main
+
+    func_tree_service: &func_tree_service
+        "service_relay_demo":
+            "goto": goto_service_func
+            "list": list_service_func
+            "diff": diff_service_func
+            "desc": desc_service_func
+
 plugin_instance_entries:
 
     FirstArgInterpFactory.default:
@@ -71,6 +164,8 @@ plugin_instance_entries:
             -   FuncTreeInterpFactory.help_hint_func
             -   FuncTreeInterpFactory.query_enum_items_func
         plugin_config:
+            # TODO: TODO_18_51_46_14: refactor FS_42_76_93_51 zero_arg_interp into FS_15_79_76_85 line processor:
+            #       `first_arg_vals_to_next_interp_factory_ids` should be selecting line processors.
             first_arg_vals_to_next_interp_factory_ids:
                 # This binding uses existing file system name `relay_demo`:
                 "relay_demo": InterpTreeInterpFactory.default
@@ -115,59 +210,35 @@ plugin_instance_entries:
         plugin_class_name: FuncTreeInterpFactory
         plugin_config:
             jump_tree: *jump_tree
-            func_selector_tree: intercept_invocation_func
+            func_selector_tree: *func_tree_intercept_invocation_func
 
     FuncTreeInterpFactory.help_hint_func:
         plugin_module_name: argrelay.plugin_interp.FuncTreeInterpFactory
         plugin_class_name: FuncTreeInterpFactory
         plugin_config:
             jump_tree: *jump_tree
-            func_selector_tree: help_hint_func
+            func_selector_tree: *func_tree_help_hint_func
 
     FuncTreeInterpFactory.query_enum_items_func:
         plugin_module_name: argrelay.plugin_interp.FuncTreeInterpFactory
         plugin_class_name: FuncTreeInterpFactory
         plugin_config:
             jump_tree: *jump_tree
-            func_selector_tree: query_enum_items_func
+            func_selector_tree: *func_tree_query_enum_items_func
 
     FuncTreeInterpFactory.default:
         plugin_module_name: argrelay.plugin_interp.FuncTreeInterpFactory
         plugin_class_name: FuncTreeInterpFactory
         plugin_config:
             jump_tree: *jump_tree
-            func_selector_tree:
-                "echo": echo_args_func
-                "goto":
-                    "repo": goto_git_repo_func
-                    "host": goto_host_func
-                    "service": goto_service_func
-                "list":
-                    "host": list_host_func
-                    "service": list_service_func
-                "diff":
-                    "service": diff_service_func
-                "desc":
-                    "tag": desc_git_tag_func
-                    "commit": desc_git_commit_func
-                    "host": desc_host_func
-                    "service": desc_service_func
-                "config":
-                    "print_with_level": funct_id_print_with_severity_level
-                    "print_with_exit": funct_id_print_with_exit_code
-                    "print_with_io_redirect": funct_id_print_with_io_redirect
-                    "double_execution": funct_id_double_execution
+            func_selector_tree: *func_tree_default
 
     FuncTreeInterpFactory.service:
         plugin_module_name: argrelay.plugin_interp.FuncTreeInterpFactory
         plugin_class_name: FuncTreeInterpFactory
         plugin_config:
             jump_tree: *jump_tree
-            func_selector_tree:
-                "goto": goto_service_func
-                "list": list_service_func
-                "diff": diff_service_func
-                "desc": desc_service_func
+            func_selector_tree: *func_tree_service
 
     NoopInterpFactory.default:
         plugin_module_name: argrelay.plugin_interp.NoopInterpFactory
@@ -238,7 +309,7 @@ plugin_instance_entries:
         plugin_module_name: argrelay.custom_integ.ConfigOnlyLoader
         plugin_class_name: ConfigOnlyLoader
         plugin_config:
-            collection_name_to_index_fields_map:
+            collection_name_to_index_props_map:
                 ConfigOnlyClass:
                     -   severity_level
                     -   exit_code

--- a/src/argrelay/schema_config_core_server/EnvelopeCollectionSchema.py
+++ b/src/argrelay/schema_config_core_server/EnvelopeCollectionSchema.py
@@ -11,7 +11,7 @@ from argrelay.runtime_data.ServerConfig import ServerConfig
 from argrelay.schema_config_interp.DataEnvelopeSchema import data_envelope_desc
 from argrelay.schema_response.EnvelopeContainerSchema import data_envelopes_
 
-index_fields_ = "index_fields"
+index_props_ = "index_props"
 
 
 class EnvelopeCollectionSchema(ObjectSchema):
@@ -21,7 +21,7 @@ class EnvelopeCollectionSchema(ObjectSchema):
 
     model_class = EnvelopeCollection
 
-    index_fields = fields.List(
+    index_props = fields.List(
         fields.String(),
         required = False,
         load_default = [],
@@ -39,7 +39,7 @@ envelope_collection_desc = TypeDesc(
     dict_schema = EnvelopeCollectionSchema(),
     ref_name = EnvelopeCollectionSchema.__name__,
     dict_example = {
-        index_fields_: [
+        index_props_: [
             "SomeTypeA",
             "SomeTypeB",
         ],
@@ -54,7 +54,7 @@ envelope_collection_desc = TypeDesc(
 def init_envelop_collections(
     server_config: ServerConfig,
     class_names: Collection[str],
-    get_index_fields: Callable[[str, str], list[str]],
+    get_index_props: Callable[[str, str], list[str]],
 ):
     """
     FS_56_43_05_79: Part of "search diff collection" implementation.
@@ -62,7 +62,7 @@ def init_envelop_collections(
     Init:
     *   mapping from `class_name` to `collection_name`
     *   association of `collection_name` with its data as `EnvelopeCollection` (default = new and empty)
-    *   list of `index_field`-s for each `EnvelopeCollection` via `get_index_fields`
+    *   list of `index_prop`-s for each `EnvelopeCollection` via `get_index_props`
 
     By default, class_name is mapped into collection_name which matches as string that class_name.
     """
@@ -78,12 +78,12 @@ def init_envelop_collections(
         envelope_collection = server_config.static_data.envelope_collections.setdefault(
             collection_name,
             EnvelopeCollection(
-                index_fields = [],
+                index_props = [],
                 data_envelopes = [],
             ),
         )
 
-        index_fields = envelope_collection.index_fields
-        for index_field in get_index_fields(collection_name, class_name):
-            if index_field not in index_fields:
-                index_fields.append(index_field)
+        index_props = envelope_collection.index_props
+        for index_prop in get_index_props(collection_name, class_name):
+            if index_prop not in index_props:
+                index_props.append(index_prop)

--- a/src/argrelay/schema_config_interp/DataEnvelopeSchema.py
+++ b/src/argrelay/schema_config_interp/DataEnvelopeSchema.py
@@ -1,7 +1,7 @@
 from marshmallow import Schema, fields, validates_schema, INCLUDE, post_dump
 
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.misc_helper_common.TypeDesc import TypeDesc
 from argrelay.schema_config_interp.FunctionEnvelopeInstanceDataSchema import function_envelope_instance_data_desc
 

--- a/src/argrelay/schema_config_interp/FuncEnvelopeSchema.py
+++ b/src/argrelay/schema_config_interp/FuncEnvelopeSchema.py
@@ -1,8 +1,8 @@
 from marshmallow import fields, validates_schema, INCLUDE
 
 from argrelay.enum_desc.FuncState import FuncState
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.misc_helper_common.TypeDesc import TypeDesc
 from argrelay.schema_config_interp.DataEnvelopeSchema import (
     DataEnvelopeSchema,

--- a/tests/env_tests/test_relay_client_relay_line_args.py
+++ b/tests/env_tests/test_relay_client_relay_line_args.py
@@ -1,5 +1,5 @@
-from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.custom_integ.ServiceEnvelopeClass import ServiceEnvelopeClass
+from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.enum_desc.CompType import CompType
 from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.plugin_delegator.ErrorDelegator import ErrorDelegator

--- a/tests/offline_tests/composite_tree/test_CompositeTreeWalker.py
+++ b/tests/offline_tests/composite_tree/test_CompositeTreeWalker.py
@@ -385,60 +385,113 @@ class ThisTestClass(LocalTestClass):
         as specified per plugin manually (not via `composite_tree`).
         """
 
+        func_tree_main = {
+            "echo": "echo_args_func",
+            "goto": {
+                "repo": "goto_git_repo_func",
+                "host": "goto_host_func",
+                "service": "goto_service_func",
+            },
+            "list": {
+                "host": "list_host_func",
+                "service": "list_service_func",
+            },
+            "diff": {
+                "service": "diff_service_func",
+            },
+            "desc": {
+                "tag": "desc_git_tag_func",
+                "commit": "desc_git_commit_func",
+                "host": "desc_host_func",
+                "service": "desc_service_func",
+            },
+            "config": {
+                "print_with_level": "funct_id_print_with_severity_level",
+                "print_with_exit": "funct_id_print_with_exit_code",
+                "print_with_io_redirect": "funct_id_print_with_io_redirect",
+                "double_execution": "funct_id_double_execution",
+            },
+        }
+
         test_cases = [
             (
                 line_no(),
-                SpecialFunc.intercept_invocation_func.name,
+                {
+                    "relay_demo": {
+                        "intercept": SpecialFunc.intercept_invocation_func.name,
+                        "duplicates": {
+                            "intercept": SpecialFunc.intercept_invocation_func.name,
+                        },
+                    },
+                    "some_command": {
+                        "intercept": SpecialFunc.intercept_invocation_func.name,
+                        "duplicates": {
+                            "intercept": SpecialFunc.intercept_invocation_func.name,
+                        }
+                    },
+                },
                 f"{FuncTreeInterpFactory.__name__}.intercept_invocation_func",
             ),
             (
                 line_no(),
-                SpecialFunc.help_hint_func.name,
+                {
+                    "relay_demo": {
+                        "help": SpecialFunc.help_hint_func.name,
+                        "duplicates": {
+                            "help": SpecialFunc.help_hint_func.name,
+                        },
+                    },
+                    "some_command": {
+                        "help": SpecialFunc.help_hint_func.name,
+                        "duplicates": {
+                            "help": SpecialFunc.help_hint_func.name,
+                        }
+                    },
+                    "service_relay_demo": {
+                        "help": SpecialFunc.help_hint_func.name,
+                    },
+                },
                 f"{FuncTreeInterpFactory.__name__}.help_hint_func",
             ),
             (
                 line_no(),
-                SpecialFunc.query_enum_items_func.name,
+                {
+                    "relay_demo": {
+                        "enum": SpecialFunc.query_enum_items_func.name,
+                    },
+                    "some_command": {
+                        "enum": SpecialFunc.query_enum_items_func.name,
+                    },
+                },
                 f"{FuncTreeInterpFactory.__name__}.query_enum_items_func",
             ),
             (
                 line_no(),
                 {
-                    "echo": "echo_args_func",
-                    "goto": {
-                        "repo": "goto_git_repo_func",
-                        "host": "goto_host_func",
-                        "service": "goto_service_func",
+                    "relay_demo": {
+                        "duplicates": {
+                            "": func_tree_main,
+                        },
+                        "": func_tree_main,
                     },
-                    "list": {
-                        "host": "list_host_func",
-                        "service": "list_service_func",
+                    "some_command": {
+                        "duplicates": {
+                            "": func_tree_main,
+                        },
+                        "": func_tree_main,
                     },
-                    "diff": {
-                        "service": "diff_service_func",
-                    },
-                    "desc": {
-                        "tag": "desc_git_tag_func",
-                        "commit": "desc_git_commit_func",
-                        "host": "desc_host_func",
-                        "service": "desc_service_func",
-                    },
-                    "config": {
-                        "print_with_level": "funct_id_print_with_severity_level",
-                        "print_with_exit": "funct_id_print_with_exit_code",
-                        "print_with_io_redirect": "funct_id_print_with_io_redirect",
-                        "double_execution": "funct_id_double_execution",
-                    }
                 },
                 f"{FuncTreeInterpFactory.__name__}.default",
             ),
             (
                 line_no(),
                 {
-                    "goto": "goto_service_func",
-                    "list": "list_service_func",
-                    "diff": "diff_service_func",
-                    "desc": "desc_service_func",
+                    "service_relay_demo": {
+                        "goto": "goto_service_func",
+                        "list": "list_service_func",
+                        "diff": "diff_service_func",
+                        "desc": "desc_service_func",
+                    },
                 },
                 f"{FuncTreeInterpFactory.__name__}.service",
             ),
@@ -457,10 +510,10 @@ class ThisTestClass(LocalTestClass):
                 # No need to normalize extracted `actual_dict`
                 # because `composite_tree` is constructed to maintain `dict` structure
                 # without `surrogate_node_id_`-s and `surrogate_tree_leaf_`-s.
-                actual_dict = extract_func_tree(
+                actual_dict = normalize_tree(extract_func_tree(
                     self.load_composite_tree(),
                     plugin_instance_id,
-                )
+                ))
 
                 self.assertEqual(
                     normalized_expected_dict,

--- a/tests/offline_tests/mongo_query/MongoClientTestClass.py
+++ b/tests/offline_tests/mongo_query/MongoClientTestClass.py
@@ -77,9 +77,9 @@ class MongoClientTestClass(BaseTestClass):
         col_proxy.drop_indexes()
 
     @staticmethod
-    def index_fields(
+    def index_props(
         col_proxy: Collection,
-        index_fields: list[str],
+        index_props: list[str],
     ):
-        for index_field in index_fields:
-            col_proxy.create_index(index_field)
+        for index_prop in index_props:
+            col_proxy.create_index(index_prop)

--- a/tests/offline_tests/mongo_query/test_MongoClient_distinct_values_search.py
+++ b/tests/offline_tests/mongo_query/test_MongoClient_distinct_values_search.py
@@ -12,7 +12,7 @@ class ThisTestClass(MongoClientTestClass):
         https://stackoverflow.com/a/63595331/441652
         """
 
-        index_fields = [
+        index_props = [
             ServicePropName.access_type.name,
             ServicePropName.live_status.name,
             ServicePropName.code_maturity.name,
@@ -58,7 +58,7 @@ class ThisTestClass(MongoClientTestClass):
             envelope_004,
         ])
 
-        self.index_fields(self.col_proxy, index_fields)
+        self.index_props(self.col_proxy, index_props)
 
         print("query 1:")
         for result_item in self.col_proxy.aggregate([

--- a/tests/offline_tests/mongo_query/test_MongoClient_envelope_search.py
+++ b/tests/offline_tests/mongo_query/test_MongoClient_envelope_search.py
@@ -14,7 +14,7 @@ class ThisTestClass(MongoClientTestClass):
         """
 
         # Fields which will be indexed:
-        index_fields = [
+        index_props = [
             ServicePropName.access_type.name,
             ServicePropName.live_status.name,
             ServicePropName.code_maturity.name,
@@ -59,7 +59,7 @@ class ThisTestClass(MongoClientTestClass):
             envelope_004,
         ])
 
-        self.index_fields(self.col_proxy, index_fields)
+        self.index_props(self.col_proxy, index_props)
 
         print("query 1:")
         for data_envelope in self.col_proxy.find(

--- a/tests/offline_tests/mongo_query/test_MongoClient_envelope_search_with_array_fields.py
+++ b/tests/offline_tests/mongo_query/test_MongoClient_envelope_search_with_array_fields.py
@@ -19,7 +19,7 @@ class ThisTestClass(MongoClientTestClass):
         """
 
         # Fields which will be indexed:
-        index_fields = [
+        index_props = [
             ServicePropName.access_type.name,
             ServicePropName.live_status.name,
             ServicePropName.code_maturity.name,
@@ -110,7 +110,7 @@ class ThisTestClass(MongoClientTestClass):
             envelope_007,
         ])
 
-        self.index_fields(self.col_proxy, index_fields)
+        self.index_props(self.col_proxy, index_props)
 
         self.find_and_assert(
             self.col_proxy,

--- a/tests/offline_tests/mongo_query/test_MongoClient_index_limits.py
+++ b/tests/offline_tests/mongo_query/test_MongoClient_index_limits.py
@@ -111,15 +111,15 @@ class ThisTestClass(MongoClientTestClass):
         """
 
         # Fields which will be indexed:
-        index_fields = self.generate_field_names()
+        index_props = self.generate_field_names()
 
-        array_field_names = self.decide_array_field_names(index_fields)
+        array_field_names = self.decide_array_field_names(index_props)
 
-        data_envelopes = self.generate_data_envelopes(index_fields, array_field_names)
+        data_envelopes = self.generate_data_envelopes(index_props, array_field_names)
 
         self.col_proxy.insert_many(data_envelopes)
 
-        self.index_fields(self.col_proxy, index_fields)
+        self.index_props(self.col_proxy, index_props)
 
         # noinspection PyUnreachableCode
         if False:

--- a/tests/offline_tests/plugin_delegator/test_HelpDelegator.py
+++ b/tests/offline_tests/plugin_delegator/test_HelpDelegator.py
@@ -4,6 +4,7 @@ from typing import Union
 
 from argrelay.client_command_local.AbstractLocalClientCommand import AbstractLocalClientCommand
 from argrelay.enum_desc.CompType import CompType
+from argrelay.enum_desc.SpecialChar import SpecialChar
 from argrelay.enum_desc.TermColor import TermColor
 from argrelay.plugin_delegator.HelpDelegator import HelpDelegator
 from argrelay.relay_client import __main__
@@ -12,7 +13,7 @@ from argrelay.schema_request.CallContextSchema import call_context_desc
 from argrelay.schema_response.InvocationInput import InvocationInput
 from argrelay.test_infra import line_no_from_ctor, line_no, parse_line_and_cpos
 from argrelay.test_infra.CustomTestCase import ShellInputTestCase
-from argrelay.test_infra.CustomVerifier import RelayLineArgsVerifier, ProposeArgValuesVerifier, ServerActionVerifier
+from argrelay.test_infra.CustomVerifier import RelayLineArgsVerifier, ServerActionVerifier, ProposeArgValuesVerifier
 from argrelay.test_infra.EnvMockBuilder import LocalClientEnvMockBuilder, EmptyEnvMockBuilder, EnvMockBuilder
 from argrelay.test_infra.LocalTestClass import LocalTestClass
 
@@ -134,17 +135,17 @@ class ThisTestClass(LocalTestClass):
                 line_no(), "relay_demo help goto |",
                 "FS_71_87_33_52 ensure ordered list of args in help output "
                 "(command name first, then function spec args)",
-                f"""relay_demo goto host {TermColor.known_envelope_id.value}# {TermColor.reset_style.value}{TermColor.known_envelope_id.value}goto_host_func {TermColor.reset_style.value}{TermColor.help_hint.value}# {TermColor.reset_style.value}{TermColor.help_hint.value}Go (log in) to remote host {TermColor.reset_style.value}
-relay_demo goto repo {TermColor.known_envelope_id.value}# {TermColor.reset_style.value}{TermColor.known_envelope_id.value}goto_git_repo_func {TermColor.reset_style.value}{TermColor.help_hint.value}# {TermColor.reset_style.value}{TermColor.help_hint.value}Goto Git repository (`cd` to its path) {TermColor.reset_style.value}
-relay_demo goto service {TermColor.known_envelope_id.value}# {TermColor.reset_style.value}{TermColor.known_envelope_id.value}goto_service_func {TermColor.reset_style.value}{TermColor.help_hint.value}# {TermColor.reset_style.value}{TermColor.help_hint.value}Go (log in) to remote host and dir path with specified service {TermColor.reset_style.value}
+                f"""relay_demo goto host ~ {TermColor.known_envelope_id.value}# {TermColor.reset_style.value}{TermColor.known_envelope_id.value}goto_host_func {TermColor.reset_style.value}{TermColor.help_hint.value}# {TermColor.reset_style.value}{TermColor.help_hint.value}Go (log in) to remote host {TermColor.reset_style.value}
+relay_demo goto repo {SpecialChar.NoPropValue.value} {TermColor.known_envelope_id.value}# {TermColor.reset_style.value}{TermColor.known_envelope_id.value}goto_git_repo_func {TermColor.reset_style.value}{TermColor.help_hint.value}# {TermColor.reset_style.value}{TermColor.help_hint.value}Goto Git repository (`cd` to its path) {TermColor.reset_style.value}
+relay_demo goto service {SpecialChar.NoPropValue.value} {TermColor.known_envelope_id.value}# {TermColor.reset_style.value}{TermColor.known_envelope_id.value}goto_service_func {TermColor.reset_style.value}{TermColor.help_hint.value}# {TermColor.reset_style.value}{TermColor.help_hint.value}Go (log in) to remote host and dir path with specified service {TermColor.reset_style.value}
 """,
             ),
             (
                 line_no(), "some_command help list |",
                 "FS_71_87_33_52 ensure ordered list of args in help output "
                 "(command name first, then function spec args)",
-                f"""some_command list host {TermColor.known_envelope_id.value}# {TermColor.reset_style.value}{TermColor.known_envelope_id.value}list_host_func {TermColor.reset_style.value}{TermColor.help_hint.value}# {TermColor.reset_style.value}{TermColor.help_hint.value}List remote hosts matching search query {TermColor.reset_style.value}
-some_command list service {TermColor.known_envelope_id.value}# {TermColor.reset_style.value}{TermColor.known_envelope_id.value}list_service_func {TermColor.reset_style.value}{TermColor.help_hint.value}# {TermColor.reset_style.value}{TermColor.help_hint.value}List service instances matching search query {TermColor.reset_style.value}
+                f"""some_command list host {SpecialChar.NoPropValue.value} {TermColor.known_envelope_id.value}# {TermColor.reset_style.value}{TermColor.known_envelope_id.value}list_host_func {TermColor.reset_style.value}{TermColor.help_hint.value}# {TermColor.reset_style.value}{TermColor.help_hint.value}List remote hosts matching search query {TermColor.reset_style.value}
+some_command list service {SpecialChar.NoPropValue.value} {TermColor.known_envelope_id.value}# {TermColor.reset_style.value}{TermColor.known_envelope_id.value}list_service_func {TermColor.reset_style.value}{TermColor.help_hint.value}# {TermColor.reset_style.value}{TermColor.help_hint.value}List service instances matching search query {TermColor.reset_style.value}
 """,
             ),
         ]

--- a/tests/offline_tests/plugin_delegator/test_InterceptorDelegator.py
+++ b/tests/offline_tests/plugin_delegator/test_InterceptorDelegator.py
@@ -1,8 +1,8 @@
 from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.CompType import CompType
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.plugin_delegator.InterceptDelegator import output_format_class_name, OutputFormat, output_format_prop_name
 from argrelay.plugin_interp.FuncTreeInterpFactory import func_envelope_path_step_prop_name
 from argrelay.runtime_data.AssignedValue import AssignedValue

--- a/tests/offline_tests/plugin_interp/test_FuncArgsInterpFactory.py
+++ b/tests/offline_tests/plugin_interp/test_FuncArgsInterpFactory.py
@@ -4,8 +4,8 @@ import unittest
 
 from argrelay.enum_desc.CompType import CompType
 from argrelay.enum_desc.FuncState import FuncState
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.plugin_delegator.NoopDelegator import NoopDelegator
 from argrelay.plugin_interp.FuncTreeInterp import func_search_control_
 from argrelay.plugin_interp.FuncTreeInterpFactory import FuncTreeInterpFactory
@@ -14,7 +14,7 @@ from argrelay.plugin_interp.FuncTreeInterpFactoryConfigSchema import (
 )
 from argrelay.relay_client import __main__
 from argrelay.schema_config_core_client.ClientConfigSchema import client_config_desc
-from argrelay.schema_config_core_server.EnvelopeCollectionSchema import index_fields_, data_envelopes_
+from argrelay.schema_config_core_server.EnvelopeCollectionSchema import index_props_, data_envelopes_
 from argrelay.schema_config_core_server.ServerConfigSchema import (
     static_data_,
     server_config_desc,
@@ -60,7 +60,7 @@ class ThisTestClass(BaseTestClass):
         envelope_collection = server_config_dict[static_data_][envelope_collections_].setdefault(
             ReservedEnvelopeClass.ClassFunction.name,
             {
-                index_fields_: [],
+                index_props_: [],
                 data_envelopes_: [],
             },
         )

--- a/tests/offline_tests/plugin_interp/test_FuncTreeInterp.py
+++ b/tests/offline_tests/plugin_interp/test_FuncTreeInterp.py
@@ -1,13 +1,12 @@
-from argrelay.custom_integ.GitRepoPropName import GitRepoPropName
 from argrelay.custom_integ.GitRepoEnvelopeClass import GitRepoEnvelopeClass
+from argrelay.custom_integ.GitRepoPropName import GitRepoPropName
 from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.CompType import CompType
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.plugin_interp.FuncTreeInterpFactory import func_envelope_path_step_prop_name
 from argrelay.runtime_data.AssignedValue import AssignedValue
 from argrelay.test_infra import line_no
-
 from argrelay.test_infra.LocalTestClass import LocalTestClass
 
 

--- a/tests/offline_tests/relay_client/test_relay_client.py
+++ b/tests/offline_tests/relay_client/test_relay_client.py
@@ -105,8 +105,8 @@ class ThisTestClass(BaseTestClass):
                 f"""
 {TermColor.consumed_token.value}some_command{TermColor.reset_style.value} {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}unrecognized_{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}token{TermColor.reset_style.value} {TermColor.consumed_token.value}goto{TermColor.reset_style.value} {TermColor.consumed_token.value}host{TermColor.reset_style.value} {TermColor.consumed_token.value}prod{TermColor.reset_style.value} {TermColor.excluded_token.value}{SpecialChar.ArgBucketDelimiter.value}{TermColor.reset_style.value} 
 {ReservedEnvelopeClass.ClassFunction.name}: {TermColor.found_count_1.value}1{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.no_option_to_suggest.value}TypeA: [none]{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.no_option_to_suggest.value}TypeB: [none]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.no_option_to_suggest.value}TypeA: {SpecialChar.NoPropValue.value}{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.no_option_to_suggest.value}TypeB: {SpecialChar.NoPropValue.value}{TermColor.reset_style.value}
 """,
 
                 ic(env_mock_builder.actual_stdout.getvalue()),

--- a/tests/offline_tests/relay_demo/test_GitRepoLoader_offline.py
+++ b/tests/offline_tests/relay_demo/test_GitRepoLoader_offline.py
@@ -1,5 +1,4 @@
 from argrelay.client_command_local.AbstractLocalClientCommand import AbstractLocalClientCommand
-from argrelay.custom_integ.GitRepoPropName import GitRepoPropName
 from argrelay.custom_integ.GitRepoEntryConfigSchema import (
     repo_rel_path_,
     envelope_properties_,
@@ -13,6 +12,7 @@ from argrelay.custom_integ.GitRepoLoaderConfigSchema import (
     repo_entries_,
     load_git_tags_default_,
 )
+from argrelay.custom_integ.GitRepoPropName import GitRepoPropName
 from argrelay.enum_desc.CompType import CompType
 from argrelay.misc_helper_common import get_argrelay_dir
 from argrelay.relay_client import __main__
@@ -318,7 +318,7 @@ class ThisTestClass(LocalTestClass):
                         envelope_collection = static_data.envelope_collections.setdefault(
                             class_name,
                             EnvelopeCollection(
-                                index_fields = [],
+                                index_props = [],
                                 data_envelopes = [],
                             ),
                         )
@@ -327,12 +327,12 @@ class ThisTestClass(LocalTestClass):
 
                             is_empty = False
                             if prop_name_existence:
-                                assert prop_name in static_data.envelope_collections[class_name].index_fields
+                                assert prop_name in static_data.envelope_collections[class_name].index_props
                             else:
                                 # Do not assert it as loader over-specifies index fields at the moment:
                                 # noinspection PyUnreachableCode
                                 if False:
-                                    assert prop_name not in static_data.envelope_collections[class_name].index_fields
+                                    assert prop_name not in static_data.envelope_collections[class_name].index_props
 
                             # Find list of all values in `data_envelope`-s per `prop_name`:
                             prop_values = []

--- a/tests/offline_tests/relay_demo/test_relay_demo.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 from argrelay.client_command_local.AbstractLocalClientCommand import AbstractLocalClientCommand
-from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.custom_integ.ServiceDelegator import ServiceDelegator
 from argrelay.custom_integ.ServiceEnvelopeClass import ServiceEnvelopeClass
+from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.custom_integ.value_constants import goto_service_func_, goto_host_func_
 from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.CompType import CompType
 from argrelay.enum_desc.FuncState import FuncState
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
+from argrelay.enum_desc.SpecialChar import SpecialChar
 from argrelay.enum_desc.TermColor import TermColor
 from argrelay.handler_response.DescribeLineArgsClientResponseHandler import (
     indent_size,
@@ -540,7 +541,8 @@ class ThisTestClass(LocalTestClass):
 {ReservedEnvelopeClass.ClassFunction.name}: {TermColor.found_count_n.value}35{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: some_command {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.remaining_value.value}*{func_envelope_path_step_prop_name(1)}: ?{TermColor.reset_style.value} config desc diff duplicates echo enum goto help intercept list 
-{" " * indent_size}{TermColor.remaining_value.value}{func_envelope_path_step_prop_name(2)}: ?{TermColor.reset_style.value} commit config desc diff double_execution echo goto help host intercept list print_with_exit print_with_io_redirect print_with_level repo service tag 
+{" " * indent_size}{TermColor.remaining_value.value}{func_envelope_path_step_prop_name(2)}: ?{TermColor.reset_style.value} commit config desc diff double_execution echo goto help host intercept list print_with_exit print_with_io_redirect print_with_level repo service tag {SpecialChar.NoPropValue.value} 
+{" " * indent_size}{TermColor.remaining_value.value}{func_envelope_path_step_prop_name(3)}: ?{TermColor.reset_style.value} commit double_execution host print_with_exit print_with_io_redirect print_with_level repo service tag {SpecialChar.NoPropValue.value} 
 {" " * indent_size}{TermColor.remaining_value.value}{ReservedPropName.func_state.name}: ?{TermColor.reset_style.value} alpha beta demo gamma 
 {" " * indent_size}{TermColor.remaining_value.value}{ReservedPropName.func_id.name}: ?{TermColor.reset_style.value} desc_git_commit_func desc_git_tag_func desc_host_func desc_service_func diff_service_func echo_args_func funct_id_double_execution funct_id_print_with_exit_code funct_id_print_with_io_redirect funct_id_print_with_severity_level goto_git_repo_func goto_host_func goto_service_func help_hint_func intercept_invocation_func list_host_func list_service_func query_enum_items_func 
 """,
@@ -555,6 +557,7 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: some_command {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(2)}: service {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(3)}: {SpecialChar.NoPropValue.value} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedPropName.func_state.name}: {FuncState.demo.name} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedPropName.func_id.name}: {goto_service_func_} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassService.name}: {TermColor.found_count_n.value}2{TermColor.reset_style.value}
@@ -566,23 +569,24 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.remaining_value.value}service_name: ?{TermColor.reset_style.value} {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}s_{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}a{TermColor.reset_style.value} {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}s_{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}b{TermColor.reset_style.value} 
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}run_mode: active {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}host_name: asdf-du {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: [none]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: {SpecialChar.NoPropValue.value}{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}data_center: dc.22 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}ip_address: ip.172.16.2.1 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassAccessType.name}: {TermColor.found_count_0.value}0{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.no_option_to_suggest.value}access_type: [none]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.no_option_to_suggest.value}access_type: {SpecialChar.NoPropValue.value}{TermColor.reset_style.value}
 """,
             ),
             (
                 line_no(), "some_command goto host upstream |", CompType.DescribeArgs,
                 "Regular description with some props specified (flow_stage) and many still to be narrowed down.",
-                # TODO: show differently `[none]` values: those in envelopes which haven't been searched yet, and those which were searched, but no values found in data.
+                # TODO: show differently `{SpecialChar.NoPropValue.value}` values: those in envelopes which haven't been searched yet, and those which were searched, but no values found in data.
                 f"""
 {TermColor.consumed_token.value}some_command{TermColor.reset_style.value} {TermColor.consumed_token.value}goto{TermColor.reset_style.value} {TermColor.consumed_token.value}host{TermColor.reset_style.value} {TermColor.consumed_token.value}upstream{TermColor.reset_style.value} 
 {ReservedEnvelopeClass.ClassFunction.name}: {TermColor.found_count_1.value}1{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: some_command {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(2)}: host {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(3)}: {SpecialChar.NoPropValue.value} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedPropName.func_state.name}: {FuncState.demo.name} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedPropName.func_id.name}: {goto_host_func_} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassHost.name}: {TermColor.found_count_n.value}10{TermColor.reset_style.value}
@@ -591,10 +595,10 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.remaining_value.value}geo_region: ?{TermColor.reset_style.value} amer apac emea 
 {" " * indent_size}{TermColor.remaining_value.value}cluster_name: ?{TermColor.reset_style.value} dev-amer-upstream dev-apac-upstream dev-emea-upstream prod-apac-upstream qa-amer-upstream qa-apac-upstream 
 {" " * indent_size}{TermColor.remaining_value.value}host_name: ?{TermColor.reset_style.value} asdf-du hjkl-qu poiu-qu qwer-du qwer-pd-1 qwer-pd-2 qwer-pd-3 rt-qu rtyu-qu zxcv-du 
-{" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: [none]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: {SpecialChar.NoPropValue.value}{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.remaining_value.value}ip_address: ?{TermColor.reset_style.value} ip.172.16.2.1 ip.172.16.4.2 ip.172.16.7.2 ip.192.168.1.1 ip.192.168.3.1 ip.192.168.4.1 ip.192.168.6.1 ip.192.168.6.2 ip.192.168.7.1 ip.192.168.7.2 
 {ServiceEnvelopeClass.ClassAccessType.name}: {TermColor.found_count_0.value}0{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.no_option_to_suggest.value}access_type: [none]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.no_option_to_suggest.value}access_type: {SpecialChar.NoPropValue.value}{TermColor.reset_style.value}
 """,
             ),
             (
@@ -606,6 +610,7 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: some_command {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(2)}: service {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(3)}: {SpecialChar.NoPropValue.value} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedPropName.func_state.name}: {FuncState.demo.name} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedPropName.func_id.name}: {goto_service_func_} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassService.name}: {TermColor.found_count_n.value}2{TermColor.reset_style.value}
@@ -617,11 +622,11 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.remaining_value.value}service_name: ?{TermColor.reset_style.value} s_a s_b 
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}run_mode: active {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}host_name: {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}qwer-p{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}d-1{TermColor.reset_style.value} {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: [none]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: {SpecialChar.NoPropValue.value}{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}data_center: dc.07 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}ip_address: ip.192.168.7.1 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassAccessType.name}: {TermColor.found_count_0.value}0{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.no_option_to_suggest.value}access_type: [none]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.no_option_to_suggest.value}access_type: {SpecialChar.NoPropValue.value}{TermColor.reset_style.value}
 """,
             ),
         ]
@@ -1068,6 +1073,7 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: relay_demo {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(2)}: service {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(3)}: ~ {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedPropName.func_state.name}: {FuncState.demo.name} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedPropName.func_id.name}: {goto_service_func_} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassService.name}: {TermColor.found_count_1.value}1{TermColor.reset_style.value}
@@ -1079,7 +1085,7 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}service_name: xx {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}run_mode: active {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}host_name: poiu-dd {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: [none]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: {SpecialChar.NoPropValue.value}{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}data_center: dc.01 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}ip_address: ip.192.168.1.3 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassAccessType.name}: {TermColor.found_count_1.value}1{TermColor.reset_style.value}
@@ -1095,6 +1101,7 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}r{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}elay_demo{TermColor.reset_style.value} {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(2)}: service {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(3)}: ~ {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedPropName.func_state.name}: {FuncState.demo.name} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedPropName.func_id.name}: {goto_service_func_} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassService.name}: {TermColor.found_count_1.value}1{TermColor.reset_style.value}
@@ -1106,7 +1113,7 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}service_name: xx {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}run_mode: active {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}host_name: poiu-dd {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: [none]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: {SpecialChar.NoPropValue.value}{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}data_center: dc.01 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}ip_address: ip.192.168.1.3 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassAccessType.name}: {TermColor.found_count_1.value}1{TermColor.reset_style.value}
@@ -1122,6 +1129,7 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: some_command {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(2)}: service {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(3)}: ~ {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedPropName.func_state.name}: {FuncState.demo.name} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedPropName.func_id.name}: {goto_service_func_} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {ServiceEnvelopeClass.ClassService.name}: {TermColor.found_count_n.value}3{TermColor.reset_style.value}
@@ -1133,11 +1141,11 @@ class ThisTestClass(LocalTestClass):
 {" " * indent_size}{TermColor.remaining_value.value}*service_name: ?{TermColor.reset_style.value} tt1 tt2 xx 
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}run_mode: active {TermColor.other_assigned_arg_value.value}[{ArgSource.DefaultValue.name}]{TermColor.reset_style.value} {TermColor.caption_hidden_by_default.value}overrides:{TermColor.reset_style.value} {TermColor.value_hidden_by_default.value}active{TermColor.reset_style.value} {TermColor.value_hidden_by_default.value}passive{TermColor.reset_style.value} 
 {" " * indent_size}{TermColor.remaining_value.value}host_name: ?{TermColor.reset_style.value} wert-pd-1 wert-pd-2 
-{" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: [none]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.no_option_to_suggest.value}live_status: {SpecialChar.NoPropValue.value}{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}data_center: dc.07 {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.remaining_value.value}ip_address: ?{TermColor.reset_style.value} ip.192.168.7.3 ip.192.168.7.4 
 {ServiceEnvelopeClass.ClassAccessType.name}: {TermColor.found_count_0.value}0{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.no_option_to_suggest.value}access_type: [none]{TermColor.reset_style.value}
+{" " * indent_size}{TermColor.no_option_to_suggest.value}access_type: {SpecialChar.NoPropValue.value}{TermColor.reset_style.value}
 """,
             ),
         ]

--- a/tests/offline_tests/relay_demo/test_relay_demo_TD_76_09_29_31_overlapped.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_TD_76_09_29_31_overlapped.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.custom_integ.ServiceEnvelopeClass import ServiceEnvelopeClass
+from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.CompType import CompType
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.plugin_interp.FuncTreeInterpFactory import func_envelope_path_step_prop_name
 from argrelay.runtime_data.AssignedValue import AssignedValue
 from argrelay.test_infra import line_no
@@ -82,7 +82,10 @@ class ThisTestClass(LocalTestClass):
                         ServicePropName.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
                         ServicePropName.geo_region.name: AssignedValue("amer", ArgSource.ExplicitPosArg),
                         ServicePropName.flow_stage.name: AssignedValue("downstream", ArgSource.ExplicitPosArg),
-                        ServicePropName.cluster_name.name: AssignedValue("dev-amer-downstream", ArgSource.ImplicitValue),
+                        ServicePropName.cluster_name.name: AssignedValue(
+                            "dev-amer-downstream",
+                            ArgSource.ImplicitValue,
+                        ),
                         ServicePropName.host_name.name: None,
                     },
                     2: {
@@ -108,7 +111,10 @@ class ThisTestClass(LocalTestClass):
                         ServicePropName.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
                         ServicePropName.geo_region.name: AssignedValue("amer", ArgSource.ExplicitPosArg),
                         ServicePropName.flow_stage.name: AssignedValue("downstream", ArgSource.ExplicitPosArg),
-                        ServicePropName.cluster_name.name: AssignedValue("dev-amer-downstream", ArgSource.ImplicitValue),
+                        ServicePropName.cluster_name.name: AssignedValue(
+                            "dev-amer-downstream",
+                            ArgSource.ImplicitValue,
+                        ),
                         ServicePropName.host_name.name: None,
                     },
                     2: {
@@ -134,7 +140,10 @@ class ThisTestClass(LocalTestClass):
                         ServicePropName.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
                         ServicePropName.geo_region.name: AssignedValue("amer", ArgSource.ExplicitPosArg),
                         ServicePropName.flow_stage.name: AssignedValue("downstream", ArgSource.ExplicitPosArg),
-                        ServicePropName.cluster_name.name: AssignedValue("dev-amer-downstream", ArgSource.ImplicitValue),
+                        ServicePropName.cluster_name.name: AssignedValue(
+                            "dev-amer-downstream",
+                            ArgSource.ImplicitValue,
+                        ),
                         ServicePropName.host_name.name: None,
                     },
                     2: {
@@ -160,7 +169,10 @@ class ThisTestClass(LocalTestClass):
                         ServicePropName.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
                         ServicePropName.geo_region.name: AssignedValue("amer", ArgSource.ExplicitPosArg),
                         ServicePropName.flow_stage.name: AssignedValue("downstream", ArgSource.ExplicitPosArg),
-                        ServicePropName.cluster_name.name: AssignedValue("dev-amer-downstream", ArgSource.ImplicitValue),
+                        ServicePropName.cluster_name.name: AssignedValue(
+                            "dev-amer-downstream",
+                            ArgSource.ImplicitValue,
+                        ),
                         ServicePropName.host_name.name: AssignedValue("amer", ArgSource.ExplicitPosArg),
                     },
                     2: {

--- a/tests/offline_tests/relay_demo/test_relay_demo_TD_99_99_88_75_mutually_exclusive.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_TD_99_99_88_75_mutually_exclusive.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.custom_integ.ServiceEnvelopeClass import ServiceEnvelopeClass
+from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.CompType import CompType
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.plugin_interp.FuncTreeInterpFactory import func_envelope_path_step_prop_name
 from argrelay.runtime_data.AssignedValue import AssignedValue
 from argrelay.test_infra import line_no
@@ -105,7 +105,10 @@ class ThisTestClass(LocalTestClass):
                         ServicePropName.code_maturity.name: AssignedValue("dev", ArgSource.ImplicitValue),
                         ServicePropName.geo_region.name: AssignedValue("emea", ArgSource.ExplicitPosArg),
                         ServicePropName.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
-                        ServicePropName.cluster_name.name: AssignedValue("dev-emea-downstream", ArgSource.ImplicitValue),
+                        ServicePropName.cluster_name.name: AssignedValue(
+                            "dev-emea-downstream",
+                            ArgSource.ImplicitValue,
+                        ),
                     },
                     2: {
                         # ServiceEnvelopeClass.ClassAccessType.name
@@ -129,7 +132,10 @@ class ThisTestClass(LocalTestClass):
                         ServicePropName.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
                         ServicePropName.geo_region.name: AssignedValue("emea", ArgSource.ImplicitValue),
                         ServicePropName.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
-                        ServicePropName.cluster_name.name: AssignedValue("dev-emea-downstream", ArgSource.ImplicitValue),
+                        ServicePropName.cluster_name.name: AssignedValue(
+                            "dev-emea-downstream",
+                            ArgSource.ImplicitValue,
+                        ),
                     },
                     2: {
                         # ServiceEnvelopeClass.ClassAccessType.name
@@ -153,7 +159,10 @@ class ThisTestClass(LocalTestClass):
                         ServicePropName.code_maturity.name: AssignedValue("dev", ArgSource.ImplicitValue),
                         ServicePropName.geo_region.name: AssignedValue("emea", ArgSource.ExplicitPosArg),
                         ServicePropName.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
-                        ServicePropName.cluster_name.name: AssignedValue("dev-emea-downstream", ArgSource.ImplicitValue),
+                        ServicePropName.cluster_name.name: AssignedValue(
+                            "dev-emea-downstream",
+                            ArgSource.ImplicitValue,
+                        ),
                     },
                     2: {
                         # ServiceEnvelopeClass.ClassAccessType.name
@@ -237,7 +246,10 @@ class ThisTestClass(LocalTestClass):
                         ServicePropName.code_maturity.name: AssignedValue("dev", ArgSource.ExplicitPosArg),
                         ServicePropName.geo_region.name: AssignedValue("emea", ArgSource.ImplicitValue),
                         ServicePropName.flow_stage.name: AssignedValue("downstream", ArgSource.ImplicitValue),
-                        ServicePropName.cluster_name.name: AssignedValue("dev-emea-downstream", ArgSource.ImplicitValue),
+                        ServicePropName.cluster_name.name: AssignedValue(
+                            "dev-emea-downstream",
+                            ArgSource.ImplicitValue,
+                        ),
                     },
                     2: {
                         # ServiceEnvelopeClass.ClassAccessType.name

--- a/tests/offline_tests/test_infra/test_TD_63_37_05_36_default.py
+++ b/tests/offline_tests/test_infra/test_TD_63_37_05_36_default.py
@@ -3,8 +3,8 @@ from io import StringIO
 
 import pandas as pd
 
-from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.custom_integ.ServiceEnvelopeClass import ServiceEnvelopeClass
+from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.relay_server.LocalServer import LocalServer
 from argrelay.relay_server.QueryEngine import scalar_to_list_values

--- a/tests/online_tests/end_to_end/test_run_argrelay_client_server.py
+++ b/tests/online_tests/end_to_end/test_run_argrelay_client_server.py
@@ -1,7 +1,8 @@
 from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.CompType import CompType
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
+from argrelay.enum_desc.SpecialChar import SpecialChar
 from argrelay.enum_desc.TermColor import TermColor
 from argrelay.handler_response.DescribeLineArgsClientResponseHandler import indent_size
 from argrelay.plugin_interp.FuncTreeInterpFactory import func_envelope_path_step_prop_name
@@ -29,6 +30,7 @@ class ThisTestClass(End2EndTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: relay_demo {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.remaining_value.value}*{func_envelope_path_step_prop_name(2)}: ?{TermColor.reset_style.value} {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}h{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}ost{TermColor.reset_style.value} repo service 
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(3)}: {SpecialChar.NoPropValue.value} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.remaining_value.value}{ReservedPropName.func_state.name}: ?{TermColor.reset_style.value} beta demo 
 {" " * indent_size}{TermColor.remaining_value.value}{ReservedPropName.func_id.name}: ?{TermColor.reset_style.value} goto_git_repo_func goto_host_func goto_service_func 
 """,
@@ -42,6 +44,7 @@ class ThisTestClass(End2EndTestClass):
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: relay_demo {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.explicit_pos_arg_value.value}{func_envelope_path_step_prop_name(1)}: goto {TermColor.explicit_pos_arg_value.value}[{ArgSource.ExplicitPosArg.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.remaining_value.value}*{func_envelope_path_step_prop_name(2)}: ?{TermColor.reset_style.value} host repo {TermColor.prefix_highlight.value}{TermColor.tangent_token_l_part.value}s{TermColor.reset_style.value}{TermColor.tangent_token_r_part.value}ervice{TermColor.reset_style.value} 
+{" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(3)}: {SpecialChar.NoPropValue.value} {TermColor.other_assigned_arg_value.value}[{ArgSource.ImplicitValue.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.remaining_value.value}{ReservedPropName.func_state.name}: ?{TermColor.reset_style.value} beta demo 
 {" " * indent_size}{TermColor.remaining_value.value}{ReservedPropName.func_id.name}: ?{TermColor.reset_style.value} goto_git_repo_func goto_host_func goto_service_func 
 """,

--- a/tests/online_tests/relay_demo/test_GitRepoLoader_online.py
+++ b/tests/online_tests/relay_demo/test_GitRepoLoader_online.py
@@ -3,7 +3,6 @@ import subprocess
 import tempfile
 
 from argrelay.client_command_local.AbstractLocalClientCommand import AbstractLocalClientCommand
-from argrelay.custom_integ.GitRepoPropName import GitRepoPropName
 from argrelay.custom_integ.GitRepoEntryConfigSchema import (
     repo_rel_path_,
     is_repo_enabled_,
@@ -15,6 +14,7 @@ from argrelay.custom_integ.GitRepoLoaderConfigSchema import (
     load_git_commits_default_,
     repo_entries_,
 )
+from argrelay.custom_integ.GitRepoPropName import GitRepoPropName
 from argrelay.enum_desc.CompType import CompType
 from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.misc_helper_common import eprint, get_argrelay_dir

--- a/tests/online_tests/remote_client/test_remote_relay_demo.py
+++ b/tests/online_tests/remote_client/test_remote_relay_demo.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.custom_integ.ServiceDelegator import ServiceDelegator
 from argrelay.custom_integ.ServiceEnvelopeClass import ServiceEnvelopeClass
+from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.CompType import CompType
-from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.plugin_delegator.ErrorDelegator import ErrorDelegator
 from argrelay.plugin_interp.FuncTreeInterpFactory import func_envelope_path_step_prop_name
 from argrelay.runtime_data.AssignedValue import AssignedValue

--- a/tests/slow_tests/relay_demo/test_relay_demo_TD_38_03_48_51_large_generated.py
+++ b/tests/slow_tests/relay_demo/test_relay_demo_TD_38_03_48_51_large_generated.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.custom_integ.ServiceLoader import ServiceLoader
+from argrelay.custom_integ.ServicePropName import ServicePropName
 from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.CompType import CompType
 from argrelay.runtime_data.AssignedValue import AssignedValue


### PR DESCRIPTION
*   Fix `TODO_39_25_11_76.data_envelopes_with_missing_props.md` by populating all func envelope props.
*   Make `func_tree` use absolute paths.
*   Use `~` (`SpecialChar.NoPropValue`) instead of `[none]`.
*   Avoid double func load (e.g. `duplicates`).
*   Rename `index_fields` to `index_props`.
*   Rename `collection_name_to_index_fields_map` to `collection_name_to_index_props_map`.
*   Rename `index_fields_` to `index_props_`.
*   Spec `TODO_48_38_59_64.remove_interp_tree_abs_paths_to_node_configs.md`.
*   Spec `TODO_18_51_46_14.refactor_zero_arg_interp_into_line_processor.md`.