### PR TITLE
Implement client-side fail over redundant server connections

### DIFF
--- a/docs/feature_stories/FS_36_17_84_44.check_env.md
+++ b/docs/feature_stories/FS_36_17_84_44.check_env.md
@@ -1,7 +1,7 @@
 ---
 feature_story: FS_36_17_84_44
 feature_title: check_env script
-feature_status: TODO
+feature_status: TEST
 ---
 
 The script is supposed to provide single place to perform multi-level verification.
@@ -16,12 +16,13 @@ It can start with checking:
 *   `argrelay` package existence
 
 Then it jumps into checks implemented in Python (for testability) to verify:
-*   whether it is run under FS_58_61_77_69 `dev_shell`
+*   DONE: whether it is run under FS_58_61_77_69 `dev_shell`
+*   check whether debug enabled and which debug (p, s, ... etc.).
 *   whether `PATH` env var reaches client and server binaries
 *   whether completion is configured in shell
-*   config locations used
+*   DONE: `@/conf` locations used
 *   any useful missing (or useless existing) settings in `~/.inputrc`
-*   server availability
+*   DONE: server availability
 *   server version and compatibility
 *   prints server instance id and whatever we can query to verify its state
 *   print plugin list (serialized DAG) with types and activation status
@@ -29,9 +30,9 @@ Then it jumps into checks implemented in Python (for testability) to verify:
     *   client-side plugin config
     *   server-side plugin config
 *   any useful `readline` settings set or not
-*   FS_57_36_37_48 (multiple clients) show all registered clients
-*   show all registered commands (FS_57_36_37_48 per client)
-*   print the same line info what `@/exe/dev_shell.bash` prints about version, conf, URL, etc.
+*   DONE: FS_57_36_37_48 (multiple clients) show all registered clients
+*   DONE: show all registered commands (FS_57_36_37_48 per client)
+*   DONE: print the same line info what `@/exe/dev_shell.bash` prints about version, conf, URL, etc.
 
 What else?
 

--- a/docs/feature_stories/FS_93_18_57_91.client_fail_over_to_redundant_servers.md
+++ b/docs/feature_stories/FS_93_18_57_91.client_fail_over_to_redundant_servers.md
@@ -1,0 +1,25 @@
+---
+feature_story: FS_93_18_57_91
+feature_title: client fail over to redundant servers
+feature_status: TEST
+---
+
+keywords: client-side fail over, redundant servers
+
+This feature is for client-side fail-over to other configured redundant servers.
+
+It uses special state file `@/var/argrelay_client.server_index`
+to select one of the several configured server connection.
+
+If connection fails, it selects (round-robin) next connection.
+
+# High-level logic
+
+*   Read the state with the CURR latest online server.
+    *   If none, read client config for the first server.
+*   Read config with ALL configured servers.
+*   Loop through a ring of ALL configured servers starting with the selected one.
+    *   If data retrieval succeeds, store the current server as the latest online server. Exit.
+    *   If data retrieval fails, select the next server to try.
+    *   If the ring is over, fail.
+

--- a/docs/task_refs/TODO_67_33_03_53.add_check_env_test_support.md
+++ b/docs/task_refs/TODO_67_33_03_53.add_check_env_test_support.md
@@ -1,6 +1,8 @@
 
-TODO: TODO_67_33_03_53: add `check_env` test support
+TODO: TODO_67_33_03_53: add FS_36_17_84_44 `check_env` test support
+
+Target: to be able to test it with `LocalServer` (and `LocalClient`).
 
 This may require special `EnvMockBuilder` and other classes.
 
-Target: to be able to test it with `LocalServer` (and `LocalClient`).
+Also, consider splitting `check_env` plugin config into separate file.

--- a/docs/task_refs/TODO_72_51_13_18.test_optimized_requests.md
+++ b/docs/task_refs/TODO_72_51_13_18.test_optimized_requests.md
@@ -1,0 +1,7 @@
+
+TODO: TODO_72_51_13_18: test optimized requests
+
+TODO: Provide test coverage for special implementation: `ClientCommandRemoteWorkerTextProposeArgValuesOptimized`
+
+It became more important with implementation of FS_93_18_57_91 client fail over to redundant servers.
+

--- a/dst/.github/argrelay.bootstrap.bash
+++ b/dst/.github/argrelay.bootstrap.bash
@@ -59,9 +59,7 @@ do
             "${argrelay_dir}/exe/bootstrap_env.bash"
 
             # Script `check_env` should succeed after bootstrap:
-            # TODO: TODO_67_33_03_53.add_check_env_test_support.md: also, introduce online and offline mode:
-            #       Currently, it fails if server is not.
-            #"${argrelay_dir}/exe/check_env.bash"
+            "${argrelay_dir}/exe/check_env.bash" "offline"
 
             ensure_no_uncommitted_changes_except \
                 ":(exclude)dst/.github/env_packages.txt" \

--- a/exe/bootstrap_env.bash
+++ b/exe/bootstrap_env.bash
@@ -83,8 +83,8 @@ fi
 
 ########################################################################################################################
 
-success_color="\e[42m"
-failure_color="\e[41m"
+success_color="\e[42m\e[30m"
+failure_color="\e[41m\e[97m"
 reset_color="\e[0m"
 
 # Indicate success|failure by color:
@@ -188,13 +188,11 @@ then
         # Load Python config to reset its `venv`:
         source "${argrelay_dir}/conf/python_env.conf.bash"
 
-        # Careful: instead of `rm -rf` (in case of misconfig), move `venv` to `/tmp/`:
-        run_timestamp="$( date -u "+%Y-%m-%dT%H-%M-%SZ" )"
         # shellcheck disable=SC2154
         if [[ -e "${path_to_venvX}" ]]
         then
-            backup_dst_path="/tmp/$( basename "${path_to_venvX}" ).backup.${run_timestamp}"
-            mv "${path_to_venvX}" "${backup_dst_path}"
+            # It must be a dir, if exists:
+            test -d "${path_to_venvX}"
         fi
 
         # Next: continue with bootstrap...

--- a/exe/relay_demo.bash
+++ b/exe/relay_demo.bash
@@ -26,7 +26,7 @@ set -E
 # Error on undefined variables:
 set -u
 
-failure_color="\e[41m"
+failure_color="\e[41m\e[97m"
 reset_color="\e[0m"
 
 # Indicate failure by color:
@@ -59,9 +59,12 @@ source "${argrelay_dir}/exe/argrelay_common_lib.bash"
 
 remove_pid_file_if_stale "${pid_file}"
 
-# NOTE: `server_host_name` is supposed to be local for this script to make sense:
-server_host_name="$( jq --raw-output ".connection_config.server_host_name" "${argrelay_dir}/conf/argrelay_client.json" )"
-server_port_number="$( jq --raw-output ".connection_config.server_port_number" "${argrelay_dir}/conf/argrelay_client.json" )"
+# Using single server index:
+server_index=0
+
+# NOTE: `server_host_name` is supposed to be local for this script to make sense (to be able to control server):
+server_host_name="$( jq --raw-output ".redundant_servers[${server_index}].server_host_name" "${argrelay_dir}/conf/argrelay_client.json" )"
+server_port_number="$( jq --raw-output ".redundant_servers[${server_index}].server_port_number" "${argrelay_dir}/conf/argrelay_client.json" )"
 
 kill_via_pid_file_or_ensure_closed_port "${pid_file}" "${server_host_name}" "${server_port_number}"
 # Wait for 1 min (60 sec):

--- a/readme.md
+++ b/readme.md
@@ -161,6 +161,12 @@ Start `@/exe/relay_demo.bash` (it may take a couple of minutes to start for the 
 ./exe/relay_demo.bash
 ```
 
+Optionally, review env state (any time):
+
+```sh
+./exe/check_env.bash
+```
+
 This sub-shell configures request hotkeys to bind `relay_demo` command with `@/exe/run_argrelay_client`:
 
 *   Interact with `relay_demo` command (which uses [demo test data][TD_63_37_05_36.demo_services_data.md]):
@@ -278,6 +284,8 @@ There are two options at the moment - both using [MongoDB][MongoDB] API:
 
 Quantitative comparison tables between the two can be seen in docstring for `DistinctValuesQuery` enum.
 
+<!--
+
 `pymongo` connects to a running MongoDB instance which has to be configured in<br/>
 `argrelay_server.yaml` under `mongo_config` and `mongomock` should be disabled:
 
@@ -285,6 +293,8 @@ Quantitative comparison tables between the two can be seen in docstring for `Dis
 -    use_mongomock: True
 +    use_mongomock: False
 ```
+
+-->
 
 <a name="argrelay-full-picture"></a>
 # Full picture

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def list_dir(
 setuptools.setup(
     name = "argrelay",
     # See `docs/dev_notes/version_format.md`:
-    version = "0.7.7.dev0",
+    version = "0.7.7",
     author = "uvsmtid",
     author_email = "uvsmtid@gmail.com",
     description = "Tab-completion & data search server = total recall for Bash shell",

--- a/src/argrelay/check_env/PluginCheckEnvAbstract.py
+++ b/src/argrelay/check_env/PluginCheckEnvAbstract.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Union
+
 from argrelay.check_env.CheckEnvResult import CheckEnvResult
 from argrelay.enum_desc.PluginType import PluginType
 from argrelay.runtime_context.PluginClientAbstract import PluginClientAbstract
@@ -27,5 +29,13 @@ class PluginCheckEnvAbstract(PluginClientAbstract):
 
     def execute_check(
         self,
+        online_mode: Union[bool, None],
     ) -> list[CheckEnvResult]:
+        """
+        Executes 1 to N checks and returns results of each one.
+
+        *   `online_mode == False` allows skipping some checks which require connection to serve.
+        *   `online_mode == True` execute all checks - if connection to serve is required, such checks may fail.
+        *   `online_mode is None` allows selecting default behavior (or automatic detection).
+        """
         pass

--- a/src/argrelay/check_env/PluginCheckEnvClientLinkedCommands.py
+++ b/src/argrelay/check_env/PluginCheckEnvClientLinkedCommands.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Union
+
+from argrelay.check_env.CheckEnvResult import CheckEnvResult
+from argrelay.check_env.PluginCheckEnvAbstract import PluginCheckEnvAbstract
+from argrelay.enum_desc.ResultCategory import ResultCategory
+from argrelay.enum_desc.TopDir import TopDir
+from argrelay.misc_helper_common import get_argrelay_dir
+
+
+class PluginCheckEnvClientLinkedCommands(PluginCheckEnvAbstract):
+    """
+    This plugin lists values of `argrelay_bind_command_basenames` shell variable
+    """
+
+    shell_var_name: str = "argrelay_bind_command_basenames"
+
+    # noinspection PyMethodMayBeStatic
+    def execute_check(
+        self,
+        online_mode: Union[bool, None],
+    ) -> list[CheckEnvResult]:
+        conf_file_path = os.path.join(
+            get_argrelay_dir(),
+            TopDir.conf_dir.value,
+            "shell_env.conf.bash",
+        )
+        shell_var_value = None
+        try:
+            bash_proc = subprocess.run(
+                args = [
+                    "bash",
+                    "-c",
+                    f"source {conf_file_path} ; echo ${{argrelay_bind_command_basenames[@]}}",
+                ],
+                capture_output = True,
+            )
+            assert bash_proc.returncode == 0
+            stdout_str = bash_proc.stdout.decode("utf-8")
+            shell_var_value = stdout_str.strip()
+        except:
+            shell_var_value = None
+
+        if shell_var_value is None:
+            return [CheckEnvResult(
+                result_category = ResultCategory.ExecutionFailure,
+                result_key = "client_linked_command",
+                result_value = str(shell_var_value),
+                result_message = f"unable to retrieve values of `argrelay_bind_command_basenames` from: {conf_file_path}",
+            )]
+        else:
+            linked_commands: list[str] = shell_var_value.split()
+            check_env_results: list[CheckEnvResult] = []
+            for command_index, linked_command in enumerate(linked_commands):
+                check_env_results.append(CheckEnvResult(
+                    result_category = ResultCategory.VerificationSuccess,
+                    result_key = f"client_linked_command[{command_index}]",
+                    result_value = str(linked_command),
+                    # result_message = f"run for more info: complete -p {linked_command}",
+                    result_message = None,
+                ))
+            return check_env_results
+

--- a/src/argrelay/check_env/PluginCheckEnvDevShell.py
+++ b/src/argrelay/check_env/PluginCheckEnvDevShell.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+from typing import Union
+
+from argrelay.check_env.CheckEnvResult import CheckEnvResult
+from argrelay.check_env.PluginCheckEnvAbstract import PluginCheckEnvAbstract
+from argrelay.enum_desc.ResultCategory import ResultCategory
+
+
+class PluginCheckEnvDevShell(PluginCheckEnvAbstract):
+    """
+    Trivial plugin to report value of `ARGRELAY_DEV_SHELL` env var.
+    """
+
+    env_var_name: str = "ARGRELAY_DEV_SHELL"
+
+    # noinspection PyMethodMayBeStatic
+    def execute_check(
+        self,
+        online_mode: Union[bool, None],
+    ) -> list[CheckEnvResult]:
+        env_var_value = os.environ.get(self.env_var_name)
+        if env_var_value is None:
+            result_message = "env var is not set => outside `@/exe/dev_shell.bash`"
+        else:
+            result_message = "env var is set => inside `@/exe/dev_shell.bash`"
+        return [CheckEnvResult(
+            result_category = ResultCategory.VerificationSuccess,
+            result_key = self.env_var_name,
+            result_value = str(env_var_value),
+            result_message = result_message,
+        )]
+

--- a/src/argrelay/check_env/PluginCheckEnvOnlineMode.py
+++ b/src/argrelay/check_env/PluginCheckEnvOnlineMode.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Union
+
+from argrelay.check_env.CheckEnvResult import CheckEnvResult
+from argrelay.check_env.PluginCheckEnvAbstract import PluginCheckEnvAbstract
+from argrelay.enum_desc.ResultCategory import ResultCategory
+
+
+class PluginCheckEnvOnlineMode(PluginCheckEnvAbstract):
+    """
+    Trivial plugin to report value of `online_mode`.
+    """
+
+    # noinspection PyMethodMayBeStatic
+    def execute_check(
+        self,
+        online_mode: Union[bool, None],
+    ) -> list[CheckEnvResult]:
+        return [CheckEnvResult(
+            result_category = ResultCategory.VerificationSuccess,
+            result_key = "online_mode",
+            result_value = str(online_mode),
+            result_message = None,
+        )]

--- a/src/argrelay/check_env/PluginCheckEnvServerIndex.py
+++ b/src/argrelay/check_env/PluginCheckEnvServerIndex.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os.path
+from typing import Union
+
+from argrelay.check_env.CheckEnvResult import CheckEnvResult
+from argrelay.check_env.PluginCheckEnvAbstract import PluginCheckEnvAbstract
+from argrelay.client_command_remote.ClientCommandRemoteWorkerAbstract import (
+    get_server_index_file_path,
+    load_server_index, server_index_file_name,
+)
+from argrelay.enum_desc.ResultCategory import ResultCategory
+from argrelay.enum_desc.TopDir import TopDir
+
+_server_index_field_name = "server_index"
+
+class PluginCheckEnvServerIndex(PluginCheckEnvAbstract):
+    """
+    Simple plugin to report server index for FS_93_18_57_91 client fail over.
+    """
+
+    # noinspection PyMethodMayBeStatic
+    def execute_check(
+        self,
+        online_mode: Union[bool, None],
+    ) -> list[CheckEnvResult]:
+        at_path = f"@/{os.path.join(TopDir.var_dir.value, server_index_file_name)}"
+        if os.path.isfile(get_server_index_file_path()):
+
+            # noinspection PyBroadException
+            try:
+                server_index = load_server_index()
+            except:
+                server_index = None
+
+            if server_index is None:
+                return [CheckEnvResult(
+                    result_category = ResultCategory.VerificationFailure,
+                    result_key = _server_index_field_name,
+                    result_value = str(None),
+                    result_message = f"remove this file as its content cannot be read as a int: {at_path}",
+                )]
+            else:
+                return [CheckEnvResult(
+                    result_category = ResultCategory.VerificationSuccess,
+                    result_key = _server_index_field_name,
+                    result_value = str(server_index),
+                    result_message = f"see: {at_path}",
+                )]
+        elif os.path.exists(get_server_index_file_path()):
+            return [CheckEnvResult(
+                result_category = ResultCategory.VerificationFailure,
+                result_key = _server_index_field_name,
+                result_value = str(None),
+                result_message = f"not a file: {at_path}",
+            )]
+        else:
+            return [CheckEnvResult(
+                result_category = ResultCategory.VerificationWarning,
+                result_key = _server_index_field_name,
+                result_value = str(None),
+                result_message = f"client has not been used to create this file yet: {at_path}",
+            )]

--- a/src/argrelay/check_env/PluginCheckEnvServerResponseValueCommitId.py
+++ b/src/argrelay/check_env/PluginCheckEnvServerResponseValueCommitId.py
@@ -6,6 +6,7 @@ from argrelay.enum_desc.CheckEnvField import CheckEnvField
 from argrelay.enum_desc.ResultCategory import ResultCategory
 from argrelay.misc_helper_common import get_argrelay_dir
 
+_commit_id_display_length = 8
 
 class PluginCheckEnvServerResponseValueCommitId(PluginCheckEnvServerResponseValueAbstract):
 
@@ -17,7 +18,6 @@ class PluginCheckEnvServerResponseValueCommitId(PluginCheckEnvServerResponseValu
         super().__init__(
             plugin_instance_id,
             plugin_config_dict = plugin_config_dict or {
-                # TODO: Maybe remove this class and simply rely on config?
                 field_values_to_command_lines_: {
                     CheckEnvField.server_git_commit_id.name: "argrelay.check_env server_commit",
                 },
@@ -26,45 +26,38 @@ class PluginCheckEnvServerResponseValueCommitId(PluginCheckEnvServerResponseValu
 
     def verify_online_value(
         self,
-        field_name,
+        field_name: str,
         field_value,
     ) -> CheckEnvResult:
-        if field_name == CheckEnvField.server_git_commit_id.name:
+        argrelay_dir = get_argrelay_dir()
 
-            argrelay_dir = get_argrelay_dir()
-
-            if is_git_repo(argrelay_dir):
-                try:
-                    client_commit_id = get_full_commit_id(argrelay_dir)
-                except ValueError:
-                    client_commit_id = None
-            else:
+        if is_git_repo(argrelay_dir):
+            try:
+                client_commit_id = get_full_commit_id(argrelay_dir)
+            except ValueError:
                 client_commit_id = None
+        else:
+            client_commit_id = None
 
-            if client_commit_id is None:
+        if client_commit_id is None:
+            return CheckEnvResult(
+                result_category = ResultCategory.ExecutionFailure,
+                result_key = field_name,
+                result_value = field_value,
+                result_message = "failed on getting client commit id",
+            )
+        else:
+            if client_commit_id == field_value:
                 return CheckEnvResult(
-                    result_category = ResultCategory.ExecutionFailure,
+                    result_category = ResultCategory.VerificationSuccess,
                     result_key = field_name,
-                    result_value = field_value,
-                    result_message = "failed on getting client commit id",
+                    result_value = field_value[:_commit_id_display_length],
+                    result_message = f"server commit id matches client one [{client_commit_id[:_commit_id_display_length]}]",
                 )
             else:
-                if client_commit_id == field_value:
-                    return CheckEnvResult(
-                        result_category = ResultCategory.VerificationSuccess,
-                        result_key = field_name,
-                        result_value = field_value,
-                        result_message = f"client commit id [{client_commit_id}] matches server commit id",
-                    )
-                else:
-                    return CheckEnvResult(
-                        result_category = ResultCategory.VerificationWarning,
-                        result_key = field_name,
-                        result_value = field_value,
-                        result_message = f"client commit id [{client_commit_id}] does not match server commit id [{field_value}]",
-                    )
-        else:
-            return super().verify_online_value(
-                field_name,
-                field_value,
-            )
+                return CheckEnvResult(
+                    result_category = ResultCategory.VerificationWarning,
+                    result_key = field_name,
+                    result_value = field_value[:_commit_id_display_length],
+                    result_message = f"server commit id does not match client one [{client_commit_id[:_commit_id_display_length]}]",
+                )

--- a/src/argrelay/check_env/PluginCheckEnvServerResponseValueStartTime.py
+++ b/src/argrelay/check_env/PluginCheckEnvServerResponseValueStartTime.py
@@ -18,7 +18,6 @@ class PluginCheckEnvServerResponseValueStartTime(PluginCheckEnvServerResponseVal
         super().__init__(
             plugin_instance_id,
             plugin_config_dict = plugin_config_dict or {
-                # TODO: Maybe remove this class and simply rely on config?
                 field_values_to_command_lines_: {
                     CheckEnvField.server_start_time.name: "argrelay.check_env server_start_time",
                 },

--- a/src/argrelay/check_env/PluginCheckEnvServerUrl.py
+++ b/src/argrelay/check_env/PluginCheckEnvServerUrl.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Union
+
+from argrelay.check_env.CheckEnvResult import CheckEnvResult
+from argrelay.check_env.PluginCheckEnvAbstract import PluginCheckEnvAbstract
+from argrelay.enum_desc.ResultCategory import ResultCategory
+from argrelay.runtime_data.ClientConfig import ClientConfig
+from argrelay.schema_config_core_client.ClientConfigSchema import client_config_desc
+
+
+class PluginCheckEnvServerUrl(PluginCheckEnvAbstract):
+    """
+    Simple plugin which lists URL-s for configured servers.
+    """
+
+    # noinspection PyMethodMayBeStatic
+    def execute_check(
+        self,
+        online_mode: Union[bool, None],
+    ) -> list[CheckEnvResult]:
+        check_env_results: list[CheckEnvResult] = []
+        client_config: ClientConfig = client_config_desc.obj_from_default_file()
+        for server_index, redundant_server in enumerate(client_config.redundant_servers):
+            check_env_results.append(CheckEnvResult(
+                result_category = ResultCategory.VerificationSuccess,
+                result_key = f"server_url[{server_index}]",
+                result_value = f"http://{redundant_server.server_host_name}:{redundant_server.server_port_number}",
+                result_message = None,
+            ))
+        return check_env_results

--- a/src/argrelay/client_command_remote/ClientCommandRemoteAbstract.py
+++ b/src/argrelay/client_command_remote/ClientCommandRemoteAbstract.py
@@ -25,6 +25,11 @@ class ClientCommandRemoteAbstract(ClientCommandAbstract):
     def execute_command(
         self,
     ):
+        """
+        Basic implementation of connection with single server.
+
+        FS_93_18_57_91 client fail over is implemented in derived `ClientCommandRemoteWorkerAbstract` class.
+        """
         try:
             self._execute_remotely()
         except (

--- a/src/argrelay/client_command_remote/ClientCommandRemoteWorkerAbstract.py
+++ b/src/argrelay/client_command_remote/ClientCommandRemoteWorkerAbstract.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import os
+
+from argrelay.client_command_remote.ClientCommandRemoteAbstract import ClientCommandRemoteAbstract
+from argrelay.client_pipeline import BytesSrcAbstract
+from argrelay.enum_desc.ClientExitCode import ClientExitCode
+from argrelay.enum_desc.ProcRole import ProcRole
+from argrelay.enum_desc.TopDir import TopDir
+from argrelay.misc_helper_common import get_argrelay_dir
+from argrelay.runtime_data.ConnectionConfig import ConnectionConfig
+from argrelay.server_spec.CallContext import CallContext
+
+server_index_file_name = "argrelay_client.server_index"
+
+
+def get_var_dir_path() -> str:
+    return str(os.path.join(get_argrelay_dir(), TopDir.var_dir.value))
+
+
+def get_server_index_file_path() -> str:
+    return str(os.path.join(get_var_dir_path(), server_index_file_name))
+
+
+def load_server_index(
+) -> int:
+    server_index_file_path = get_server_index_file_path()
+    if os.path.isfile(server_index_file_path):
+        with open(server_index_file_path, "r") as open_file:
+            return int(open_file.read())
+    else:
+        return 0
+
+
+def store_server_index(
+    curr_server_index: int,
+) -> None:
+    os.makedirs(
+        get_var_dir_path(),
+        exist_ok = True,
+    )
+    server_index_file_path = get_server_index_file_path()
+    with open(server_index_file_path, "w") as open_file:
+        open_file.write(str(curr_server_index))
+
+class ClientCommandRemoteWorkerAbstract(ClientCommandRemoteAbstract):
+
+    def __init__(
+        self,
+        call_ctx: CallContext,
+        proc_role: ProcRole,
+        redundant_servers: list[ConnectionConfig],
+        server_index: int,
+        bytes_src: BytesSrcAbstract,
+    ):
+        super().__init__(
+            call_ctx,
+            proc_role,
+        )
+        self.redundant_servers: list[ConnectionConfig] = redundant_servers
+        self.bytes_src: BytesSrcAbstract = bytes_src
+        if server_index < 0:
+            self.curr_connection_config: ConnectionConfig = self.redundant_servers[0]
+            self.use_round_robin = True
+        else:
+            self.curr_connection_config: ConnectionConfig = self.redundant_servers[server_index]
+            self.use_round_robin = False
+
+        self.server_index_file_path: str = get_server_index_file_path()
+
+    def execute_command(
+        self,
+    ):
+        """
+        Implements FS_93_18_57_91 client fail over.
+
+        For basic implementation (no round-robin) see base `ClientCommandRemoteAbstract` class.
+        """
+        if not self.use_round_robin:
+            super().execute_command()
+            return
+
+        connections_count = len(self.redundant_servers)
+        init_server_index = load_server_index()
+        for curr_connection_offset in range(connections_count):
+            curr_server_index = (init_server_index + curr_connection_offset) % connections_count
+            self.curr_connection_config = self.redundant_servers[curr_server_index]
+
+            try:
+                self._execute_remotely()
+                store_server_index(curr_server_index)
+                return
+            except (
+                ConnectionError,
+                ConnectionRefusedError,
+            ):
+                continue
+
+        if self.proc_role is ProcRole.ChildProcWorker:
+            # Tell parent what happened (let parent talk the rest):
+            exit(ClientExitCode.ConnectionError.value)
+        else:
+            raise ConnectionError(f"Unable to connect to any of [{connections_count}] configured connections")
+

--- a/src/argrelay/client_command_remote/ClientCommandRemoteWorkerJson.py
+++ b/src/argrelay/client_command_remote/ClientCommandRemoteWorkerJson.py
@@ -1,14 +1,10 @@
 import signal
 from dataclasses import asdict
 
-from argrelay.client_command_remote.ClientCommandRemoteAbstract import ClientCommandRemoteAbstract
-from argrelay.client_pipeline.BytesSrcAbstract import BytesSrcAbstract
-from argrelay.enum_desc.ProcRole import ProcRole
+from argrelay.client_command_remote.ClientCommandRemoteWorkerAbstract import ClientCommandRemoteWorkerAbstract
 from argrelay.misc_helper_common import eprint
 from argrelay.misc_helper_common.ElapsedTime import ElapsedTime
-from argrelay.runtime_data.ConnectionConfig import ConnectionConfig
 from argrelay.schema_request.CallContextSchema import call_context_desc
-from argrelay.server_spec.CallContext import CallContext
 from argrelay.server_spec.const_int import BASE_URL_FORMAT
 
 has_error_happened = False
@@ -22,26 +18,14 @@ def _signal_handler(signal_number, signal_frame):
         has_error_happened = True
 
 
-class ClientCommandRemoteWorkerJson(ClientCommandRemoteAbstract):
-
-    def __init__(
-        self,
-        call_ctx: CallContext,
-        proc_role: ProcRole,
-        connection_config: ConnectionConfig,
-        bytes_src: BytesSrcAbstract,
-    ):
-        super().__init__(
-            call_ctx,
-            proc_role,
-        )
-        self.connection_config: ConnectionConfig = connection_config
-        self.bytes_src: BytesSrcAbstract = bytes_src
+class ClientCommandRemoteWorkerJson(ClientCommandRemoteWorkerAbstract):
 
     def _execute_remotely(
         self,
     ):
-        server_url = BASE_URL_FORMAT.format(**asdict(self.connection_config)) + f"{self.call_ctx.server_action.value}"
+        server_url = BASE_URL_FORMAT.format(
+            **asdict(self.curr_connection_config)
+        ) + f"{self.call_ctx.server_action.value}"
         headers_dict = {
             "Content-Type": "application/json",
             "Accept": "application/json",

--- a/src/argrelay/custom_integ_res/bootstrap_env.bash
+++ b/src/argrelay/custom_integ_res/bootstrap_env.bash
@@ -83,8 +83,8 @@ fi
 
 ########################################################################################################################
 
-success_color="\e[42m"
-failure_color="\e[41m"
+success_color="\e[42m\e[30m"
+failure_color="\e[41m\e[97m"
 reset_color="\e[0m"
 
 # Indicate success|failure by color:
@@ -188,13 +188,11 @@ then
         # Load Python config to reset its `venv`:
         source "${argrelay_dir}/conf/python_env.conf.bash"
 
-        # Careful: instead of `rm -rf` (in case of misconfig), move `venv` to `/tmp/`:
-        run_timestamp="$( date -u "+%Y-%m-%dT%H-%M-%SZ" )"
         # shellcheck disable=SC2154
         if [[ -e "${path_to_venvX}" ]]
         then
-            backup_dst_path="/tmp/$( basename "${path_to_venvX}" ).backup.${run_timestamp}"
-            mv "${path_to_venvX}" "${backup_dst_path}"
+            # It must be a dir, if exists:
+            test -d "${path_to_venvX}"
         fi
 
         # Next: continue with bootstrap...

--- a/src/argrelay/custom_integ_res/dev_shell.bash
+++ b/src/argrelay/custom_integ_res/dev_shell.bash
@@ -52,7 +52,7 @@ set -E
 # Error on undefined variables:
 set -u
 
-failure_color="\e[41m"
+failure_color="\e[41m\e[97m"
 reset_color="\e[0m"
 banner_color="\e[94m"
 

--- a/src/argrelay/custom_integ_res/init_shell_env.bash
+++ b/src/argrelay/custom_integ_res/init_shell_env.bash
@@ -82,9 +82,16 @@ fi
 # Enable auto-completion:
 source "${argrelay_dir}/exe/shell_env.bash"
 
+if [[ -f "${argrelay_dir}/var/argrelay_client.server_index" ]]
+then
+    server_index="$( cat "${argrelay_dir}/var/argrelay_client.server_index" )"
+else
+    server_index="0"
+fi
+
 # TODO: FS_16_07_78_84: respect conf dir priority:
-server_host_name="$( jq --raw-output ".connection_config.server_host_name" "${argrelay_dir}/conf/argrelay_client.json" )"
-server_port_number="$( jq --raw-output ".connection_config.server_port_number" "${argrelay_dir}/conf/argrelay_client.json" )"
+server_host_name="$( jq --raw-output ".redundant_servers[${server_index}].server_host_name" "${argrelay_dir}/conf/argrelay_client.json" )"
+server_port_number="$( jq --raw-output ".redundant_servers[${server_index}].server_port_number" "${argrelay_dir}/conf/argrelay_client.json" )"
 
 eval "${init_shell_env_old_opts}"
 unset init_shell_env_old_opts
@@ -99,5 +106,5 @@ ${field_color}nested shell level:${reset_color} ${SHLVL} ${delimiter_color}|${re
 ${field_color}argrelay:${reset_color} $( pip show argrelay | grep '^Version:' | cut -f2 -d' ' || true ) ${delimiter_color}|${reset_color} \
 ${field_color}@/conf:${reset_color} ${conf_status} ${delimiter_color}|${reset_color} \
 ${field_color}venv:${reset_color} ${VIRTUAL_ENV} ${delimiter_color}|${reset_color} \
-${field_color}server:${reset_color} http://${server_host_name}:${server_port_number}" \
+${field_color}server[${server_index}]:${reset_color} http://${server_host_name}:${server_port_number}" \
 1>&2

--- a/src/argrelay/enum_desc/ClientExitCode.py
+++ b/src/argrelay/enum_desc/ClientExitCode.py
@@ -11,6 +11,11 @@ class ClientExitCode(IntEnum):
     GeneralError = 1
 
     ConnectionError = 2
+    """
+    Used to communicate specifically connection issues between client `ProcRole`-s.
+
+    Provides a mechanism to implement FS_93_18_57_91 client fail over.
+    """
 
     # maximum exit code:
     # https://stackoverflow.com/a/67219932/441652

--- a/src/argrelay/enum_desc/DistinctValuesQuery.py
+++ b/src/argrelay/enum_desc/DistinctValuesQuery.py
@@ -5,7 +5,7 @@ class DistinctValuesQuery(Enum):
     """
     Selects implementation for FS_02_25_41_81 `func_id_query_enum_items`.
 
-    See `test_QueryEngine_perf.py` for perf test used to produce these tables:
+    See `test_QueryEngine_perf.py` for perf test used to produce these tables (time is in seconds):
 
     Numbers for "use_single_collection: True" are more evident as `object_count` directly affects the query.
 

--- a/src/argrelay/enum_desc/TopDir.py
+++ b/src/argrelay/enum_desc/TopDir.py
@@ -26,5 +26,7 @@ class TopDir(Enum):
 
     test_dir = "test"
 
+    var_dir = "var"
+
     def __str__(self):
         return self.name

--- a/src/argrelay/plugin_delegator/QueryEnumDelegator.py
+++ b/src/argrelay/plugin_delegator/QueryEnumDelegator.py
@@ -6,7 +6,8 @@ from argrelay.enum_desc.ReservedPropName import ReservedPropName
 from argrelay.enum_desc.SpecialFunc import SpecialFunc
 from argrelay.handler_response.ClientResponseHandlerDescribeLineArgs import ClientResponseHandlerDescribeLineArgs
 from argrelay.plugin_delegator.AbstractJumpDelegator import AbstractJumpDelegator
-from argrelay.runtime_context.InterpContext import function_container_ipos_
+from argrelay.relay_server.LocalServer import LocalServer
+from argrelay.runtime_context.InterpContext import function_container_ipos_, InterpContext
 from argrelay.schema_config_interp.DataEnvelopeSchema import instance_data_
 from argrelay.schema_config_interp.FunctionEnvelopeInstanceDataSchema import (
     delegator_plugin_instance_id_,
@@ -39,6 +40,25 @@ class QueryEnumDelegator(AbstractJumpDelegator):
             ReservedPropName.func_id.name: SpecialFunc.func_id_query_enum_items.name,
         }]
         return func_envelopes
+
+    def run_invoke_control(
+        self,
+        interp_ctx: InterpContext,
+        local_server: LocalServer,
+    ) -> InvocationInput:
+        assert interp_ctx.is_func_found(), "the (first) function envelope must be found"
+
+        # TODO: Fail (send to ErrorDelegator) if next function is not specified -
+        #       showing the payload in this case is misleading.
+        delegator_plugin_instance_id = self.plugin_instance_id
+        invocation_input = InvocationInput.with_interp_context(
+            interp_ctx,
+            delegator_plugin_entry = local_server.plugin_config.plugin_instance_entries[
+                delegator_plugin_instance_id
+            ],
+            custom_plugin_data = {},
+        )
+        return invocation_input
 
     @staticmethod
     def invoke_action(invocation_input: InvocationInput):

--- a/src/argrelay/relay_client/ClientCommandFactoryRemote.py
+++ b/src/argrelay/relay_client/ClientCommandFactoryRemote.py
@@ -21,11 +21,13 @@ class ClientCommandFactoryRemote(ClientCommandFactoryAbstract):
         proc_role: ProcRole,
         w_pipe_end,
         is_optimized_completion: bool,
+        server_index: int,
     ):
         self.client_config: ClientConfig = client_config
         self.proc_role: ProcRole = proc_role
         self.w_pipe_end = w_pipe_end
         self.is_optimized_completion = is_optimized_completion
+        self.server_index = server_index
         if proc_role.is_worker_proc and proc_role.is_split_mode:
             assert self.w_pipe_end is not None
         else:
@@ -80,7 +82,8 @@ class ClientCommandFactoryRemote(ClientCommandFactoryAbstract):
             return command_cls(
                 call_ctx,
                 self.proc_role,
-                self.client_config.connection_config,
+                self.client_config.redundant_servers,
+                self.server_index,
                 bytes_src,
             )
         else:

--- a/src/argrelay/relay_client/ClientRemote.py
+++ b/src/argrelay/relay_client/ClientRemote.py
@@ -19,6 +19,7 @@ class ClientRemote(ClientAbstract):
         proc_role: ProcRole,
         w_pipe_end,
         is_optimized_completion: bool,
+        server_index: int,
     ):
         super().__init__(
             client_config,
@@ -27,6 +28,7 @@ class ClientRemote(ClientAbstract):
                 proc_role,
                 w_pipe_end,
                 is_optimized_completion,
+                server_index,
             ),
         )
         assert not client_config.use_local_requests

--- a/src/argrelay/relay_client/__main__.py
+++ b/src/argrelay/relay_client/__main__.py
@@ -71,6 +71,7 @@ def main():
         is_optimized_completion,
         w_pipe_end,
         shell_ctx,
+        -1,
     )
     return command_obj
 
@@ -87,14 +88,17 @@ def client_config_dict_to_object(client_config_dict):
     """
     Optimized dict -> object conversion avoiding import of `*Schema` for performance:
     """
+    redundant_servers: list[ConnectionConfig] = []
+    for redundant_server in client_config_dict["redundant_servers"]:
+        redundant_servers.append(ConnectionConfig(
+            server_host_name = redundant_server["server_host_name"],
+            server_port_number = redundant_server["server_port_number"],
+        ))
     client_config = ClientConfig(
         __comment__ = client_config_dict.get("use_local_requests", None),
         use_local_requests = client_config_dict.get("use_local_requests", False),
         optimize_completion_request = client_config_dict.get("optimize_completion_request", True),
-        connection_config = ConnectionConfig(
-            server_host_name = client_config_dict["connection_config"]["server_host_name"],
-            server_port_number = client_config_dict["connection_config"]["server_port_number"],
-        ),
+        redundant_servers = redundant_servers,
         show_pending_spinner = client_config_dict.get("show_pending_spinner", True),
         spinless_sleep_sec = client_config_dict.get("spinless_sleep_sec", 0.0),
     )

--- a/src/argrelay/relay_client/proc_spinner.py
+++ b/src/argrelay/relay_client/proc_spinner.py
@@ -130,6 +130,7 @@ def spinner_main(
         proc_role,
         None,
         is_optimized_completion,
+        -1,
     )
     # TODO: Rethink/Rename: spinner does not make any request:
     #       Maybe remove *Client altogether and move its functionality into *ClientCommandFactory?

--- a/src/argrelay/relay_client/proc_worker.py
+++ b/src/argrelay/relay_client/proc_worker.py
@@ -8,6 +8,7 @@ def worker_main(
     is_optimized_completion,
     w_pipe_end,
     shell_ctx,
+    server_index: int,
 ) -> "ClientCommandAbstract":
     if client_config.use_local_requests:
         # This branch with `use_local_requests` is used only for testing
@@ -23,6 +24,7 @@ def worker_main(
             proc_role,
             w_pipe_end,
             is_optimized_completion,
+            server_index,
         )
 
     ElapsedTime.measure("before_client_invocation")

--- a/src/argrelay/runtime_data/ClientConfig.py
+++ b/src/argrelay/runtime_data/ClientConfig.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 
 from argrelay.runtime_data.ConnectionConfig import ConnectionConfig
@@ -8,6 +10,6 @@ class ClientConfig:
     __comment__: str = field()
     use_local_requests: bool = field()
     optimize_completion_request: bool = field()
-    connection_config: ConnectionConfig = field()
+    redundant_servers: list[ConnectionConfig] = field()
     show_pending_spinner: bool = field()
     spinless_sleep_sec: float = field()

--- a/src/argrelay/runtime_data/PluginConfig.py
+++ b/src/argrelay/runtime_data/PluginConfig.py
@@ -27,3 +27,16 @@ class PluginConfig:
     walking through a DAG described by `plugin_dependencies`.
     Each `plugin_instance_id` is a key into `plugin_instance_entries`.
     """
+
+    # TODO: Move it into separate file/object:
+    check_env_plugin_instance_entries: dict[str, PluginEntry] = field()
+    """
+    Same as `plugin_instance_entries` but for FS_36_17_84_44 `check_env` only.
+    """
+
+    # TODO: Move it into separate file/object:
+    check_env_plugin_instance_id_activate_list: list[str] = field()
+    """
+    Same as `plugin_instance_id_activate_list` but for FS_36_17_84_44 `check_env` only.
+    """
+

--- a/src/argrelay/sample_conf/argrelay_client.json
+++ b/src/argrelay/sample_conf/argrelay_client.json
@@ -1,9 +1,14 @@
-
 {
     "__comment__": "This is an `argrelay` client config.",
-    "connection_config": {
-        "server_host_name": "localhost",
-        "server_port_number": 8787
-    },
+    "redundant_servers": [
+        {
+            "server_host_name": "localhost",
+            "server_port_number": 8787
+        },
+        {
+            "server_host_name": "localhost",
+            "server_port_number": 7878
+        }
+    ],
     "show_pending_spinner": true
 }

--- a/src/argrelay/sample_conf/argrelay_plugin.yaml
+++ b/src/argrelay/sample_conf/argrelay_plugin.yaml
@@ -515,8 +515,35 @@ plugin_instance_entries:
             git_files_by_commit_id_url_prefix: "https://github.com/argrelay/argrelay/tree/"
             commit_id_url_prefix: "https://github.com/argrelay/argrelay/commit/"
 
+check_env_plugin_instance_entries:
+
     ####################################################################################################################
     # List of client-side plugins for FS_36_17_84_44 `check_env`
+
+    PluginCheckEnvDevShell.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvDevShell
+        plugin_class_name: PluginCheckEnvDevShell
+
+    PluginCheckEnvClientLinkedCommands.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvClientLinkedCommands
+        plugin_class_name: PluginCheckEnvClientLinkedCommands
+
+    PluginCheckEnvOnlineMode.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvOnlineMode
+        plugin_class_name: PluginCheckEnvOnlineMode
+
+    PluginCheckEnvServerIndex.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvServerIndex
+        plugin_class_name: PluginCheckEnvServerIndex
+
+    PluginCheckEnvServerUrl.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvServerUrl
+        plugin_class_name: PluginCheckEnvServerUrl
 
     PluginCheckEnvServerResponseValueCommitId.default:
         plugin_side: PluginClientSideOnly

--- a/src/argrelay/schema_config_core_client/ClientConfigSchema.py
+++ b/src/argrelay/schema_config_core_client/ClientConfigSchema.py
@@ -6,7 +6,7 @@ from argrelay.runtime_data.ClientConfig import ClientConfig
 from argrelay.schema_config_core_client.ConnectionConfigSchema import connection_config_desc
 
 __comment___ = "__comment__"
-connection_config_ = "connection_config"
+redundant_servers_ = "redundant_servers"
 use_local_requests_ = "use_local_requests"
 optimize_completion_request_ = "optimize_completion_request"
 show_pending_spinner_ = "show_pending_spinner"
@@ -45,7 +45,10 @@ class ClientConfigSchema(ObjectSchema):
         load_default = True,
     )
 
-    connection_config = fields.Nested(connection_config_desc.dict_schema)
+    redundant_servers = fields.List(
+        fields.Nested(connection_config_desc.dict_schema),
+        required = True,
+    )
 
     # Enables spinner for FS_14_59_14_06: pending requests.
     show_pending_spinner = fields.Boolean(
@@ -64,7 +67,9 @@ client_config_desc = TypeDesc(
     dict_schema = ClientConfigSchema(),
     ref_name = ClientConfigSchema.__name__,
     dict_example = {
-        connection_config_: connection_config_desc.dict_example,
+        redundant_servers_: [
+            connection_config_desc.dict_example,
+        ]
     },
     default_file_path = "argrelay_client.json",
 )

--- a/src/argrelay/schema_config_plugin/PluginConfigSchema.py
+++ b/src/argrelay/schema_config_plugin/PluginConfigSchema.py
@@ -10,7 +10,7 @@ from argrelay.schema_config_plugin.PluginEntrySchema import plugin_entry_desc
 
 reusable_config_data_ = "reusable_config_data"
 plugin_instance_entries_ = "plugin_instance_entries"
-
+check_env_plugin_instance_entries_ = "check_env_plugin_instance_entries"
 
 class PluginConfigSchema(ObjectSchema):
     class Meta:
@@ -40,6 +40,13 @@ class PluginConfigSchema(ObjectSchema):
         required = True,
     )
 
+    # TODO: Move it into separate file/schema:
+    check_env_plugin_instance_entries = fields.Dict(
+        keys = fields.String(),
+        values = fields.Nested(plugin_entry_desc.dict_schema),
+        required = True,
+    )
+
     @post_load
     def make_object(
         self,
@@ -53,10 +60,19 @@ class PluginConfigSchema(ObjectSchema):
             plugin_entry: PluginEntry = input_dict[plugin_instance_entries_][plugin_instance_id]
             plugin_instance_id_activate_order_dag[plugin_instance_id] = plugin_entry.plugin_dependencies
 
+        # TODO: Move it into separate file/schema:
+        check_env_plugin_instance_id_activate_order_dag = {}
+        for plugin_instance_id in input_dict[check_env_plugin_instance_entries_]:
+            plugin_entry: PluginEntry = input_dict[check_env_plugin_instance_entries_][plugin_instance_id]
+            check_env_plugin_instance_id_activate_order_dag[plugin_instance_id] = plugin_entry.plugin_dependencies
+
         return type(self).model_class(
             **input_dict,
             plugin_instance_id_activate_list = serialize_dag_to_list(
                 plugin_instance_id_activate_order_dag,
+            ),
+            check_env_plugin_instance_id_activate_list = serialize_dag_to_list(
+                check_env_plugin_instance_id_activate_order_dag,
             ),
         )
 
@@ -69,6 +85,11 @@ plugin_config_desc = TypeDesc(
             "some_plugin_instance_id": plugin_entry_desc.dict_example,
             "some_plugin_instance_id1": plugin_entry_desc.dict_example,
             "some_plugin_instance_id2": plugin_entry_desc.dict_example,
+        },
+        check_env_plugin_instance_entries_: {
+            "some_check_env_plugin_instance_id": plugin_entry_desc.dict_example,
+            "some_check_env_plugin_instance_id1": plugin_entry_desc.dict_example,
+            "some_check_env_plugin_instance_id2": plugin_entry_desc.dict_example,
         },
     },
     default_file_path = "argrelay_plugin.yaml",

--- a/src/argrelay/test_infra/ClientServerTestClass.py
+++ b/src/argrelay/test_infra/ClientServerTestClass.py
@@ -56,14 +56,17 @@ class ClientServerTestClass(InOutTestClass):
     def wait_for_connection_to_server():
         client_config: ClientConfig = client_config_desc.obj_from_default_file()
 
+        # Checking only one server index:
+        server_index = 0
+
         delay_s = 1
         # 10 mins should be enough, right?
         timeout_ts = datetime.now() + timedelta(minutes = 10.0)
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
             while True:
                 result = sock.connect_ex((
-                    client_config.connection_config.server_host_name,
-                    client_config.connection_config.server_port_number,
+                    client_config.redundant_servers[server_index].server_host_name,
+                    client_config.redundant_servers[server_index].server_port_number,
                 ))
                 if result == 0:
                     print("connected to server")

--- a/src/argrelay/test_infra/EnvMockBuilder.py
+++ b/src/argrelay/test_infra/EnvMockBuilder.py
@@ -1026,16 +1026,16 @@ def wrap_instance_method_on_instance(
 @contextlib.contextmanager
 def wrap_instance_method_on_class(
     any_class,
-    callable_on_instance: Callable,
+    callable_on_class: Callable,
 ):
     """
-    Wraps `callable_on_instance` by a mock which still calls original method.
+    Wraps `callable_on_class` by a mock which still calls original method.
     Use case: test whether original method is called.
     See also: `wrap_instance_method_on_instance` - similar purpose but requires completely different mocking call.
     """
     with mock.patch(
-        f"{any_class.__module__}.{any_class.__name__}.{callable_on_instance.__name__}",
-        side_effect = callable_on_instance,
+        f"{any_class.__module__}.{any_class.__name__}.{callable_on_class.__name__}",
+        side_effect = callable_on_class,
         autospec = True,
     ) as method_wrap_mock:
         yield method_wrap_mock

--- a/tests/offline_tests/plugin_delegator/test_QueryEnumDelegator.py
+++ b/tests/offline_tests/plugin_delegator/test_QueryEnumDelegator.py
@@ -1,0 +1,167 @@
+from argrelay.custom_integ.ServicePropName import ServicePropName
+from argrelay.enum_desc.ArgSource import ArgSource
+from argrelay.enum_desc.CompType import CompType
+from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
+from argrelay.plugin_interp.FuncTreeInterpFactory import func_envelope_path_step_prop_name
+from argrelay.runtime_data.AssignedValue import AssignedValue
+from argrelay.test_infra import line_no
+from argrelay.test_infra.LocalTestClass import LocalTestClass
+
+
+class ThisTestClass(LocalTestClass):
+    same_test_data_per_class = "TD_63_37_05_36"  # demo
+
+    def test_FS_02_25_41_81_enum(self):
+        """
+        Test FS_02_25_41_81 `func_id_query_enum_items`.
+        """
+
+        test_cases = [
+            (
+                line_no(),
+                "some_command enum |",
+                CompType.PrefixShown,
+                [
+                    "config",
+                    "desc",
+                    "diff",
+                    "duplicates",
+                    "echo",
+                    "enum",
+                    "goto",
+                    "help",
+                    "intercept",
+                    "list",
+                ],
+                None,
+                None,
+                "If `enum` is already selected, it can be recursively suggested during selection of the function",
+            ),
+            (
+                line_no(),
+                "some_command enum goto |",
+                CompType.PrefixShown,
+                [
+                    "host",
+                    "repo",
+                    "service",
+                ],
+                None,
+                None,
+                "Completion continues to select functions with `goto` path node in it.",
+            ),
+            (
+                line_no(),
+                "some_command enum goto service s_b |",
+                CompType.PrefixShown,
+                [
+                    "dev",
+                    "prod",
+                    "qa",
+                ],
+                None,
+                None,
+                "Completion continues to be driven by function selected via `goto` and `service`.",
+            ),
+            (
+                line_no(),
+                "some_command enum goto service s_b prod qwer-pd-2 |",
+                CompType.InvokeAction,
+                None,
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("enum", ArgSource.InitValue),
+                    },
+                    1: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue("service", ArgSource.ExplicitPosArg),
+                    },
+                    2: {
+                        ServicePropName.service_name.name: AssignedValue("s_b", ArgSource.ExplicitPosArg),
+                        ServicePropName.code_maturity.name: AssignedValue("prod", ArgSource.ExplicitPosArg),
+                        ServicePropName.host_name.name: AssignedValue("qwer-pd-2", ArgSource.ExplicitPosArg),
+                    },
+                    3: {
+                        ServicePropName.access_type.name: AssignedValue("ro", ArgSource.DefaultValue),
+                    },
+                    4: None,
+                },
+                None,
+                "Invocation payload is provided by function selected via `goto` and `service`.",
+            ),
+            (
+                line_no(),
+                "some_command enum enum enum enum |",
+                CompType.InvokeAction,
+                None,
+                {
+                    0: {
+                        ReservedPropName.envelope_class.name: AssignedValue(
+                            ReservedEnvelopeClass.ClassFunction.name,
+                            ArgSource.InitValue,
+                        ),
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("enum", ArgSource.InitValue),
+                    },
+                    1: {
+                        ReservedPropName.envelope_class.name: AssignedValue(
+                            ReservedEnvelopeClass.ClassFunction.name,
+                            ArgSource.InitValue,
+                        ),
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("enum", ArgSource.InitValue),
+                    },
+                    2: {
+                        ReservedPropName.envelope_class.name: AssignedValue(
+                            ReservedEnvelopeClass.ClassFunction.name,
+                            ArgSource.InitValue,
+                        ),
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("enum", ArgSource.InitValue),
+                    },
+                    3: {
+                        ReservedPropName.envelope_class.name: AssignedValue(
+                            ReservedEnvelopeClass.ClassFunction.name,
+                            ArgSource.InitValue,
+                        ),
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("enum", ArgSource.InitValue),
+                    },
+                    4: {
+                        ReservedPropName.envelope_class.name: AssignedValue(
+                            ReservedEnvelopeClass.ClassFunction.name,
+                            ArgSource.InitValue,
+                        ),
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                    },
+                    5: None,
+                },
+                None,
+                "Prepend `enum` by another `enum` multiple times.",
+            ),
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case):
+                (
+                    line_number,
+                    test_line,
+                    comp_type,
+                    expected_suggestions,
+                    container_ipos_to_expected_assignments,
+                    delegator_class,
+                    case_comment,
+                ) = test_case
+
+                self.verify_output_with_new_server_via_local_client(
+                    self.__class__.same_test_data_per_class,
+                    test_line,
+                    comp_type,
+                    expected_suggestions,
+                    container_ipos_to_expected_assignments,
+                    delegator_class,
+                    None,
+                )

--- a/tests/offline_tests/relay_client/test_client_side_fail_over.py
+++ b/tests/offline_tests/relay_client/test_client_side_fail_over.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, replace
+from typing import Union
+
+import requests
+import responses
+
+from argrelay.client_command_remote.ClientCommandRemoteWorkerAbstract import get_server_index_file_path
+from argrelay.enum_desc.CompType import CompType
+from argrelay.enum_desc.ServerAction import ServerAction
+from argrelay.relay_client import __main__
+from argrelay.runtime_data.ClientConfig import ClientConfig
+from argrelay.runtime_data.ConnectionConfig import ConnectionConfig
+from argrelay.schema_config_core_client.ClientConfigSchema import client_config_desc
+from argrelay.schema_response.InterpResultSchema import interp_result_desc
+from argrelay.server_spec.const_int import BASE_URL_FORMAT
+from argrelay.test_infra import parse_line_and_cpos
+from argrelay.test_infra.BaseTestClass import BaseTestClass
+from argrelay.test_infra.EnvMockBuilder import LiveServerEnvMockBuilder
+
+
+class ThisTestClass(BaseTestClass):
+    """
+    Test FS_93_18_57_91 client fail over to redundant servers.
+
+    Client-only test (without spanning `argrelay` server).
+    """
+
+    @responses.activate
+    def test_client_leaves_no_server_index_file_on_connection_failure(self):
+        self.verify_client_fail_over_scenario(
+            initial_file_content = None,
+            # All failed:
+            failed_server_indexes = list(range(len(self.get_test_server_connection_configs()))),
+            residual_file_content = None,
+        )
+
+    @responses.activate
+    def test_client_leaves_server_index_file_on_successful_connection(self):
+        self.verify_client_fail_over_scenario(
+            initial_file_content = None,
+            failed_server_indexes = [],
+            residual_file_content = "0",
+        )
+
+    @responses.activate
+    def test_client_fail_over_to_next_server(self):
+        self.verify_client_fail_over_scenario(
+            initial_file_content = "0",
+            failed_server_indexes = [0],
+            residual_file_content = "1",
+        )
+
+    @responses.activate
+    def test_successful_connections_do_not_fail_over(self):
+        self.verify_client_fail_over_scenario(
+            initial_file_content = "1",
+            failed_server_indexes = [0, 2],
+            residual_file_content = "1",
+        )
+
+    @responses.activate
+    def test_client_fail_over_with_negative_server_index_stored(self):
+        self.verify_client_fail_over_scenario(
+            initial_file_content = "-100",
+            failed_server_indexes = [],
+            # Stores immediately successful:
+            # -100 % 3 = 2:
+            residual_file_content = "2",
+        )
+        self.verify_client_fail_over_scenario(
+            initial_file_content = "-100",
+            # -100 % 3 = 2:
+            failed_server_indexes = [2],
+            # Stores next successful:
+            residual_file_content = "0",
+        )
+
+    @responses.activate
+    def test_start_index_beyond_available_connections_range(self):
+        self.verify_client_fail_over_scenario(
+            initial_file_content = "100",
+            failed_server_indexes = [],
+            # Stores immediately successful:
+            # 100 % 3 = 1:
+            residual_file_content = "1",
+        )
+        self.verify_client_fail_over_scenario(
+            initial_file_content = "100",
+            # 100 % 3 = 1:
+            failed_server_indexes = [1],
+            # Stores next successful:
+            residual_file_content = "2"
+        )
+
+    # noinspection PyMethodMayBeStatic
+    def get_test_server_connection_configs(
+        self,
+    ) -> list[ConnectionConfig]:
+        """
+        These connections just have to be different to differentiate them by mocked `responses`.
+        """
+        return [
+            ConnectionConfig(
+                server_host_name = "localhost",
+                server_port_number = 10000,
+            ),
+            ConnectionConfig(
+                server_host_name = "localhost",
+                server_port_number = 10001,
+            ),
+            ConnectionConfig(
+                server_host_name = "localhost",
+                server_port_number = 10002,
+            ),
+        ]
+
+    # noinspection PyMethodMayBeStatic
+    def get_env_mock_builder(
+        self,
+        comp_type: CompType,
+    ):
+        # This test does not care about payload (it tests connection logic):
+        test_line = "some_command pro|d whatever"
+        (command_line, cursor_cpos) = parse_line_and_cpos(test_line)
+
+        client_config_obj: ClientConfig = client_config_desc.obj_from_default_file()
+        client_config_obj = replace(
+            client_config_obj,
+            redundant_servers = self.get_test_server_connection_configs()
+        )
+        client_config_dict = client_config_desc.dict_from_input_obj(client_config_obj)
+
+        env_mock_builder = (
+            # Using "LiveServer*" because we do not manage server in the test,
+            # but we mock communication with the server outside `EnvMockBuilder`:
+            LiveServerEnvMockBuilder()
+            .set_mock_client_config_file_read(True)
+            .set_client_config_dict(client_config_dict)
+            # TODO: TODO_72_51_13_18: test optimized requests:
+            #       This will require abstracting mocking of connection success and connection failure.
+            .set_client_config_to_optimize_completion_request(False)
+            .set_show_pending_spinner(False)
+            .set_command_line(command_line)
+            .set_cursor_cpos(cursor_cpos)
+            .set_comp_type(comp_type)
+            .set_capture_stdout(True)
+            .set_capture_stderr(True)
+        )
+        return env_mock_builder
+
+    # noinspection PyMethodMayBeStatic
+    def get_mocked_successful_response(
+        self,
+        connection_config: ConnectionConfig,
+        server_action: ServerAction,
+        response_body: dict,
+    ):
+        return responses.Response(
+            method = responses.POST,
+            url = BASE_URL_FORMAT.format(**asdict(connection_config)) + server_action.value,
+            json = response_body,
+            status = 200,
+            content_type = "application/json",
+        )
+
+    # noinspection PyMethodMayBeStatic
+    def get_mocked_failed_connection(
+        self,
+        connection_config: ConnectionConfig,
+        server_action: ServerAction,
+    ):
+        return responses.Response(
+            method = responses.POST,
+            url = BASE_URL_FORMAT.format(**asdict(connection_config)) + server_action.value,
+            body = requests.ConnectionError(),
+            content_type = "application/json",
+        )
+
+    def verify_client_fail_over_scenario(
+        self,
+        initial_file_content: Union[None, str],
+        failed_server_indexes: list[int],
+        residual_file_content: Union[None, str],
+    ):
+        # given:
+
+        comp_type: CompType = CompType.DescribeArgs
+        response_dict = interp_result_desc.dict_example
+
+        if initial_file_content is None:
+            if os.path.exists(get_server_index_file_path()):
+                os.remove(get_server_index_file_path())
+        else:
+            with open(get_server_index_file_path(), "w") as open_file:
+                open_file.write(initial_file_content)
+
+        for failed_server_index in failed_server_indexes:
+            # It should not reference non-existing connections:
+            self.assertTrue(failed_server_index < len(self.get_test_server_connection_configs()))
+        # All values should be unique:
+        self.assertEqual(
+            len(set(failed_server_indexes)),
+            len(failed_server_indexes),
+        )
+
+        for server_index, connection_config in enumerate(self.get_test_server_connection_configs()):
+            if server_index in failed_server_indexes:
+                responses.add(self.get_mocked_failed_connection(
+                    connection_config,
+                    ServerAction.DescribeLineArgs,
+                ))
+            else:
+                responses.add(self.get_mocked_successful_response(
+                    connection_config,
+                    ServerAction.DescribeLineArgs,
+                    response_dict,
+                ))
+
+        # It should be successful unless all connection configs fail:
+        is_connection_successful: bool = (
+            set(failed_server_indexes)
+            !=
+            set(range(len(self.get_test_server_connection_configs())))
+        )
+
+        # when:
+
+        env_mock_builder = self.get_env_mock_builder(comp_type)
+        with env_mock_builder.build():
+            if is_connection_successful:
+                __main__.main()
+            else:
+                with self.assertRaises(ConnectionError) as exc_context:
+                    __main__.main()
+
+        # then:
+
+        file_exists = os.path.exists(get_server_index_file_path())
+        if is_connection_successful:
+            self.assertTrue(file_exists)
+        else:
+            if initial_file_content is None:
+                self.assertFalse(file_exists)
+            else:
+                self.assertTrue(file_exists)
+
+        if residual_file_content is not None:
+            with open(get_server_index_file_path(), "r") as open_file:
+                self.assertEqual(
+                    residual_file_content,
+                    open_file.read(),
+                )

--- a/tests/offline_tests/relay_client/test_imports_ProposeArgValuesRemoteOptimizedClientCommand.py
+++ b/tests/offline_tests/relay_client/test_imports_ProposeArgValuesRemoteOptimizedClientCommand.py
@@ -51,19 +51,28 @@ class ThisTestClass(BaseTestClass):
             "argrelay.relay_client.ClientCommandAbstract",
             "argrelay.server_spec.CallContext"
         ],
-        "argrelay.client_command_remote.ClientCommandRemoteWorkerTextProposeArgValuesOptimized": [
+        "argrelay.client_command_remote.ClientCommandRemoteWorkerAbstract": [
+            "__future__",
             "argrelay.client_command_remote.ClientCommandRemoteAbstract",
-            "argrelay.client_pipeline.BytesSrcAbstract",
+            "argrelay.client_pipeline",
+            "argrelay.enum_desc.ClientExitCode",
             "argrelay.enum_desc.ProcRole",
+            "argrelay.enum_desc.TopDir",
+            "argrelay.misc_helper_common",
+            "argrelay.runtime_data.ConnectionConfig",
+            "argrelay.server_spec.CallContext",
+            "os"
+        ],
+        "argrelay.client_command_remote.ClientCommandRemoteWorkerTextProposeArgValuesOptimized": [
+            "argrelay.client_command_remote.ClientCommandRemoteWorkerAbstract",
             "argrelay.enum_desc.ServerAction",
             "argrelay.misc_helper_common.ElapsedTime",
             "argrelay.runtime_data.ConnectionConfig",
-            "argrelay.server_spec.CallContext",
             "json",
             "os",
             "socket"
         ],
-        "argrelay.client_pipeline.BytesSrcAbstract": [],
+        "argrelay.client_pipeline": [],
         "argrelay.client_spec.ShellContext": [
             "__future__",
             "argrelay.enum_desc.CompScope",
@@ -93,6 +102,10 @@ class ThisTestClass(BaseTestClass):
             "enum"
         ],
         "argrelay.enum_desc.TermColor": [
+            "enum"
+        ],
+        "argrelay.enum_desc.TopDir": [
+            "__future__",
             "enum"
         ],
         "argrelay.misc_helper_common": [
@@ -126,6 +139,7 @@ class ThisTestClass(BaseTestClass):
             "argrelay.misc_helper_common.ElapsedTime"
         ],
         "argrelay.runtime_data.ClientConfig": [
+            "__future__",
             "argrelay.runtime_data.ConnectionConfig",
             "dataclasses"
         ],

--- a/tests/offline_tests/relay_client/test_relay_client.py
+++ b/tests/offline_tests/relay_client/test_relay_client.py
@@ -38,11 +38,11 @@ class ThisTestClass(BaseTestClass):
         response_body: dict,
     ):
         return responses.Response(
-            method = "POST",
+            method = responses.POST,
             url = self.base_URL + server_action.value,
             json = response_body,
             status = 200,
-            content_type = "application/json"
+            content_type = "application/json",
         )
 
     # noinspection PyMethodMayBeStatic

--- a/tests/offline_tests/schema_common/test_Schema.py
+++ b/tests/offline_tests/schema_common/test_Schema.py
@@ -28,7 +28,7 @@ from argrelay.plugin_delegator.ErrorDelegatorCustomDataSchema import error_deleg
 from argrelay.plugin_interp.FirstArgInterpFactoryConfigSchema import first_arg_interp_factory_config_desc
 from argrelay.plugin_interp.FuncTreeInterpFactoryConfigSchema import func_tree_interp_config_desc
 from argrelay.runtime_data.ClientConfig import ClientConfig
-from argrelay.schema_config_core_client.ClientConfigSchema import client_config_desc, connection_config_
+from argrelay.schema_config_core_client.ClientConfigSchema import client_config_desc, redundant_servers_
 from argrelay.schema_config_core_client.ConnectionConfigSchema import (
     connection_config_desc,
     server_host_name_,
@@ -212,13 +212,17 @@ class ThisTestClass(BaseTestClass):
         client_config: ClientConfig = client_config_desc.obj_from_yaml_str(
             f"""
             {{
-                "{connection_config_}": {{
-                    "{server_host_name_}": "localhost",
-                    "{server_port_number_}": 8787,
-                }}
+                "{redundant_servers_}": [
+                    {{
+                        "{server_host_name_}": "localhost",
+                        "{server_port_number_}": 8787,
+                    }}
+                ]
             }}
             """
         )
+        # Checking only one server index:
+        server_index = 0
         self.assertEqual(
             client_config.use_local_requests,
             False,
@@ -228,11 +232,11 @@ class ThisTestClass(BaseTestClass):
             True,
         )
         self.assertEqual(
-            client_config.connection_config.server_host_name,
+            client_config.redundant_servers[server_index].server_host_name,
             DEFAULT_IP_ADDRESS,
         )
         self.assertEqual(
-            client_config.connection_config.server_port_number,
+            client_config.redundant_servers[server_index].server_port_number,
             DEFAULT_PORT_NUMBER,
         )
         self.assertEqual(

--- a/var/.gitignore
+++ b/var/.gitignore
@@ -2,3 +2,6 @@
 # Used by `@/exe/relay_demo.bash`:
 /relay_demo.bash.pid
 
+# See FS_93_18_57_91 client fail over to redundant servers:
+/argrelay_client.server_index
+


### PR DESCRIPTION
*   Update client config schema to support list of servers.
*   Implement round-robin client-side fail over list of servers.
*   Spec `FS_93_18_57_91.client_fail_over_to_redundant_servers.md`.
*   Fix `enum` delegator on invocation.
*   Use separate section of `@/conf/argrelay_plugin.yaml` for `check_env` plugins.
*   Add `PluginCheckEnvDevShell` to report `ARGRELAY_DEV_SHELL` value.
*   Add `PluginCheckEnvClientLinkedCommands` to report client-side linked commands.
*   Add `PluginCheckEnvOnlineMode` to report `online_mode` of `check_env`.
*   Add `PluginCheckEnvServerIndex` to report `server_index`.
*   Add `PluginCheckEnvServerUrl` to report server URL.
*   Spec `TODO_72_51_13_18.test_optimized_requests.md`.
