### PR TITLE
Improve `check_env` and add `usage_stats`

### DIFF
--- a/docs/feature_stories/FS_16_07_78_84.conf_dir_priority.md
+++ b/docs/feature_stories/FS_16_07_78_84.conf_dir_priority.md
@@ -21,6 +21,8 @@ It is selected based on priority:
     ls ${ARGRELAY_CONF_BASE_DIR}/argrelay_client.json
     ls ${ARGRELAY_CONF_BASE_DIR}/argrelay_server.yaml
     ls ${ARGRELAY_CONF_BASE_DIR}/argrelay_plugin.yaml
+    ls ${ARGRELAY_CONF_BASE_DIR}/check_env_plugin.conf.bash
+    ls ${ARGRELAY_CONF_BASE_DIR}/check_env_plugin.conf.yaml
     # ...
     ```
 
@@ -34,6 +36,8 @@ It is selected based on priority:
     ls ~/.argrelay.conf.d/argrelay_client.json
     ls ~/.argrelay.conf.d/argrelay_server.yaml
     ls ~/.argrelay.conf.d/argrelay_plugin.yaml
+    ls ~/.argrelay.conf.d/check_env_plugin.conf.bash
+    ls ~/.argrelay.conf.d/check_env_plugin.conf.yaml
     # ...
     ```
 
@@ -49,5 +53,7 @@ It is selected based on priority:
     ls conf/argrelay_client.json
     ls conf/argrelay_server.yaml
     ls conf/argrelay_plugin.yaml
+    ls conf/check_env_plugin.conf.bash
+    ls conf/check_env_plugin.conf.yaml
     # ...
     ```

--- a/docs/feature_stories/FS_36_17_84_44.check_env.md
+++ b/docs/feature_stories/FS_36_17_84_44.check_env.md
@@ -4,18 +4,51 @@ feature_title: check_env script
 feature_status: TEST
 ---
 
+# Purpose
+
+Shell environment is too flexible in config to rely on it blindly
+(e.g. it allows aliases to override any command).
+
+There should be a script to check automatically and report any issues with the setup (to support user easily).
+
 The script is supposed to provide single place to perform multi-level verification.
 
 This script may overlap with functions from FS_85_33_46_53 `bootstrap_env`.
 
 See also FS_86_73_43_45 server control scripts.
 
-It can start with checking:
+# Idea
+
+The set of checks to be performed should be open for extension by the target project.
+
+It can start as Bash code by checking:
 *   Python version
 *   `venv` existence
 *   `argrelay` package existence
+Then, it can continue as Python code by checking anything else.
 
-Then it jumps into checks implemented in Python (for testability) to verify:
+Guidelines:
+*   Bash part executes (preferably) things until it is confirmed that Python `venv` is ready to execute Python part.
+*   As much as possible, checks should be implemented in Python part (as it is easier to test this logic).
+
+# Implementation
+
+Entry point:
+*   It is started (both Bash and Python parts) by single script `@/exe/check_env.bash`.
+
+Config files:
+
+*   Plugins for Bash part are configured by `@/conf/check_env_plugin.conf.bash`.
+
+    The entries there are simply paths to scripts to run.
+
+*   Plugins for Python part are configured by `@/conf/check_env_plugin.conf.yaml`.
+
+    The entries there are the same as any other plugin but extend `PluginCheckEnvAbstract`.
+
+# Plans
+
+Checks:
 *   DONE: whether it is run under FS_58_61_77_69 `dev_shell`
 *   check whether debug enabled and which debug (p, s, ... etc.).
 *   whether `PATH` env var reaches client and server binaries

--- a/docs/feature_stories/FS_53_81_66_18.types_and_classes.md
+++ b/docs/feature_stories/FS_53_81_66_18.types_and_classes.md
@@ -9,4 +9,6 @@ feature_status: DONE
 
 *   Class = envelope class = indicates `envelope_payload` schema of one of the `data_envelope`-s.
 
-See also `FS_37_57_36_29`.
+See also:
+*   FS_37_57_36_29: containers, envelopes, payloads.
+*   TODO_66_66_75_78: Split `arg` to `prop` concepts.

--- a/docs/feature_stories/FS_57_36_37_48.multiple_clients_coexistence.md
+++ b/docs/feature_stories/FS_57_36_37_48.multiple_clients_coexistence.md
@@ -33,9 +33,10 @@ To make the feature work for `Alt+Shift+Q`, a map is used (see `argrelay_basenam
 But maps in Bash are not `export`-able and cannot be used
 to communicate from (outer) `@/exe/dev_shell.bash` to nested (inner) `@/exe/dev_shell.bash`.
 
-Current workaround is to use `@/conf/dev_shell_env.bash` (see FS_58_61_77_69 `dev_shell`), for example:
+Current workaround is to use `@/conf/dev_shell_env.bash` (see FS_58_61_77_69 `dev_shell`)
+to source more than one `shell_env.bash`, for example:
 ```
 source /path/to/argrelay/with/client_x/exe/shell_env.bash
 source /path/to/argrelay/with/client_y/exe/shell_env.bash
 ```
-This has to be configured manually per `argrelay` installation where extra command are required.
+This has to be configured manually per `argrelay` installation where extra commands are required.

--- a/docs/feature_stories/FS_87_02_77_34.usage_stats.md
+++ b/docs/feature_stories/FS_87_02_77_34.usage_stats.md
@@ -1,0 +1,95 @@
+---
+feature_story: FS_87_02_77_34
+feature_title: usage stats
+feature_status: TODO
+---
+
+# Purpose
+
+Accumulate usage stats persistent across server restarts.
+
+The data is collected on the server-side.
+
+# Implementation
+
+TODO: Implement: Client can set `send_usage_stats` to `true` in `ClientConfig`.
+
+TODO: Implement: Server can set `store_usage_stats` to `true`.
+
+Stats are collected in `@/var/usage_stats` on the server side.
+
+# Collected metadata
+
+The metadata can be collected from both server-side and client-side input.
+
+## Input attributes equivalent on both sides
+
+*   `${proc_side}_ts_ns`
+
+    Time stamp in nanoseconds since epoch.
+
+    *   Client: request preparation time.
+    *   Server: request arrival time.
+
+*   `${proc_side}_conf_target`
+
+    Path where `@/conf` symlink points to.
+
+*   `${proc_side}_version`
+
+    Version of `argrelay` package.
+
+    After TODO_78_94_31_68: splitting `argrelay` into multiple packages,
+    server-side and client-side may need to specify different packages. 
+
+## Server-side input attributes
+
+*   `server_ts_ns`
+
+    See `${proc_side}_ts_ns`.
+
+*   `server_conf_target`
+
+    See `${proc_side}_conf_target`.
+
+    TODO: Implement. Or do we need it if it is constant for a given server?
+          But, at least, it makes sense to keep it in schema for cases when
+          usage stats from multiple servers are combined.
+
+*   `func_id`
+
+    TODO: Implement: This should report selected `func_id` (which may not be available until it is done).
+
+## Client-side input attributes
+
+*   `client_ts_ns`
+
+    See `${proc_side}_ts_ns`.
+
+*   `client_version`
+
+    See `${proc_side}_version`.
+
+*   `client_conf_target`
+
+    See `${proc_side}_conf_target`.
+
+*   `client_user_id`
+
+    See `client_user_id` from `CallContext`.
+
+*   `server_action`
+
+    See `server_action` from `CallContext`.
+
+*   `command_line`
+
+    See `command_line` from `CallContext`.
+
+*   `cursor_cpos`
+
+    See `cursor_cpos` from `CallContext`.
+
+*   `comp_scope`
+
+    See `comp_scope` from `CallContext`.

--- a/docs/task_refs/TODO_66_66_75_78.split_arg_and_prop_concepts.md
+++ b/docs/task_refs/TODO_66_66_75_78.split_arg_and_prop_concepts.md
@@ -9,3 +9,6 @@ Split "arg" group of concepts (`arg_value`, `arg_type`) and "prop" group of conc
 *   `command_line` args are mapped to `data_envelope` props and almost identical
 *   BUT: they are not naturally/intuitively inter-change-able as `data_envelope` properties are hardly `command_line` arguments.
 *   Maybe write doc on bounded contexts? Add dictionaries (ubiquitous language) per bash, client, server, data backend?
+
+See also:
+*   FS_53_81_66_18: types and classes

--- a/docs/task_refs/TODO_69_59_78_78.register_known_files_as_enum_with_metadata.md
+++ b/docs/task_refs/TODO_69_59_78_78.register_known_files_as_enum_with_metadata.md
@@ -1,0 +1,6 @@
+
+TODO: TODO_69_59_78_78: register known files as enum with metadata
+
+It is easier to keep search where they are used via IDE.
+Plus, it will provide common methods (like getting abs bath based on `argrelay_dir`).
+

--- a/dst/.github/argrelay.bootstrap.bash
+++ b/dst/.github/argrelay.bootstrap.bash
@@ -58,6 +58,9 @@ do
 
             "${argrelay_dir}/exe/bootstrap_env.bash"
 
+            # Run selected set of tests:
+            "${argrelay_dir}/dst/.github/run_build_tests.bash"
+
             # Script `check_env` should succeed after bootstrap:
             "${argrelay_dir}/exe/check_env.bash" "offline"
 
@@ -66,6 +69,9 @@ do
                 ":(exclude)dst/.github/argrelay_client.json" \
                 ":(exclude)dst/.github/argrelay_server.yaml" \
                 ":(exclude)dst/.github/argrelay_plugin.yaml" \
+                ":(exclude)dst/.github/check_env_plugin.conf.bash" \
+                ":(exclude)dst/.github/check_env_plugin.conf.yaml" \
+
 
         ;;
         "fail_on_conf_mismatch")
@@ -81,6 +87,8 @@ do
                 ":(exclude)dst/.github/argrelay_client.json" \
                 ":(exclude)dst/.github/argrelay_server.yaml" \
                 ":(exclude)dst/.github/argrelay_plugin.yaml" \
+                ":(exclude)dst/.github/check_env_plugin.conf.bash" \
+                ":(exclude)dst/.github/check_env_plugin.conf.yaml" \
 
         ;;
         "reset_conf")
@@ -93,6 +101,8 @@ do
                 ":(exclude)dst/.github/argrelay_client.json" \
                 ":(exclude)dst/.github/argrelay_server.yaml" \
                 ":(exclude)dst/.github/argrelay_plugin.yaml" \
+                ":(exclude)dst/.github/check_env_plugin.conf.bash" \
+                ":(exclude)dst/.github/check_env_plugin.conf.yaml" \
 
         ;;
         "succeed_on_conf_match")
@@ -104,6 +114,8 @@ do
                 ":(exclude)dst/.github/argrelay_client.json" \
                 ":(exclude)dst/.github/argrelay_server.yaml" \
                 ":(exclude)dst/.github/argrelay_plugin.yaml" \
+                ":(exclude)dst/.github/check_env_plugin.conf.bash" \
+                ":(exclude)dst/.github/check_env_plugin.conf.yaml" \
 
         ;;
         *)

--- a/dst/.github/run_build_tests.bash
+++ b/dst/.github/run_build_tests.bash
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# This script executes sub-set of tests suitable for CI.
+
+# Debug: Print commands before execution:
+set -x
+# Debug: Print commands after reading from a script:
+set -v
+# Return non-zero exit code from commands within a pipeline:
+set -o pipefail
+# Exit on non-zero exit code from a command:
+set -e
+# Inherit trap on ERR by sub-shells:
+set -E
+# Error on undefined variables:
+set -u
+
+# Not running `tox` as it expects all Python versions present
+# within the environment while CI environments may have only one of
+# the Python versions per runner (each runner runs with its own
+# Python version, not all) and we are not selecting them
+# for `tox` conditionally.
+# Instead, run some selected tests which do not need extra dependencies
+# (e.g. do not run `gui_tests`):
+# TODO: TODO_04_84_79_11: Re-group tests to
+#       exclude truly online (going to Internet, but do not exclude end to end, for example):
+for test_group in \
+offline_tests \
+release_tests \
+slow_tests \
+
+do
+    ./exe/dev_shell.bash ./exe/run_max_tests.bash ./tests/"${test_group}"
+done

--- a/dst/client_a/.gitignore
+++ b/dst/client_a/.gitignore
@@ -4,4 +4,6 @@
 /argrelay_client.json
 /argrelay_server.yaml
 /argrelay_plugin.yaml
+/check_env_plugin.conf.bash
+/check_env_plugin.conf.yaml
 

--- a/dst/client_b/.gitignore
+++ b/dst/client_b/.gitignore
@@ -4,3 +4,6 @@
 /argrelay_client.json
 /argrelay_server.yaml
 /argrelay_plugin.yaml
+/check_env_plugin.conf.bash
+/check_env_plugin.conf.yaml
+

--- a/dst/relay_demo/.gitignore
+++ b/dst/relay_demo/.gitignore
@@ -4,3 +4,6 @@
 /argrelay_client.json
 /argrelay_server.yaml
 /argrelay_plugin.yaml
+/check_env_plugin.conf.bash
+/check_env_plugin.conf.yaml
+

--- a/dst/release_env/.gitignore
+++ b/dst/release_env/.gitignore
@@ -4,3 +4,6 @@
 /argrelay_client.json
 /argrelay_server.yaml
 /argrelay_plugin.yaml
+/check_env_plugin.conf.bash
+/check_env_plugin.conf.yaml
+

--- a/exe/.gitignore
+++ b/exe/.gitignore
@@ -16,4 +16,7 @@
 /dev_shell.bash
 /init_shell_env.bash
 /upgrade_env_packages.bash
+/script_plugin.d/check_env_plugin.all_plugins.bash
+/script_plugin.d/check_env_plugin.bash_version.bash
+
 

--- a/exe/build_project.bash
+++ b/exe/build_project.bash
@@ -5,21 +5,6 @@
 # Python `venv` is already activated before it is sourced.
 
 # Normally, the build scripts like this for integration project should build it and test it.
-
-# Not running `tox` as it expects all Python versions present
-# within the environment while CI environments may have only one of
-# the Python versions per runner (each runner runs with its own
-# Python version, not all) and we are not selecting them
-# for `tox` conditionally.
-# Instead, run some selected tests which do not need extra dependencies
-# (e.g. do not run `gui_tests`):
-# TODO_04_84_79_11: Re-group tests to exclude truly online (going to Internet, but do not exclude end to end, for example):
-for test_group in \
-offline_tests \
-release_tests \
-slow_tests
-do
-    ./exe/dev_shell.bash ./exe/run_max_tests.bash ./tests/"${test_group}"
-done
+true
 
 ########################################################################################################################

--- a/exe/config_files.conf.bash
+++ b/exe/config_files.conf.bash
@@ -4,7 +4,7 @@
 # It is *sourced* by `@/exe/bootstrap_env.bash` to configure `module_path_file_tuples` below.
 
 # Tuples specifying config files, format:
-# module_name relative_dir_path config_file_name
+# module_name module_dir_src_path argrelay_dir_dst_path
 # shellcheck disable=SC2034
 module_path_file_tuples=(
     # Note: a project integrating `argrelay` must provide its own set of
@@ -12,9 +12,11 @@ module_path_file_tuples=(
     #       Integration assumes different plugins, their configs, etc.
 
     # For example:
-    argrelay sample_conf argrelay_client.json
-    argrelay sample_conf argrelay_server.yaml
-    argrelay sample_conf argrelay_plugin.yaml
+    argrelay sample_conf/argrelay_client.json conf/argrelay_client.json
+    argrelay sample_conf/argrelay_server.yaml conf/argrelay_server.yaml
+    argrelay sample_conf/argrelay_plugin.yaml conf/argrelay_plugin.yaml
+    argrelay sample_conf/check_env_plugin.conf.bash conf/check_env_plugin.conf.bash
+    argrelay sample_conf/check_env_plugin.conf.yaml conf/check_env_plugin.conf.yaml
 )
 ########################################################################################################################
 

--- a/exe/resource_files.conf.bash
+++ b/exe/resource_files.conf.bash
@@ -4,14 +4,16 @@
 # It is *sourced* by `@/exe/bootstrap_env.bash` to configure `module_path_file_tuples` below.
 
 # Tuples specifying resource files, format:
-# module_name relative_dir_path resource_file_name
+# module_name module_dir_src_path argrelay_dir_dst_path
 # shellcheck disable=SC2034
 module_path_file_tuples=(
-    argrelay custom_integ_res argrelay_common_lib.bash
-    argrelay custom_integ_res shell_env.bash
-    argrelay custom_integ_res check_env.bash
-    argrelay custom_integ_res dev_shell.bash
-    argrelay custom_integ_res init_shell_env.bash
-    argrelay custom_integ_res upgrade_env_packages.bash
+    argrelay custom_integ_res/argrelay_common_lib.bash exe/argrelay_common_lib.bash
+    argrelay custom_integ_res/shell_env.bash exe/shell_env.bash
+    argrelay custom_integ_res/check_env.bash exe/check_env.bash
+    argrelay custom_integ_res/dev_shell.bash exe/dev_shell.bash
+    argrelay custom_integ_res/init_shell_env.bash exe/init_shell_env.bash
+    argrelay custom_integ_res/upgrade_env_packages.bash exe/upgrade_env_packages.bash
+    argrelay custom_integ_res/script_plugin.d/check_env_plugin.all_plugins.bash exe/script_plugin.d/check_env_plugin.all_plugins.bash
+    argrelay custom_integ_res/script_plugin.d/check_env_plugin.bash_version.bash exe/script_plugin.d/check_env_plugin.bash_version.bash
 )
 ########################################################################################################################

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,18 @@
 import os
 
+import re
+
+# Implements this:
+# https://stackoverflow.com/a/7071358/441652
+version_file = "src/argrelay/_version.py"
+version_content = open(version_file, "rt").read()
+version_regex = r"^__version__ = ['\"]([^'\"]*)['\"]"
+regex_match = re.search(version_regex, version_content, re.M)
+if regex_match:
+    version_string = regex_match.group(1)
+else:
+    raise RuntimeError(f"Unable to find version string: ${version_file}")
+
 import setuptools
 
 tests_require = [
@@ -35,8 +48,7 @@ def list_dir(
 
 setuptools.setup(
     name = "argrelay",
-    # See `docs/dev_notes/version_format.md`:
-    version = "0.7.10",
+    version = version_string,
     author = "uvsmtid",
     author_email = "uvsmtid@gmail.com",
     description = "Tab-completion & data search server = total recall for Bash shell",
@@ -94,10 +106,12 @@ See: https://github.com/argrelay/argrelay
     package_data = {
         "argrelay": [
 
-            # config files:
+            # Config files:
             "sample_conf/argrelay_client.json",
             "sample_conf/argrelay_server.yaml",
             "sample_conf/argrelay_plugin.yaml",
+            "sample_conf/check_env_plugin.conf.bash",
+            "sample_conf/check_env_plugin.conf.yaml",
 
             # GUI client:
             "relay_server/gui_static/argrelay_client.js",
@@ -106,7 +120,7 @@ See: https://github.com/argrelay/argrelay
             "relay_server/gui_static/external_link.svg",
             "relay_server/gui_templates/argrelay_main.html",
 
-            # other resource files:
+            # Other resource files:
             "custom_integ_res/argrelay_common_lib.bash",
             "custom_integ_res/shell_env.bash",
             "custom_integ_res/bootstrap_env.bash",
@@ -114,6 +128,10 @@ See: https://github.com/argrelay/argrelay
             "custom_integ_res/dev_shell.bash",
             "custom_integ_res/init_shell_env.bash",
             "custom_integ_res/upgrade_env_packages.bash",
+
+            # Files in `script_plugin.d`:
+            "custom_integ_res/script_plugin.d/check_env_plugin.all_plugins.bash",
+            "custom_integ_res/script_plugin.d/check_env_plugin.bash_version.bash",
 
         ],
         "argrelay_docs": list_dir("./docs/") + [

--- a/src/argrelay/__init__.py
+++ b/src/argrelay/__init__.py
@@ -1,2 +1,4 @@
 """
 """
+
+from argrelay._version import __version__

--- a/src/argrelay/_version.py
+++ b/src/argrelay/_version.py
@@ -1,0 +1,5 @@
+
+# See `docs/dev_notes/version_format.md`:
+# Implements this:
+# https://stackoverflow.com/a/7071358/441652
+__version__ = "0.7.11"

--- a/src/argrelay/check_env/PluginCheckEnvArgrelayLocalVersionMismatch.py
+++ b/src/argrelay/check_env/PluginCheckEnvArgrelayLocalVersionMismatch.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+from typing import Union
+
+import argrelay
+from argrelay.check_env.CheckEnvResult import CheckEnvResult
+from argrelay.check_env.PluginCheckEnvAbstract import PluginCheckEnvAbstract
+from argrelay.enum_desc.ResultCategory import ResultCategory
+from argrelay.misc_helper_common import get_argrelay_dir
+
+
+class PluginCheckEnvArgrelayLocalVersionMismatch(PluginCheckEnvAbstract):
+    """
+    Plugin reports mismatch between
+    *   `argrelay.__version__`
+    *   version in `@/conf/env_packages.txt`
+    """
+
+    # TODO: TODO_69_59_78_78: register known files as enum with metadata:
+    file_rel_path = "conf/env_packages.txt"
+    bootstrap_rel_path = "exe/bootstrap_env.bash"
+    result_key = "env_packages_version"
+
+    # noinspection PyMethodMayBeStatic
+    def execute_check(
+        self,
+        online_mode: Union[bool, None],
+    ) -> list[CheckEnvResult]:
+        module_version = argrelay.__version__
+        env_packages_version = self.get_env_packages_version()
+        if env_packages_version is None:
+            return [CheckEnvResult(
+                result_category = ResultCategory.VerificationWarning,
+                result_key = self.result_key,
+                result_value = env_packages_version,
+                result_message = f"file `@/{self.file_rel_path}` does not contain `argrelay` package => is it installed in editable mode?",
+            )]
+        else:
+            if env_packages_version == module_version:
+                return [CheckEnvResult(
+                    result_category = ResultCategory.VerificationSuccess,
+                    result_key = self.result_key,
+                    result_value = env_packages_version,
+                    result_message = f"matches `argrelay_module_version`",
+                )]
+            else:
+                return [CheckEnvResult(
+                    result_category = ResultCategory.VerificationFailure,
+                    result_key = self.result_key,
+                    result_value = env_packages_version,
+                    result_message = f"does not match `argrelay_module_version` => re-base and re-run `@/{self.bootstrap_rel_path}`",
+                )]
+
+    def get_env_packages_version(
+        self,
+    ):
+        file_content = open(f"{get_argrelay_dir()}/{self.file_rel_path}", "rt").read()
+        version_regex = r"^argrelay==(.*)$"
+        regex_match = re.search(version_regex, file_content, re.M)
+        if regex_match:
+            return regex_match.group(1).strip()
+        else:
+            return None

--- a/src/argrelay/check_env/PluginCheckEnvClientLinkedCommands.py
+++ b/src/argrelay/check_env/PluginCheckEnvClientLinkedCommands.py
@@ -13,7 +13,13 @@ from argrelay.misc_helper_common import get_argrelay_dir
 
 class PluginCheckEnvClientLinkedCommands(PluginCheckEnvAbstract):
     """
-    This plugin lists values of `argrelay_bind_command_basenames` shell variable
+    This plugin checks which `argrelay_dir` client each command is linked.
+
+    This is related to FS_57_36_37_48 multiple clients coexistence.
+
+    It loops through values keys of `argrelay_basename_to_client_path_map` shell variable
+    (which is supposed to map each linked command to a client with potentially different `argrelay_dir`).
+    Then, it verifies `argrelay_dir` of the mapped client with the `argrelay_dir` of currently running process.
     """
 
     shell_var_name: str = "argrelay_bind_command_basenames"
@@ -23,18 +29,18 @@ class PluginCheckEnvClientLinkedCommands(PluginCheckEnvAbstract):
         self,
         online_mode: Union[bool, None],
     ) -> list[CheckEnvResult]:
-        conf_file_path = os.path.join(
+        dev_shell_path = os.path.join(
             get_argrelay_dir(),
-            TopDir.conf_dir.value,
-            "shell_env.conf.bash",
+            TopDir.exe_dir.value,
+            "dev_shell.bash",
         )
         shell_var_value = None
         try:
             bash_proc = subprocess.run(
                 args = [
-                    "bash",
-                    "-c",
-                    f"source {conf_file_path} ; echo ${{argrelay_bind_command_basenames[@]}}",
+                    dev_shell_path,
+                    # f"echo ${{argrelay_bind_command_basenames[@]}}",
+                    f"echo ${{!argrelay_basename_to_client_path_map[@]}}",
                 ],
                 capture_output = True,
             )
@@ -49,17 +55,50 @@ class PluginCheckEnvClientLinkedCommands(PluginCheckEnvAbstract):
                 result_category = ResultCategory.ExecutionFailure,
                 result_key = "client_linked_command",
                 result_value = str(shell_var_value),
-                result_message = f"unable to retrieve values of `argrelay_bind_command_basenames` from: {conf_file_path}",
+                result_message = f"unable to retrieve keys of `argrelay_bind_command_basenames` under started: {dev_shell_path}",
             )]
         else:
             linked_commands: list[str] = shell_var_value.split()
             check_env_results: list[CheckEnvResult] = []
             for command_index, linked_command in enumerate(linked_commands):
-                check_env_results.append(CheckEnvResult(
-                    result_category = ResultCategory.VerificationSuccess,
-                    result_key = f"client_linked_command[{command_index}]",
-                    result_value = str(linked_command),
-                    # result_message = f"run for more info: complete -p {linked_command}",
-                    result_message = None,
-                ))
+
+                shell_var_value = None
+                try:
+                    bash_proc = subprocess.run(
+                        args = [
+                            dev_shell_path,
+                            f"echo ${{argrelay_basename_to_client_path_map[{linked_command}]}}",
+                        ],
+                        capture_output = True,
+                    )
+                    assert bash_proc.returncode == 0
+                    stdout_str = bash_proc.stdout.decode("utf-8")
+                    shell_var_value = stdout_str.strip()
+                except:
+                    shell_var_value = None
+
+                if shell_var_value is None:
+                    check_env_results.append(CheckEnvResult(
+                        result_category = ResultCategory.ExecutionFailure,
+                        result_key = f"client_linked_command[{command_index}]",
+                        result_value = str(linked_command),
+                        result_message = f"Unable to map `{linked_command}` to `@/exe/run_argrelay_client`",
+                    ))
+                else:
+                    argrelay_client_path = shell_var_value
+                    if argrelay_client_path == f"{get_argrelay_dir()}/exe/run_argrelay_client":
+                        check_env_results.append(CheckEnvResult(
+                            result_category = ResultCategory.VerificationSuccess,
+                            result_key = f"client_linked_command[{command_index}]",
+                            result_value = str(linked_command),
+                            result_message = "Command is linked to `@/exe/run_argrelay_client` from this `argrelay_dir`",
+                        ))
+                    else:
+                        check_env_results.append(CheckEnvResult(
+                            result_category = ResultCategory.VerificationWarning,
+                            result_key = f"client_linked_command[{command_index}]",
+                            result_value = str(linked_command),
+                            result_message = f"Command is linked to another `argrelay_dir` with: {argrelay_client_path}",
+                        ))
+
             return check_env_results

--- a/src/argrelay/check_env/PluginCheckEnvModuleVersion.py
+++ b/src/argrelay/check_env/PluginCheckEnvModuleVersion.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Union
+
+import argrelay
+from argrelay.check_env.CheckEnvResult import CheckEnvResult
+from argrelay.check_env.PluginCheckEnvAbstract import PluginCheckEnvAbstract
+from argrelay.enum_desc.ResultCategory import ResultCategory
+
+
+class PluginCheckEnvModuleVersion(PluginCheckEnvAbstract):
+    """
+    Trivial plugin to report `argrelay.__version__`.
+    """
+
+    # noinspection PyMethodMayBeStatic
+    def execute_check(
+        self,
+        online_mode: Union[bool, None],
+    ) -> list[CheckEnvResult]:
+        return [CheckEnvResult(
+            result_category = ResultCategory.VerificationSuccess,
+            result_key = "argrelay_module_version",
+            result_value = argrelay.__version__,
+            result_message = None,
+        )]

--- a/src/argrelay/check_env/PluginCheckEnvServerIndex.py
+++ b/src/argrelay/check_env/PluginCheckEnvServerIndex.py
@@ -7,7 +7,8 @@ from argrelay.check_env.CheckEnvResult import CheckEnvResult
 from argrelay.check_env.PluginCheckEnvAbstract import PluginCheckEnvAbstract
 from argrelay.client_command_remote.ClientCommandRemoteWorkerAbstract import (
     get_server_index_file_path,
-    load_server_index, server_index_file_name,
+    load_server_index,
+    server_index_file_name,
 )
 from argrelay.enum_desc.ResultCategory import ResultCategory
 from argrelay.enum_desc.TopDir import TopDir

--- a/src/argrelay/check_env/PluginCheckEnvServerResponseValueCommitId.py
+++ b/src/argrelay/check_env/PluginCheckEnvServerResponseValueCommitId.py
@@ -53,12 +53,12 @@ class PluginCheckEnvServerResponseValueCommitId(PluginCheckEnvServerResponseValu
                     result_category = ResultCategory.VerificationSuccess,
                     result_key = field_name,
                     result_value = field_value[:_commit_id_display_length],
-                    result_message = f"server commit id matches client one [{client_commit_id[:_commit_id_display_length]}]",
+                    result_message = f"runtime server commit id matches client one [{client_commit_id[:_commit_id_display_length]}]",
                 )
             else:
                 return CheckEnvResult(
                     result_category = ResultCategory.VerificationWarning,
                     result_key = field_name,
                     result_value = field_value[:_commit_id_display_length],
-                    result_message = f"server commit id does not match client one [{client_commit_id[:_commit_id_display_length]}]",
+                    result_message = f"runtime server commit id does not match client one [{client_commit_id[:_commit_id_display_length]}]",
                 )

--- a/src/argrelay/check_env/PluginCheckEnvServerResponseValueVersion.py
+++ b/src/argrelay/check_env/PluginCheckEnvServerResponseValueVersion.py
@@ -1,0 +1,50 @@
+import argrelay
+from argrelay.check_env.CheckEnvResult import CheckEnvResult
+from argrelay.check_env.PluginCheckEnvServerResponseValueAbstract import PluginCheckEnvServerResponseValueAbstract
+from argrelay.custom_integ.SchemaPluginCheckEvnServerResponseValueAbstract import field_values_to_command_lines_
+from argrelay.custom_integ.git_utils import is_git_repo, get_full_commit_id
+from argrelay.enum_desc.CheckEnvField import CheckEnvField
+from argrelay.enum_desc.ResultCategory import ResultCategory
+from argrelay.misc_helper_common import get_argrelay_dir
+
+
+class PluginCheckEnvServerResponseValueVersion(PluginCheckEnvServerResponseValueAbstract):
+
+    # TODO: TODO_69_59_78_78: register known files as enum with metadata:
+    bootstrap_rel_path = "exe/bootstrap_env.bash"
+
+    def __init__(
+        self,
+        plugin_instance_id: str,
+        plugin_config_dict: dict,
+    ):
+        super().__init__(
+            plugin_instance_id,
+            plugin_config_dict = plugin_config_dict or {
+                field_values_to_command_lines_: {
+                    CheckEnvField.server_version.name: "argrelay.check_env server_version",
+                },
+            },
+        )
+
+    def verify_online_value(
+        self,
+        field_name: str,
+        field_value,
+    ) -> CheckEnvResult:
+        client_version = argrelay.__version__
+
+        if client_version == field_value:
+            return CheckEnvResult(
+                result_category = ResultCategory.VerificationSuccess,
+                result_key = field_name,
+                result_value = field_value,
+                result_message = f"matches client `argrelay_module_version`",
+            )
+        else:
+            return CheckEnvResult(
+                result_category = ResultCategory.VerificationWarning,
+                result_key = field_name,
+                result_value = field_value,
+                result_message = f"does not match client `argrelay_module_version` => re-base and re-run `@/{self.bootstrap_rel_path}`",
+            )

--- a/src/argrelay/check_env/__main__.py
+++ b/src/argrelay/check_env/__main__.py
@@ -14,8 +14,10 @@ from argrelay.enum_desc.PluginType import PluginType
 from argrelay.enum_desc.ResultCategory import ResultCategory
 from argrelay.enum_desc.TermColor import TermColor
 from argrelay.runtime_context.PluginClientAbstract import instantiate_client_plugin
+from argrelay.runtime_data.CheckEnvPluginConfig import CheckEnvPluginConfig
 from argrelay.runtime_data.PluginConfig import PluginConfig
 from argrelay.runtime_data.PluginEntry import PluginEntry
+from argrelay.schema_config_plugin.CheckEnvPluginConfigSchema import check_env_plugin_config_desc
 from argrelay.schema_config_plugin.PluginConfigSchema import plugin_config_desc
 
 # Standard color scheme has to be synced with `@/exe/check_env.bash`:
@@ -51,7 +53,7 @@ def main():
     else:
         online_mode = None
 
-    plugin_config: PluginConfig = plugin_config_desc.obj_from_default_file()
+    plugin_config: CheckEnvPluginConfig = check_env_plugin_config_desc.obj_from_default_file()
 
     total_success: bool = True
 

--- a/src/argrelay/client_command_remote/ClientCommandRemoteWorkerTextProposeArgValuesOptimized.py
+++ b/src/argrelay/client_command_remote/ClientCommandRemoteWorkerTextProposeArgValuesOptimized.py
@@ -1,5 +1,4 @@
 import json
-import os
 import socket
 
 from argrelay.client_command_remote.ClientCommandRemoteWorkerAbstract import ClientCommandRemoteWorkerAbstract
@@ -52,12 +51,15 @@ class ClientCommandRemoteWorkerTextProposeArgValuesOptimized(ClientCommandRemote
 
         request_body_str = (f"""\
 {{
+    "client_version": {json.dumps(self.call_ctx.client_version)},
+    "client_conf_target": {json.dumps(self.call_ctx.client_conf_target)},
     "server_action": "{self.call_ctx.server_action.name}",
     "command_line": {json.dumps(self.call_ctx.command_line)},
     "cursor_cpos": {self.call_ctx.cursor_cpos},
     "comp_scope": "{self.call_ctx.comp_scope.name}",
-    "client_pid": "{os.getpid()}",
-    "is_debug_enabled": "{'true' if self.call_ctx.is_debug_enabled else 'false'}"
+    "client_uid": {json.dumps(self.call_ctx.client_uid)},
+    "client_pid": {self.call_ctx.client_pid},
+    "is_debug_enabled": {'true' if self.call_ctx.is_debug_enabled else 'false'}
 }}
 """)
         request_body_len = len(request_body_str.encode())

--- a/src/argrelay/client_command_remote/exception_utils.py
+++ b/src/argrelay/client_command_remote/exception_utils.py
@@ -1,0 +1,36 @@
+
+class ServerResponseError(Exception):
+    """
+    Exception for failed server responses.
+
+    It is related to `ClientExitCode.ServerError`.
+
+    Specifically, it is NOT connection error.
+    """
+
+    pass
+
+def print_full_stack_trace():
+    """
+    Print full stack trace equivalent to not catching exception.
+
+    Somehow Python does not have standard function
+    (only stack trace to current line and stack trace for exception from current caller)
+    which requires implementations like these:
+    https://stackoverflow.com/a/16589622/441652
+    """
+    import traceback, sys
+    exception_obj = sys.exc_info()[0]
+    # Remove curr func frame:
+    caller_stack = traceback.extract_stack()[:-1]
+    if exception_obj is not None:
+        # Remove curr func frame:
+        del caller_stack[-1]
+    head_message = "Traceback (most recent call last):\n"
+    caller_stack_str = head_message + "".join(traceback.format_list(caller_stack))
+    if exception_obj is not None:
+        exception_stack_str = traceback.format_exc().lstrip(head_message)
+        full_stack_str = caller_stack_str + exception_stack_str
+    else:
+        full_stack_str = caller_stack_str
+    print(full_stack_str, file = sys.stderr)

--- a/src/argrelay/custom_integ_res/check_env.bash
+++ b/src/argrelay/custom_integ_res/check_env.bash
@@ -137,27 +137,32 @@ echo -e "${success_color}INFO:${reset_style} ${field_color}python_version:${rese
 source "${argrelay_dir}/exe/argrelay_common_lib.bash"
 
 ########################################################################################################################
-# TODO: Rename this to `argrelay_pip_version` and add `argrelay_module_version` which is obtained via Python part from internal module variable.
-# Report `argrelay_version`:
+# TODO: Add `argrelay_module_version` which is obtained via Python part from internal module variable.
+# Report `argrelay_pip_version`:
 set +e
-argrelay_version="$( pip show argrelay | grep '^Version:' | cut -f2 -d' ' )"
+argrelay_pip_version="$( pip show argrelay | grep '^Version:' | cut -f2 -d' ' )"
 exit_code="${?}"
 set -e
 if [[ "${exit_code}" != "0" ]]
 then
-    echo -e "${failure_color}ERROR:${reset_style} ${field_color}argrelay_version:${reset_style} ${failure_message}# unable to detect version of \`argrelay\` package via \`pip show argrelay\`${reset_style}"
+    echo -e "${failure_color}ERROR:${reset_style} ${field_color}argrelay_pip_version:${reset_style} ${failure_message}# unable to detect version of \`argrelay\` package via \`pip show argrelay\`${reset_style}"
     exit 1
 fi
-# Check if `argrelay_version` string matches semver version format:
+# Check if `argrelay_pip_version` string matches semver version format:
 # https://stackoverflow.com/a/72900791/441652
 # But semver version format is not compatible (conflicts) with - see: `docs/dev_notes/version_format.md`.
 # Using simplified regex to see if version looks like version:
-if [[ ! "${argrelay_version}" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+.*$ ]]
+if [[ ! "${argrelay_pip_version}" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+.*$ ]]
 then
-    echo -e "${failure_color}ERROR:${reset_style} ${field_color}argrelay_version:${reset_style} ${failure_message}# \`argrelay_version\` does not match version format: ${argrelay_version}${reset_style}"
+    echo -e "${failure_color}ERROR:${reset_style} ${field_color}argrelay_pip_version:${reset_style} ${failure_message}# \`argrelay_pip_version\` does not match version format: ${argrelay_pip_version}${reset_style}"
     exit 1
 fi
-echo -e "${success_color}INFO:${reset_style} ${field_color}argrelay_version:${reset_style} ${argrelay_version}"
+echo -e "${success_color}INFO:${reset_style} ${field_color}argrelay_pip_version:${reset_style} ${argrelay_pip_version}"
+
+########################################################################################################################
+# Run all `check_env_plugin.*`:
+
+source "${argrelay_dir}/conf/check_env_plugin.conf.bash"
 
 ########################################################################################################################
 # Switch to Python:

--- a/src/argrelay/custom_integ_res/dev_shell.bash
+++ b/src/argrelay/custom_integ_res/dev_shell.bash
@@ -80,18 +80,17 @@ cd "${argrelay_dir}" || exit 1
 ARGRELAY_DEV_SHELL="$(date)"
 export ARGRELAY_DEV_SHELL
 
-echo -e "${banner_color}INFO: keep starting nested \`@/exe/dev_shell.bash\` on demand or \`source\` this config by default in \`~/.bashrc\`: ${argrelay_dir}/exe/shell_env.bash${reset_color}" 1>&2
-
 # The new shell executes `@/exe/init_shell_env.bash` script as its init file:
 # https://serverfault.com/questions/368054
 # Use `exec` to replace current process:
 if [[ "$#" -eq "0" ]]
 then
     # Interactive:
+    echo -e "${banner_color}INFO: keep starting nested \`@/exe/dev_shell.bash\` on demand or \`source\` this config by default in \`~/.bashrc\`: ${argrelay_dir}/exe/shell_env.bash${reset_color}" 1>&2
     exec bash --init-file <( echo "source ~/.bashrc && source ${argrelay_dir}/exe/init_shell_env.bash" )
 else
     # Non-interactive:
     # All args passed to `@/exe/dev_shell.bash` are executed as command line:
-    exec bash --init-file <( echo "source ~/.bashrc && source ${argrelay_dir}/exe/init_shell_env.bash" ) -i -c "${*}"
+    exec bash -c "source ~/.bashrc && source ${argrelay_dir}/exe/init_shell_env.bash && ( ${*} )"
 fi
 

--- a/src/argrelay/custom_integ_res/init_shell_env.bash
+++ b/src/argrelay/custom_integ_res/init_shell_env.bash
@@ -82,17 +82,6 @@ fi
 # Enable auto-completion:
 source "${argrelay_dir}/exe/shell_env.bash"
 
-if [[ -f "${argrelay_dir}/var/argrelay_client.server_index" ]]
-then
-    server_index="$( cat "${argrelay_dir}/var/argrelay_client.server_index" )"
-else
-    server_index="0"
-fi
-
-# TODO: FS_16_07_78_84: respect conf dir priority:
-server_host_name="$( jq --raw-output ".redundant_servers[${server_index}].server_host_name" "${argrelay_dir}/conf/argrelay_client.json" )"
-server_port_number="$( jq --raw-output ".redundant_servers[${server_index}].server_port_number" "${argrelay_dir}/conf/argrelay_client.json" )"
-
 eval "${init_shell_env_old_opts}"
 unset init_shell_env_old_opts
 
@@ -100,11 +89,27 @@ unset init_shell_env_old_opts
 # shellcheck disable=SC2154
 eval "${ARGRELAY_USER_SHELL_OPTS}"
 
-# This is a basic info normally reported by FS_36_17_84_44 `check_env` script:
-echo -e "\
+if [[ $- == *i* ]]
+then
+    # Interactive shell.
+
+    if [[ -f "${argrelay_dir}/var/argrelay_client.server_index" ]]
+    then
+        server_index="$( cat "${argrelay_dir}/var/argrelay_client.server_index" )"
+    else
+        server_index="0"
+    fi
+
+    # TODO: FS_16_07_78_84: respect conf dir priority:
+    server_host_name="$( jq --raw-output ".redundant_servers[${server_index}].server_host_name" "${argrelay_dir}/conf/argrelay_client.json" )"
+    server_port_number="$( jq --raw-output ".redundant_servers[${server_index}].server_port_number" "${argrelay_dir}/conf/argrelay_client.json" )"
+
+    # This is a basic info normally reported by FS_36_17_84_44 `check_env` script:
+    echo -e "\
 ${field_color}nested shell level:${reset_color} ${SHLVL} ${delimiter_color}|${reset_color} \
 ${field_color}argrelay:${reset_color} $( pip show argrelay | grep '^Version:' | cut -f2 -d' ' || true ) ${delimiter_color}|${reset_color} \
 ${field_color}@/conf:${reset_color} ${conf_status} ${delimiter_color}|${reset_color} \
 ${field_color}venv:${reset_color} ${VIRTUAL_ENV} ${delimiter_color}|${reset_color} \
 ${field_color}server[${server_index}]:${reset_color} http://${server_host_name}:${server_port_number}" \
-1>&2
+    1>&2
+fi

--- a/src/argrelay/custom_integ_res/script_plugin.d/check_env_plugin.all_plugins.bash
+++ b/src/argrelay/custom_integ_res/script_plugin.d/check_env_plugin.all_plugins.bash
@@ -1,0 +1,3 @@
+
+# shellcheck disable=SC2154
+source "${argrelay_dir}/exe/script_plugin.d/check_env_plugin.bash_version.bash"

--- a/src/argrelay/custom_integ_res/script_plugin.d/check_env_plugin.bash_version.bash
+++ b/src/argrelay/custom_integ_res/script_plugin.d/check_env_plugin.bash_version.bash
@@ -1,0 +1,11 @@
+
+########################################################################################################################
+# Report `bash_version`:
+# shellcheck disable=SC2154
+if [[ -n "${BASH_VERSION+x}" ]]
+then
+    echo -e "${success_color}INFO:${reset_style} ${field_color}bash_version:${reset_style} ${BASH_VERSION}"
+else
+    echo -e "${failure_color}ERROR:${reset_style} ${field_color}bash_version:${reset_style} ${failure_message}# Env var \`BASH_VERSION\` is not defined${reset_style}"
+    exit 1
+fi

--- a/src/argrelay/enum_desc/CheckEnvField.py
+++ b/src/argrelay/enum_desc/CheckEnvField.py
@@ -6,6 +6,8 @@ class CheckEnvField(Enum):
     Field names reported by FS_36_17_84_44 `check_env`.
     """
 
+    server_version = auto()
+
     server_git_commit_id = auto()
 
     server_start_time = auto()

--- a/src/argrelay/enum_desc/CheckEnvFunc.py
+++ b/src/argrelay/enum_desc/CheckEnvFunc.py
@@ -6,6 +6,11 @@ class CheckEnvFunc(Enum):
     Functions used by FS_36_17_84_44 `check_env`.
     """
 
+    func_id_get_server_argrelay_version = auto()
+    """
+    Query server `argrelay` package version.
+    """
+
     func_id_get_server_project_git_commit_id = auto()
     """
     Query server git commit id.

--- a/src/argrelay/enum_desc/ClientExitCode.py
+++ b/src/argrelay/enum_desc/ClientExitCode.py
@@ -17,6 +17,14 @@ class ClientExitCode(IntEnum):
     Provides a mechanism to implement FS_93_18_57_91 client fail over.
     """
 
+    ServerError = 3
+    """
+    Server responded with an error (e.g. HTTP status code not 200),
+    but it is not a `ConnectionError`.
+
+    See also `ServerResponseError`.
+    """
+
     # maximum exit code:
     # https://stackoverflow.com/a/67219932/441652
     UnknownError = 255

--- a/src/argrelay/enum_desc/TopDir.py
+++ b/src/argrelay/enum_desc/TopDir.py
@@ -26,6 +26,8 @@ class TopDir(Enum):
 
     test_dir = "test"
 
+    tmp_dir = "tmp"
+
     var_dir = "var"
 
     def __str__(self):

--- a/src/argrelay/handler_request/AbstractServerRequestHandler.py
+++ b/src/argrelay/handler_request/AbstractServerRequestHandler.py
@@ -1,4 +1,7 @@
+import time
+
 from argrelay.relay_server.LocalServer import LocalServer
+from argrelay.relay_server.UsageStatsEntry import UsageStatsEntry
 from argrelay.runtime_context.InterpContext import InterpContext
 from argrelay.runtime_context.ParsedContext import ParsedContext
 from argrelay.server_spec.CallContext import CallContext
@@ -35,3 +38,31 @@ class AbstractServerRequestHandler:
         )
         self.interp_ctx.interpret_command(local_server.server_config.server_plugin_control.first_interp_factory_id)
         self.interp_ctx.print_debug()
+
+
+    @staticmethod
+    def _create_usage_stats_entry(
+        call_ctx: CallContext,
+    ) -> UsageStatsEntry:
+        usage_stats_entry = UsageStatsEntry(
+            server_action = call_ctx.server_action,
+            comp_scope = call_ctx.comp_scope,
+            server_ts_ns = time.time_ns(),
+            client_version = call_ctx.client_version,
+            client_conf_target = call_ctx.client_conf_target,
+            client_user_id = call_ctx.client_uid,
+            command_line = call_ctx.command_line,
+            cursor_cpos = call_ctx.cursor_cpos,
+        )
+        return usage_stats_entry
+
+    def _store_usage_stats_entry(
+        self,
+        call_ctx: CallContext,
+    ) -> None:
+        usage_stats_entry = self._create_usage_stats_entry(
+            call_ctx = call_ctx,
+        )
+        self.local_server.usage_stats_store.store_usage_stats_entry(
+            usage_stats_entry,
+        )

--- a/src/argrelay/handler_request/DescribeLineArgsServerRequestHandler.py
+++ b/src/argrelay/handler_request/DescribeLineArgsServerRequestHandler.py
@@ -24,6 +24,7 @@ class DescribeLineArgsServerRequestHandler(AbstractServerRequestHandler):
         call_ctx: CallContext,
     ) -> dict:
         assert call_ctx.server_action is ServerAction.DescribeLineArgs
+        self._store_usage_stats_entry(call_ctx)
 
         self.interpret_command(self.local_server, call_ctx)
         ElapsedTime.measure("after_interpret_command")

--- a/src/argrelay/handler_request/ProposeArgValuesServerRequestHandler.py
+++ b/src/argrelay/handler_request/ProposeArgValuesServerRequestHandler.py
@@ -21,6 +21,7 @@ class ProposeArgValuesServerRequestHandler(AbstractServerRequestHandler):
         call_ctx: CallContext,
     ) -> dict:
         assert call_ctx.server_action is ServerAction.ProposeArgValues
+        self._store_usage_stats_entry(call_ctx)
 
         self.interpret_command(self.local_server, call_ctx)
         ElapsedTime.measure("after_interpret_command")

--- a/src/argrelay/handler_request/RelayLineArgsServerRequestHandler.py
+++ b/src/argrelay/handler_request/RelayLineArgsServerRequestHandler.py
@@ -32,6 +32,7 @@ class RelayLineArgsServerRequestHandler(AbstractServerRequestHandler):
         call_ctx: CallContext,
     ) -> dict:
         assert call_ctx.server_action is ServerAction.RelayLineArgs
+        self._store_usage_stats_entry(call_ctx)
 
         self.interpret_command(self.local_server, call_ctx)
         ElapsedTime.measure("after_interpret_command")

--- a/src/argrelay/plugin_delegator/DelegatorCheckEnv.py
+++ b/src/argrelay/plugin_delegator/DelegatorCheckEnv.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argrelay
 from argrelay.enum_desc.CheckEnvField import CheckEnvField
 from argrelay.enum_desc.CheckEnvFunc import CheckEnvFunc
 from argrelay.enum_desc.FuncState import FuncState
@@ -31,6 +32,20 @@ class DelegatorCheckEnv(AbstractDelegator):
         self,
     ) -> list[dict]:
         func_envelopes = [
+            {
+                instance_data_: {
+                    func_id_: CheckEnvFunc.func_id_get_server_argrelay_version.name,
+                    delegator_plugin_instance_id_: self.plugin_instance_id,
+                    search_control_list_: [
+                    ],
+                },
+                ReservedPropName.envelope_class.name: ReservedEnvelopeClass.ClassFunction.name,
+                ReservedPropName.help_hint.name: (
+                    CheckEnvFunc.func_id_get_server_argrelay_version.name
+                ),
+                ReservedPropName.func_state.name: FuncState.fs_alpha.name,
+                ReservedPropName.func_id.name: CheckEnvFunc.func_id_get_server_argrelay_version.name,
+            },
             {
                 instance_data_: {
                     func_id_: CheckEnvFunc.func_id_get_server_project_git_commit_id.name,
@@ -70,6 +85,12 @@ class DelegatorCheckEnv(AbstractDelegator):
 
         func_id = get_func_id_from_interp_ctx(interp_ctx)
         custom_plugin_data = {}
+
+        if func_id == CheckEnvFunc.func_id_get_server_argrelay_version.name:
+            server_version = argrelay.__version__
+            custom_plugin_data = {
+                CheckEnvField.server_version.name: server_version,
+            }
 
         if func_id == CheckEnvFunc.func_id_get_server_project_git_commit_id.name:
             project_git_commit_id: str = get_config_value_once(

--- a/src/argrelay/relay_client/__main__.py
+++ b/src/argrelay/relay_client/__main__.py
@@ -14,6 +14,23 @@ ElapsedTime.measure("after_program_entry")
 
 
 def main():
+    # noinspection PyBroadException
+    try:
+        return run_client()
+    except BaseException as e1:
+        # noinspection PyBroadException
+        try:
+            # Avoid leaving terminal in unexpected state.
+            # For example, due to some terminal control chars printed by client partially,
+            # the terminal may be left in mode which does not echo back chars typed by the user.
+            import os
+            os.system("stty sane")
+        except BaseException as e2:
+            pass
+        raise e1
+
+
+def run_client():
     ElapsedTime.measure("after_initial_imports")
 
     file_path = get_config_path("argrelay_client.json")

--- a/src/argrelay/relay_server/CustomFlaskApp.py
+++ b/src/argrelay/relay_server/CustomFlaskApp.py
@@ -6,6 +6,7 @@ import pkg_resources
 from flasgger import Swagger
 from flask import Flask, request, redirect
 
+import argrelay
 from argrelay import relay_server
 from argrelay.custom_integ.git_utils import get_git_repo_root_path
 from argrelay.misc_helper_common import get_argrelay_dir
@@ -17,8 +18,7 @@ from argrelay.schema_config_core_server.ServerConfigSchema import server_config_
 from argrelay.schema_config_plugin.PluginConfigSchema import plugin_config_desc
 from argrelay.server_spec.const_int import API_SPEC_PATH, API_DOCS_PATH, ARGRELAY_GUI_PATH
 
-# Set this here (because `require` function may fail in other contexts):
-server_version = pkg_resources.require("argrelay")[0].version
+server_version = argrelay.__version__
 server_title = relay_server.__name__
 
 

--- a/src/argrelay/relay_server/LocalServer.py
+++ b/src/argrelay/relay_server/LocalServer.py
@@ -22,6 +22,7 @@ from argrelay.plugin_interp.AbstractInterpFactory import AbstractInterpFactory
 from argrelay.plugin_loader.AbstractLoader import AbstractLoader
 from argrelay.relay_server.HelpHintCache import HelpHintCache
 from argrelay.relay_server.QueryEngine import QueryEngine
+from argrelay.relay_server.UsageStatsStore import UsageStatsStore
 from argrelay.runtime_context.AbstractPluginServer import AbstractPluginServer, instantiate_server_plugin
 from argrelay.runtime_context.SearchControl import SearchControl
 from argrelay.runtime_data.EnvelopeCollection import EnvelopeCollection
@@ -57,6 +58,7 @@ class LocalServer:
         self.plugin_config: PluginConfig = plugin_config
         self.mongo_server: MongoServerWrapper = MongoServerWrapper()
         self.mongo_client: MongoClient = MongoClientWrapper.get_mongo_client(self.server_config.mongo_config)
+        self.usage_stats_store = UsageStatsStore()
         self.query_engine: QueryEngine = QueryEngine(
             self.server_config.query_cache_config,
             self.get_mongo_database(),

--- a/src/argrelay/relay_server/UsageStatsEntry.py
+++ b/src/argrelay/relay_server/UsageStatsEntry.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from argrelay.enum_desc.CompScope import CompScope
+from argrelay.enum_desc.ServerAction import ServerAction
+
+
+@dataclass
+class UsageStatsEntry:
+    """
+    Stored entry for FS_87_02_77_34: usage stats.
+    """
+
+    server_action: ServerAction
+
+    comp_scope: CompScope
+
+    server_ts_ns: int = 0
+
+    client_version: str = ""
+
+    client_conf_target: str = ""
+
+    client_user_id: str = ""
+
+    command_line: str = ""
+
+    cursor_cpos: int = 0

--- a/src/argrelay/relay_server/UsageStatsEntrySchema.py
+++ b/src/argrelay/relay_server/UsageStatsEntrySchema.py
@@ -1,0 +1,86 @@
+from marshmallow import fields, RAISE
+
+from argrelay.enum_desc.CompScope import CompScope
+from argrelay.enum_desc.ServerAction import ServerAction
+from argrelay.misc_helper_common.ObjectSchema import ObjectSchema
+from argrelay.misc_helper_common.TypeDesc import TypeDesc
+from argrelay.relay_server.UsageStatsEntry import UsageStatsEntry
+from argrelay.schema_request.CallContextSchema import (
+    server_action_,
+    command_line_,
+    call_context_desc,
+    comp_scope_,
+    cursor_cpos_,
+)
+
+server_ts_ns_ = "server_ts_ns"
+client_version_ = "client_version"
+client_conf_target_ = "client_conf_target"
+client_user_id_ = "client_user_id"
+
+
+class UsageStatsEntrySchema(ObjectSchema):
+    """
+    Schema for FS_87_02_77_34: usage stats entry - see `UsageStatsEntry`.
+    """
+
+    class Meta:
+        unknown = RAISE
+        ordered = True
+
+    model_class = UsageStatsEntry
+
+    server_action = fields.Enum(
+        ServerAction,
+        required = True,
+    )
+
+    comp_scope = fields.Enum(
+        CompScope,
+        required = True,
+    )
+
+    server_ts_ns = fields.Integer(
+        required = False,
+        load_default = 0,
+    )
+
+    client_version = fields.String(
+        required = False,
+        load_default = "",
+    )
+
+    client_conf_target = fields.String(
+        required = False,
+        load_default = "",
+    )
+
+    client_user_id = fields.String(
+        required = False,
+        load_default = "",
+    )
+
+    command_line = fields.String(
+        required = True,
+    )
+
+    cursor_cpos = fields.Integer(
+        required = True,
+    )
+
+
+usage_stats_entry_desc = TypeDesc(
+    dict_schema = UsageStatsEntrySchema(),
+    ref_name = UsageStatsEntrySchema.__name__,
+    dict_example = {
+        server_action_: call_context_desc.dict_example[server_action_],
+        comp_scope_: call_context_desc.dict_example[comp_scope_],
+        server_ts_ns_: 0,
+        client_version_: "",
+        client_conf_target_: "",
+        client_user_id_: "",
+        command_line_: call_context_desc.dict_example[command_line_],
+        cursor_cpos_: call_context_desc.dict_example[cursor_cpos_],
+    },
+    default_file_path = "",
+)

--- a/src/argrelay/relay_server/UsageStatsStore.py
+++ b/src/argrelay/relay_server/UsageStatsStore.py
@@ -1,0 +1,33 @@
+import json
+import os
+
+from argrelay.enum_desc.TopDir import TopDir
+from argrelay.misc_helper_common import get_argrelay_dir
+from argrelay.relay_server.UsageStatsEntry import UsageStatsEntry
+from argrelay.relay_server.UsageStatsEntrySchema import usage_stats_entry_desc
+
+
+class UsageStatsStore:
+    """
+    Stored entry for FS_87_02_77_34: usage stats.
+    """
+
+    def __init__(
+        self,
+    ):
+        self.store_file_path: str = str(os.path.join(
+            get_argrelay_dir(),
+            TopDir.var_dir.value,
+            "usage_stats",
+        ))
+
+    def store_usage_stats_entry(
+        self,
+        usage_stats_entry: UsageStatsEntry,
+    ):
+        with open(self.store_file_path, "a") as json_file:
+            json.dump(
+                usage_stats_entry_desc.dict_from_input_obj(usage_stats_entry),
+                json_file,
+            )
+            json_file.write("\n")

--- a/src/argrelay/relay_server/route_api.py
+++ b/src/argrelay/relay_server/route_api.py
@@ -24,7 +24,7 @@ def create_blueprint_api(local_server: LocalServer):
     propose_arg_values_handler = ProposeArgValuesServerRequestHandler(local_server)
     relay_line_args_handler = RelayLineArgsServerRequestHandler(local_server)
 
-    def create_call_ctx() -> CallContext:
+    def _create_call_ctx() -> CallContext:
         ElapsedTime.clear_measurements()
         ElapsedTime.measure("before_request_payload_load")
 
@@ -48,7 +48,7 @@ def create_blueprint_api(local_server: LocalServer):
     @swag_from(ProposeArgValuesSpec.spec_data)
     def propose_arg_values():
         try:
-            call_ctx = create_call_ctx()
+            call_ctx = _create_call_ctx()
             response_dict = propose_arg_values_handler.handle_request(call_ctx)
 
             if request.accept_mimetypes["text/plain"] or len(request.accept_mimetypes) == 0:
@@ -79,7 +79,7 @@ def create_blueprint_api(local_server: LocalServer):
     @swag_from(DescribeLineArgsSpec.spec_data)
     def describe_line_args():
         try:
-            call_ctx = create_call_ctx()
+            call_ctx = _create_call_ctx()
             response_dict = describe_line_args_handler.handle_request(call_ctx)
 
             if request.accept_mimetypes["application/json"] or len(request.accept_mimetypes) == 0:
@@ -101,7 +101,7 @@ def create_blueprint_api(local_server: LocalServer):
     @swag_from(RelayLineArgsSpec.spec_data)
     def relay_line_args():
         try:
-            call_ctx = create_call_ctx()
+            call_ctx = _create_call_ctx()
             response_dict = relay_line_args_handler.handle_request(call_ctx)
 
             if request.accept_mimetypes["application/json"] or len(request.accept_mimetypes) == 0:

--- a/src/argrelay/runtime_data/CheckEnvPluginConfig.py
+++ b/src/argrelay/runtime_data/CheckEnvPluginConfig.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from argrelay.runtime_data.PluginEntry import PluginEntry
+
+
+@dataclass
+class CheckEnvPluginConfig:
+    """
+    See also `CheckEnvPluginConfigSchema`.
+    """
+
+    check_env_plugin_instance_entries: dict[str, PluginEntry] = field()
+    """
+    Same as `plugin_instance_entries` but for FS_36_17_84_44 `check_env` only.
+    """
+
+    check_env_plugin_instance_id_activate_list: list[str] = field()
+    """
+    Same as `plugin_instance_id_activate_list` but for FS_36_17_84_44 `check_env` only.
+    """

--- a/src/argrelay/runtime_data/PluginConfig.py
+++ b/src/argrelay/runtime_data/PluginConfig.py
@@ -27,15 +27,3 @@ class PluginConfig:
     walking through a DAG described by `plugin_dependencies`.
     Each `plugin_instance_id` is a key into `plugin_instance_entries`.
     """
-
-    # TODO: Move it into separate file/object:
-    check_env_plugin_instance_entries: dict[str, PluginEntry] = field()
-    """
-    Same as `plugin_instance_entries` but for FS_36_17_84_44 `check_env` only.
-    """
-
-    # TODO: Move it into separate file/object:
-    check_env_plugin_instance_id_activate_list: list[str] = field()
-    """
-    Same as `plugin_instance_id_activate_list` but for FS_36_17_84_44 `check_env` only.
-    """

--- a/src/argrelay/sample_conf/argrelay_plugin.yaml
+++ b/src/argrelay/sample_conf/argrelay_plugin.yaml
@@ -146,6 +146,7 @@ reusable_config_data:
 
     func_tree_check_env: &func_tree_check_env
         "argrelay.check_env":
+            "server_version": func_id_get_server_argrelay_version
             "server_commit": func_id_get_server_project_git_commit_id
             "server_start_time": func_id_get_server_start_time
 
@@ -519,43 +520,3 @@ plugin_instance_entries:
             project_page_url: "https://argrelay.org"
             git_files_by_commit_id_url_prefix: "https://github.com/argrelay/argrelay/tree/"
             commit_id_url_prefix: "https://github.com/argrelay/argrelay/commit/"
-
-check_env_plugin_instance_entries:
-
-    ####################################################################################################################
-    # List of client-side plugins for FS_36_17_84_44 `check_env`
-
-    PluginCheckEnvDevShell.default:
-        plugin_side: PluginClientSideOnly
-        plugin_module_name: argrelay.check_env.PluginCheckEnvDevShell
-        plugin_class_name: PluginCheckEnvDevShell
-
-    PluginCheckEnvClientLinkedCommands.default:
-        plugin_side: PluginClientSideOnly
-        plugin_module_name: argrelay.check_env.PluginCheckEnvClientLinkedCommands
-        plugin_class_name: PluginCheckEnvClientLinkedCommands
-
-    PluginCheckEnvOnlineMode.default:
-        plugin_side: PluginClientSideOnly
-        plugin_module_name: argrelay.check_env.PluginCheckEnvOnlineMode
-        plugin_class_name: PluginCheckEnvOnlineMode
-
-    PluginCheckEnvServerIndex.default:
-        plugin_side: PluginClientSideOnly
-        plugin_module_name: argrelay.check_env.PluginCheckEnvServerIndex
-        plugin_class_name: PluginCheckEnvServerIndex
-
-    PluginCheckEnvServerUrl.default:
-        plugin_side: PluginClientSideOnly
-        plugin_module_name: argrelay.check_env.PluginCheckEnvServerUrl
-        plugin_class_name: PluginCheckEnvServerUrl
-
-    PluginCheckEnvServerResponseValueCommitId.default:
-        plugin_side: PluginClientSideOnly
-        plugin_module_name: argrelay.check_env.PluginCheckEnvServerResponseValueCommitId
-        plugin_class_name: PluginCheckEnvServerResponseValueCommitId
-
-    PluginCheckEnvServerResponseValueStartTime.default:
-        plugin_side: PluginClientSideOnly
-        plugin_module_name: argrelay.check_env.PluginCheckEnvServerResponseValueStartTime
-        plugin_class_name: PluginCheckEnvServerResponseValueStartTime

--- a/src/argrelay/sample_conf/argrelay_server.yaml
+++ b/src/argrelay/sample_conf/argrelay_server.yaml
@@ -247,6 +247,9 @@ server_plugin_control:
                         node_type: interp_tree_node
                         plugin_instance_id: FuncTreeInterpFactory.check_env
                         sub_tree:
+                            "server_version":
+                                node_type: func_tree_node
+                                func_id: func_id_get_server_argrelay_version
                             "server_commit":
                                 node_type: func_tree_node
                                 func_id: func_id_get_server_project_git_commit_id

--- a/src/argrelay/sample_conf/check_env_plugin.conf.bash
+++ b/src/argrelay/sample_conf/check_env_plugin.conf.bash
@@ -1,0 +1,3 @@
+
+# shellcheck disable=SC2154
+source "${argrelay_dir}/exe/script_plugin.d/check_env_plugin.all_plugins.bash"

--- a/src/argrelay/sample_conf/check_env_plugin.conf.yaml
+++ b/src/argrelay/sample_conf/check_env_plugin.conf.yaml
@@ -1,0 +1,56 @@
+
+check_env_plugin_instance_entries:
+
+    ####################################################################################################################
+    # List of client-side plugins for FS_36_17_84_44 `check_env`
+
+    PluginCheckEnvModuleVersion.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvModuleVersion
+        plugin_class_name: PluginCheckEnvModuleVersion
+
+    PluginCheckEnvArgrelayLocalVersionMismatch.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvArgrelayLocalVersionMismatch
+        plugin_class_name: PluginCheckEnvArgrelayLocalVersionMismatch
+
+    PluginCheckEnvServerResponseValueVersion.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvServerResponseValueVersion
+        plugin_class_name: PluginCheckEnvServerResponseValueVersion
+
+    PluginCheckEnvDevShell.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvDevShell
+        plugin_class_name: PluginCheckEnvDevShell
+
+    PluginCheckEnvClientLinkedCommands.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvClientLinkedCommands
+        plugin_class_name: PluginCheckEnvClientLinkedCommands
+
+    PluginCheckEnvOnlineMode.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvOnlineMode
+        plugin_class_name: PluginCheckEnvOnlineMode
+
+    PluginCheckEnvServerIndex.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvServerIndex
+        plugin_class_name: PluginCheckEnvServerIndex
+
+    PluginCheckEnvServerUrl.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvServerUrl
+        plugin_class_name: PluginCheckEnvServerUrl
+
+    PluginCheckEnvServerResponseValueCommitId.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvServerResponseValueCommitId
+        plugin_class_name: PluginCheckEnvServerResponseValueCommitId
+
+    PluginCheckEnvServerResponseValueStartTime.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvServerResponseValueStartTime
+        plugin_class_name: PluginCheckEnvServerResponseValueStartTime
+

--- a/src/argrelay/schema_config_plugin/BasePluginConfigSchema.py
+++ b/src/argrelay/schema_config_plugin/BasePluginConfigSchema.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from marshmallow import RAISE
+
+from argrelay.misc_helper_common.ObjectSchema import ObjectSchema
+
+
+class BasePluginConfigSchema(ObjectSchema):
+    class Meta:
+        unknown = RAISE
+        strict = True
+
+
+def serialize_dag_to_list(
+    entire_dag: dict[str, list[str]],
+) -> list[str]:
+    output_list: list[str] = list_sub_dag(
+        [],
+        entire_dag,
+        [node_id for node_id in entire_dag],
+    )
+    return output_list
+
+
+def list_sub_dag(
+    curr_path: list[str],
+    entire_dag: dict[str, list[str]],
+    id_sub_list: list[str],
+) -> list[str]:
+    output_list: list[str] = []
+
+    for node_id in id_sub_list:
+        if node_id in curr_path:
+            raise ValueError(f"cyclic ref to plugin id in path `{curr_path}` -> `{node_id}`")
+        if node_id not in entire_dag:
+            raise ValueError(f"plugin id in path `{curr_path}` -> `{node_id}` is not defined")
+        if node_id in entire_dag:
+            # plugin has dependencies:
+            sub_list = list_sub_dag(
+                curr_path + [node_id],
+                entire_dag,
+                entire_dag[node_id],
+            )
+            for sub_node_id in sub_list:
+                if sub_node_id not in output_list:
+                    output_list.append(sub_node_id)
+        else:
+            raise ValueError(f"plugin id in path `{curr_path}` -> `{node_id}` is not included for activation")
+
+        if node_id not in output_list:
+            output_list.append(node_id)
+
+    return output_list

--- a/src/argrelay/schema_config_plugin/CheckEnvPluginConfigSchema.py
+++ b/src/argrelay/schema_config_plugin/CheckEnvPluginConfigSchema.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from marshmallow import fields, RAISE, post_load
+
+from argrelay.misc_helper_common.TypeDesc import TypeDesc
+from argrelay.runtime_data.CheckEnvPluginConfig import CheckEnvPluginConfig
+from argrelay.runtime_data.PluginEntry import PluginEntry
+from argrelay.schema_config_plugin.BasePluginConfigSchema import BasePluginConfigSchema, serialize_dag_to_list
+from argrelay.schema_config_plugin.PluginEntrySchema import plugin_entry_desc
+
+check_env_plugin_instance_entries_ = "check_env_plugin_instance_entries"
+
+
+class CheckEnvPluginConfigSchema(BasePluginConfigSchema):
+    class Meta:
+        unknown = RAISE
+        strict = True
+
+    model_class = CheckEnvPluginConfig
+
+    check_env_plugin_instance_entries = fields.Dict(
+        keys = fields.String(),
+        values = fields.Nested(plugin_entry_desc.dict_schema),
+        required = True,
+    )
+
+    @post_load
+    def make_object(
+        self,
+        input_dict,
+        **kwargs,
+    ):
+
+        # Build DAG:
+        check_env_plugin_instance_id_activate_order_dag = {}
+        for plugin_instance_id in input_dict[check_env_plugin_instance_entries_]:
+            plugin_entry: PluginEntry = input_dict[check_env_plugin_instance_entries_][plugin_instance_id]
+            check_env_plugin_instance_id_activate_order_dag[plugin_instance_id] = plugin_entry.plugin_dependencies
+
+        return type(self).model_class(
+            **input_dict,
+            check_env_plugin_instance_id_activate_list = serialize_dag_to_list(
+                check_env_plugin_instance_id_activate_order_dag,
+            ),
+        )
+
+
+check_env_plugin_config_desc = TypeDesc(
+    dict_schema = CheckEnvPluginConfigSchema(),
+    ref_name = CheckEnvPluginConfigSchema.__name__,
+    dict_example = {
+        check_env_plugin_instance_entries_: {
+            "some_check_env_plugin_instance_id": plugin_entry_desc.dict_example,
+            "some_check_env_plugin_instance_id1": plugin_entry_desc.dict_example,
+            "some_check_env_plugin_instance_id2": plugin_entry_desc.dict_example,
+        },
+    },
+    default_file_path = "check_env_plugin.conf.yaml",
+)

--- a/src/argrelay/schema_config_plugin/PluginConfigSchema.py
+++ b/src/argrelay/schema_config_plugin/PluginConfigSchema.py
@@ -2,18 +2,17 @@ from __future__ import annotations
 
 from marshmallow import fields, RAISE, post_load
 
-from argrelay.misc_helper_common.ObjectSchema import ObjectSchema
 from argrelay.misc_helper_common.TypeDesc import TypeDesc
 from argrelay.runtime_data.PluginConfig import PluginConfig
 from argrelay.runtime_data.PluginEntry import PluginEntry
+from argrelay.schema_config_plugin.BasePluginConfigSchema import BasePluginConfigSchema, serialize_dag_to_list
 from argrelay.schema_config_plugin.PluginEntrySchema import plugin_entry_desc
 
 reusable_config_data_ = "reusable_config_data"
 plugin_instance_entries_ = "plugin_instance_entries"
-check_env_plugin_instance_entries_ = "check_env_plugin_instance_entries"
 
 
-class PluginConfigSchema(ObjectSchema):
+class PluginConfigSchema(BasePluginConfigSchema):
     class Meta:
         unknown = RAISE
         strict = True
@@ -41,13 +40,6 @@ class PluginConfigSchema(ObjectSchema):
         required = True,
     )
 
-    # TODO: Move it into separate file/schema:
-    check_env_plugin_instance_entries = fields.Dict(
-        keys = fields.String(),
-        values = fields.Nested(plugin_entry_desc.dict_schema),
-        required = True,
-    )
-
     @post_load
     def make_object(
         self,
@@ -61,19 +53,10 @@ class PluginConfigSchema(ObjectSchema):
             plugin_entry: PluginEntry = input_dict[plugin_instance_entries_][plugin_instance_id]
             plugin_instance_id_activate_order_dag[plugin_instance_id] = plugin_entry.plugin_dependencies
 
-        # TODO: Move it into separate file/schema:
-        check_env_plugin_instance_id_activate_order_dag = {}
-        for plugin_instance_id in input_dict[check_env_plugin_instance_entries_]:
-            plugin_entry: PluginEntry = input_dict[check_env_plugin_instance_entries_][plugin_instance_id]
-            check_env_plugin_instance_id_activate_order_dag[plugin_instance_id] = plugin_entry.plugin_dependencies
-
         return type(self).model_class(
             **input_dict,
             plugin_instance_id_activate_list = serialize_dag_to_list(
                 plugin_instance_id_activate_order_dag,
-            ),
-            check_env_plugin_instance_id_activate_list = serialize_dag_to_list(
-                check_env_plugin_instance_id_activate_order_dag,
             ),
         )
 
@@ -87,53 +70,6 @@ plugin_config_desc = TypeDesc(
             "some_plugin_instance_id1": plugin_entry_desc.dict_example,
             "some_plugin_instance_id2": plugin_entry_desc.dict_example,
         },
-        check_env_plugin_instance_entries_: {
-            "some_check_env_plugin_instance_id": plugin_entry_desc.dict_example,
-            "some_check_env_plugin_instance_id1": plugin_entry_desc.dict_example,
-            "some_check_env_plugin_instance_id2": plugin_entry_desc.dict_example,
-        },
     },
     default_file_path = "argrelay_plugin.yaml",
 )
-
-
-def serialize_dag_to_list(
-    entire_dag: dict[str, list[str]],
-) -> list[str]:
-    output_list: list[str] = list_sub_dag(
-        [],
-        entire_dag,
-        [node_id for node_id in entire_dag],
-    )
-    return output_list
-
-
-def list_sub_dag(
-    curr_path: list[str],
-    entire_dag: dict[str, list[str]],
-    id_sub_list: list[str],
-) -> list[str]:
-    output_list: list[str] = []
-
-    for node_id in id_sub_list:
-        if node_id in curr_path:
-            raise ValueError(f"cyclic ref to plugin id in path `{curr_path}` -> `{node_id}`")
-        if node_id not in entire_dag:
-            raise ValueError(f"plugin id in path `{curr_path}` -> `{node_id}` is not defined")
-        if node_id in entire_dag:
-            # plugin has dependencies:
-            sub_list = list_sub_dag(
-                curr_path + [node_id],
-                entire_dag,
-                entire_dag[node_id],
-            )
-            for sub_node_id in sub_list:
-                if sub_node_id not in output_list:
-                    output_list.append(sub_node_id)
-        else:
-            raise ValueError(f"plugin id in path `{curr_path}` -> `{node_id}` is not included for activation")
-
-        if node_id not in output_list:
-            output_list.append(node_id)
-
-    return output_list

--- a/src/argrelay/schema_request/CallContextSchema.py
+++ b/src/argrelay/schema_request/CallContextSchema.py
@@ -6,20 +6,26 @@ from argrelay.misc_helper_common.ObjectSchema import ObjectSchema
 from argrelay.misc_helper_common.TypeDesc import TypeDesc
 from argrelay.server_spec.CallContext import CallContext
 
+client_version_ = "client_version"
+client_conf_target_ = "client_conf_target"
 server_action_ = "server_action"
 command_line_ = "command_line"
 cursor_cpos_ = "cursor_cpos"
 comp_scope_ = "comp_scope"
+client_uid_ = "client_uid"
 client_pid_ = "client_pid"
 is_debug_enabled_ = "is_debug_enabled"
 
 _sample_command_line = "some_command goto service "
 
 _call_context_example = {
+    client_version_: "",
+    client_conf_target_: "",
     server_action_: ServerAction.DescribeLineArgs.name,
     command_line_: _sample_command_line,
     cursor_cpos_: len(_sample_command_line),
     comp_scope_: CompScope.ScopeInitial.name,
+    client_uid_: "",
     client_pid_: 0,
     is_debug_enabled_: False,
 }
@@ -32,6 +38,22 @@ class CallContextSchema(ObjectSchema):
 
     model_class = CallContext
 
+    client_version = fields.String(
+        required = False,
+        metadata = {
+            "description": "client version of `argrelay` package (empty = not set)",
+            "example": _call_context_example[client_version_],
+        },
+        load_default = "",
+    )
+    client_conf_target = fields.String(
+        required = False,
+        metadata = {
+            "description": "target path of `@/conf` symlink (empty = not set)",
+            "example": _call_context_example[client_conf_target_],
+        },
+        load_default = "",
+    )
     server_action = fields.Enum(
         ServerAction,
         required = True,
@@ -62,6 +84,14 @@ class CallContextSchema(ObjectSchema):
             "description": "Name for a completion scope - see " + CompScope.__name__ + " enum",
             "example": _call_context_example[comp_scope_],
         },
+    )
+    client_uid = fields.String(
+        required = False,
+        metadata = {
+            "description": "UID (user name) of the client user according to OS (empty = not set)",
+            "example": _call_context_example[client_uid_],
+        },
+        load_default = "",
     )
     client_pid = fields.Integer(
         required = False,

--- a/src/argrelay/server_spec/CallContext.py
+++ b/src/argrelay/server_spec/CallContext.py
@@ -14,10 +14,13 @@ class CallContext:
     Immutable input data from client to server
     """
 
+    client_version: str = field()
+    client_conf_target: str = field()
     server_action: ServerAction = field()
     command_line: str = field()
     cursor_cpos: int = field()
     comp_scope: CompScope = field()
+    client_uid: str = field()
     client_pid: int = field()
     is_debug_enabled: bool = field()
 
@@ -28,9 +31,12 @@ class CallContext:
         if not self.is_debug_enabled:
             return
         eprint(TermColor.debug_output.value, end = "")
+        eprint(f"client_version: {self.client_version}", end = " ")
+        eprint(f"client_conf_target: {self.client_conf_target}", end = " ")
         eprint(f"server_action: {self.server_action}", end = " ")
         eprint(f"\"{self.command_line}\"", end = " ")
         eprint(f"cursor_cpos: {self.cursor_cpos}", end = " ")
         eprint(f"comp_scope: {self.comp_scope}", end = " ")
+        eprint(f"client_uid: {self.client_uid}", end = " ")
         eprint(f"client_pid: {self.client_pid}", end = " ")
         eprint(TermColor.reset_style.value, end = end_str)

--- a/src/argrelay/test_infra/EnvMockBuilder.py
+++ b/src/argrelay/test_infra/EnvMockBuilder.py
@@ -35,6 +35,7 @@ from argrelay.enum_desc.CallConv import CallConv
 from argrelay.enum_desc.CompType import CompType
 from argrelay.enum_desc.DistinctValuesQuery import DistinctValuesQuery
 from argrelay.enum_desc.SpecialChar import SpecialChar
+from argrelay.enum_desc.TopDir import TopDir
 from argrelay.misc_helper_common import get_argrelay_dir
 from argrelay.plugin_delegator.AbstractDelegator import AbstractDelegator
 from argrelay.runtime_context.ParsedContext import ParsedContext
@@ -169,6 +170,7 @@ class EnvMockBuilder:
     mock_client_config_file_read: bool = field(default = False)
     mock_server_config_file_read: bool = field(default = False)
     mock_plugin_config_file_read: bool = field(default = False)
+    mock_usage_stats_file_write: bool = field(default = False)
 
     # Implement FS_62_25_92_06 generated config for `out`-processes to read it (see FS_66_17_43_42 test infra):
     generate_client_config_file: bool = field(default = False)
@@ -388,6 +390,21 @@ class EnvMockBuilder:
         return self
 
     ####################################################################################################################
+    # FS_87_02_77_34: usage stats
+
+    @staticmethod
+    def get_usage_stats_path():
+        # TODO: TODO_69_59_78_78: register known files as enum with metadata:
+        return f"{get_argrelay_dir()}/{TopDir.var_dir.value}/usage_stats"
+
+    def set_mock_usage_stats_file_write(self, given_val: bool):
+        self.mock_usage_stats_file_write = given_val
+        return self
+
+    def get_usage_stats_mock(self):
+        return self.file_mock.path_to_mock[self.get_usage_stats_path()]
+
+    ####################################################################################################################
     # General mocking
 
     @contextlib.contextmanager
@@ -557,6 +574,10 @@ class EnvMockBuilder:
                     self.plugin_config_dict
                 )
 
+        if self.mock_usage_stats_file_write:
+            # set mocked file content:
+            self.file_mock.path_to_data[self.get_usage_stats_path()] = ""
+
         with ExitStack() as exit_stack:
 
             # noinspection PyListCreation
@@ -721,7 +742,7 @@ class EnvMockBuilder:
     def generate_configs(
         self,
     ):
-        base_tmp_dir = f"{get_argrelay_dir()}/tmp"
+        base_tmp_dir = f"{get_argrelay_dir()}/{TopDir.tmp_dir.value}"
         assert os.path.isdir(base_tmp_dir)
 
         test_configs_dir = f"{base_tmp_dir}/test_configs"

--- a/tests/offline_tests/misc_helper/test_TypeDesc.py
+++ b/tests/offline_tests/misc_helper/test_TypeDesc.py
@@ -4,7 +4,10 @@ from marshmallow import ValidationError
 
 from argrelay.custom_integ.GitRepoLoader import GitRepoLoader
 from argrelay.plugin_interp.NoopInterp import NoopInterp
-from argrelay.schema_config_plugin.PluginConfigSchema import plugin_instance_entries_, plugin_config_desc
+from argrelay.schema_config_plugin.PluginConfigSchema import (
+    plugin_instance_entries_,
+    plugin_config_desc,
+)
 from argrelay.schema_config_plugin.PluginEntrySchema import (
     plugin_entry_desc,
     plugin_enabled_,

--- a/tests/offline_tests/plugin_delegator/test_HelpDelegator.py
+++ b/tests/offline_tests/plugin_delegator/test_HelpDelegator.py
@@ -18,37 +18,6 @@ from argrelay.test_infra.EnvMockBuilder import LocalClientEnvMockBuilder, EmptyE
 from argrelay.test_infra.LocalTestClass import LocalTestClass
 
 
-class ThisTestCase(ShellInputTestCase):
-
-    def __init__(
-        self,
-        case_comment: str,
-        test_line: str,
-        comp_type: CompType,
-        container_ipos_to_expected_assignments: dict[int, dict[str, AssignedValue]],
-        sever_action_verifier: ServerActionVerifier,
-    ):
-        super().__init__(
-            line_no = line_no_from_ctor(),
-            case_comment = case_comment,
-        )
-        self.set_test_line(test_line)
-        self.set_comp_type(comp_type)
-
-        self.container_ipos_to_expected_assignments = container_ipos_to_expected_assignments
-        self.sever_action_verifier = sever_action_verifier
-
-        self.expected_suggestions: Union[list[str], None] = None
-
-    def set_expected_suggestions(
-        self,
-        given_expected_suggestions: list[str],
-    ):
-        assert self.expected_suggestions is None
-        self.expected_suggestions = given_expected_suggestions
-        return self
-
-
 class ThisTestClass(LocalTestClass):
     same_test_data_per_class = "TD_63_37_05_36"  # demo
 
@@ -106,7 +75,7 @@ class ThisTestClass(LocalTestClass):
                 )
 
                 ########################################################################################################
-                # TODO_32_99_70_35: Instead of keeping JSON sample here, create TestCaseBuilder which integrates JSON verifier and convert the entire test class to use that.
+                # TODO: TODO_32_99_70_35: Instead of keeping JSON sample here, create TestCaseBuilder which integrates JSON verifier and convert the entire test class to use that.
 
                 env_mock_builder = (
                     LocalClientEnvMockBuilder()
@@ -204,3 +173,34 @@ some_command list service {SpecialChar.NoPropValue.value} {TermColor.known_envel
                         "",
                         inner_env_mock_builder.actual_stderr.getvalue(),
                     )
+
+
+class ThisTestCase(ShellInputTestCase):
+
+    def __init__(
+        self,
+        case_comment: str,
+        test_line: str,
+        comp_type: CompType,
+        container_ipos_to_expected_assignments: dict[int, dict[str, AssignedValue]],
+        sever_action_verifier: ServerActionVerifier,
+    ):
+        super().__init__(
+            line_no = line_no_from_ctor(),
+            case_comment = case_comment,
+        )
+        self.set_test_line(test_line)
+        self.set_comp_type(comp_type)
+
+        self.container_ipos_to_expected_assignments = container_ipos_to_expected_assignments
+        self.sever_action_verifier = sever_action_verifier
+
+        self.expected_suggestions: Union[list[str], None] = None
+
+    def set_expected_suggestions(
+        self,
+        given_expected_suggestions: list[str],
+    ):
+        assert self.expected_suggestions is None
+        self.expected_suggestions = given_expected_suggestions
+        return self

--- a/tests/offline_tests/relay_client/test_client_side_fail_over.py
+++ b/tests/offline_tests/relay_client/test_client_side_fail_over.py
@@ -8,6 +8,7 @@ import requests
 import responses
 
 from argrelay.client_command_remote.ClientCommandRemoteWorkerAbstract import get_server_index_file_path
+from argrelay.enum_desc.ClientExitCode import ClientExitCode
 from argrelay.enum_desc.CompType import CompType
 from argrelay.enum_desc.ServerAction import ServerAction
 from argrelay.relay_client import __main__
@@ -233,8 +234,12 @@ class ThisTestClass(BaseTestClass):
             if is_connection_successful:
                 __main__.main()
             else:
-                with self.assertRaises(ConnectionError) as exc_context:
+                with self.assertRaises(SystemExit) as cm:
                     __main__.main()
+                self.assertEqual(
+                    cm.exception.code,
+                    ClientExitCode.ConnectionError.value,
+                )
 
         # then:
 

--- a/tests/offline_tests/relay_client/test_imports_ProposeArgValuesRemoteOptimizedClientCommand.py
+++ b/tests/offline_tests/relay_client/test_imports_ProposeArgValuesRemoteOptimizedClientCommand.py
@@ -45,7 +45,12 @@ class ThisTestClass(BaseTestClass):
     # To generate `expected_imports`, run `test_print_grouped_imports`.
     expected_imports = {
         "__future__": [],
+        "argrelay": [
+            "argrelay._version"
+        ],
+        "argrelay._version": [],
         "argrelay.client_command_remote.ClientCommandRemoteAbstract": [
+            "argrelay.client_command_remote.exception_utils",
             "argrelay.enum_desc.ClientExitCode",
             "argrelay.enum_desc.ProcRole",
             "argrelay.relay_client.ClientCommandAbstract",
@@ -54,6 +59,7 @@ class ThisTestClass(BaseTestClass):
         "argrelay.client_command_remote.ClientCommandRemoteWorkerAbstract": [
             "__future__",
             "argrelay.client_command_remote.ClientCommandRemoteAbstract",
+            "argrelay.client_command_remote.exception_utils",
             "argrelay.client_pipeline",
             "argrelay.enum_desc.ClientExitCode",
             "argrelay.enum_desc.ProcRole",
@@ -69,12 +75,13 @@ class ThisTestClass(BaseTestClass):
             "argrelay.misc_helper_common.ElapsedTime",
             "argrelay.runtime_data.ConnectionConfig",
             "json",
-            "os",
             "socket"
         ],
+        "argrelay.client_command_remote.exception_utils": [],
         "argrelay.client_pipeline": [],
         "argrelay.client_spec.ShellContext": [
             "__future__",
+            "argrelay",
             "argrelay.enum_desc.CompScope",
             "argrelay.enum_desc.CompType",
             "argrelay.enum_desc.ServerAction",

--- a/tests/offline_tests/relay_server/test_usage_stats.py
+++ b/tests/offline_tests/relay_server/test_usage_stats.py
@@ -1,0 +1,145 @@
+import argrelay
+from argrelay.client_command_local.ClientCommandLocal import ClientCommandLocal
+from argrelay.client_spec.ShellContext import select_server_action, get_user_name, get_client_conf_target
+from argrelay.enum_desc.CompScope import CompScope
+from argrelay.enum_desc.CompType import CompType
+from argrelay.enum_desc.ServerAction import ServerAction
+from argrelay.relay_client import __main__
+from argrelay.relay_server.UsageStatsEntry import UsageStatsEntry
+from argrelay.relay_server.UsageStatsEntrySchema import usage_stats_entry_desc
+from argrelay.test_infra import line_no_from_ctor
+from argrelay.test_infra.CustomTestCase import ShellInputTestCase
+from argrelay.test_infra.EnvMockBuilder import LocalClientEnvMockBuilder, EnvMockBuilder
+from argrelay.test_infra.LocalTestClass import LocalTestClass
+
+
+class ThisTestClass(LocalTestClass):
+    """
+    Test FS_87_02_77_34 usage stats.
+    """
+
+    same_test_data_per_class = "TD_63_37_05_36"  # demo
+
+    @classmethod
+    def setUpClass(cls):
+        LocalTestClass.setUpClass()
+        # Clean usage stats:
+        open(EnvMockBuilder.get_usage_stats_path(), "w").close()
+
+    def test_FS_87_02_77_34_usage_stats(self):
+
+        test_cases = [
+            ThisTestCase(
+                f"Cause {ServerAction.ProposeArgValues.name} stats",
+                "some_command help |",
+                CompType.PrefixShown,
+                ServerAction.ProposeArgValues,
+            ),
+            ThisTestCase(
+                f"Cause {ServerAction.DescribeLineArgs.name} stats",
+                "some_command help interc|",
+                CompType.DescribeArgs,
+                ServerAction.DescribeLineArgs,
+            ),
+            ThisTestCase(
+                f"Cause {ServerAction.RelayLineArgs.name} stats",
+                "some_command help |",
+                CompType.InvokeAction,
+                ServerAction.RelayLineArgs,
+            ),
+        ]
+
+        for test_case in test_cases:
+
+            # Run two times:
+            # *   mocked to observe calls to file writes
+            # *   real to capture content
+            for is_mocked_stats_file in [
+                True,
+                False,
+            ]:
+                test_case.is_mocked_stats_file = is_mocked_stats_file
+                with self.subTest(test_case):
+
+                    env_mock_builder = (
+                        LocalClientEnvMockBuilder()
+                        .set_command_line(test_case.command_line)
+                        .set_cursor_cpos(test_case.cursor_cpos)
+                        .set_comp_type(test_case.comp_type)
+                        .set_mock_usage_stats_file_write(test_case.is_mocked_stats_file)
+                        .set_test_data_ids_to_load([
+                            self.__class__.same_test_data_per_class,
+                        ])
+                    )
+                    with env_mock_builder.build():
+
+                        self.assertEqual(
+                            select_server_action(test_case.comp_type),
+                            test_case.expected_server_action,
+                        )
+
+                        command_obj = __main__.main()
+                        assert isinstance(command_obj, ClientCommandLocal)
+
+                        if test_case.is_mocked_stats_file:
+                            # Assert file writes:
+
+                            file_mock = env_mock_builder.get_usage_stats_mock()
+
+                            file_mock.assert_called_once_with(env_mock_builder.get_usage_stats_path(), "a")
+                            # Each JSON string per line is separated with new line:
+                            file_mock().write.assert_called_with("\n")
+
+                            # TODO: How to capture all the content written to the mocked file?
+                            #       If that was possible, it could be asserted without
+                            #       running tests twice to check real file
+
+                        else:
+                            # Assert file content:
+
+                            # Get last JSON file line:
+                            with open(env_mock_builder.get_usage_stats_path()) as stats_usage_file:
+                                for file_line in stats_usage_file:
+                                    pass
+                                last_line = file_line
+
+                            usage_stats_entry: UsageStatsEntry = usage_stats_entry_desc.obj_from_yaml_str(last_line)
+
+                            self.assertEqual(
+                                usage_stats_entry,
+                                UsageStatsEntry(
+                                    server_action = test_case.expected_server_action,
+                                    comp_scope = CompScope.from_comp_type(test_case.comp_type),
+                                    server_ts_ns = usage_stats_entry.server_ts_ns,
+                                    client_conf_target = get_client_conf_target(),
+                                    client_version = argrelay.__version__,
+                                    client_user_id = get_user_name(),
+                                    command_line = test_case.command_line,
+                                    cursor_cpos = test_case.cursor_cpos,
+                                ),
+                            )
+
+
+
+class ThisTestCase(ShellInputTestCase):
+
+    def __init__(
+        self,
+        case_comment: str,
+        test_line: str,
+        comp_type: CompType,
+        expected_server_action: ServerAction,
+    ):
+        super().__init__(
+            line_no = line_no_from_ctor(),
+            case_comment = case_comment,
+        )
+        self.set_test_line(test_line)
+        self.set_comp_type(comp_type)
+        self.expected_server_action = expected_server_action
+        self.is_mocked_stats_file = True
+
+    def __str__(
+        self,
+    ):
+        return f"{super().__str__()}: {'mocked_file' if self.is_mocked_stats_file else 'real_file'}"

--- a/tests/offline_tests/runtime_context/test_CallContext.py
+++ b/tests/offline_tests/runtime_context/test_CallContext.py
@@ -1,6 +1,7 @@
 import os
 
-from argrelay.client_spec.ShellContext import UNKNOWN_COMP_KEY, ShellContext
+import argrelay
+from argrelay.client_spec.ShellContext import UNKNOWN_COMP_KEY, ShellContext, get_user_name, get_client_conf_target
 from argrelay.enum_desc.CompScope import CompScope
 from argrelay.enum_desc.CompType import CompType
 from argrelay.enum_desc.ServerAction import ServerAction
@@ -12,6 +13,9 @@ from argrelay.schema_request.CallContextSchema import (
     comp_scope_,
     cursor_cpos_,
     command_line_,
+    client_uid_,
+    client_conf_target_,
+    client_version_,
 )
 from argrelay.test_infra import line_no, parse_line_and_cpos
 from argrelay.test_infra.BaseTestClass import BaseTestClass
@@ -28,12 +32,17 @@ class ThisTestClass(BaseTestClass):
             (
                 line_no(), "basic conversion",
                 "some_command prod amer upstream sdfg|  ", CompType.PrefixShown,
-                f'{{"{server_action_}": "{ServerAction.ProposeArgValues.name}", '
+                f'{{'
+                f'"{client_version_}": "{argrelay.__version__}", '
+                f'"{client_conf_target_}": "{get_client_conf_target()}", '
+                f'"{server_action_}": "{ServerAction.ProposeArgValues.name}", '
                 f'"{command_line_}": "some_command prod amer upstream sdfg  ", '
                 f'"{cursor_cpos_}": 36, '
                 f'"{comp_scope_}": "{CompScope.ScopeInitial.name}", '
+                f'"{client_uid_}": "{get_user_name()}", '
                 f'"{client_pid_}": {os.getpid()}, '
-                f'"{is_debug_enabled_}": false}}',
+                f'"{is_debug_enabled_}": false'
+                f'}}',
             ),
         ]
         for test_case in test_cases:

--- a/tests/offline_tests/schema_common/test_Schema.py
+++ b/tests/offline_tests/schema_common/test_Schema.py
@@ -27,6 +27,7 @@ from argrelay.plugin_delegator.AbstractJumpDelegatorConfigSchema import abstract
 from argrelay.plugin_delegator.ErrorDelegatorCustomDataSchema import error_delegator_custom_data_desc
 from argrelay.plugin_interp.FirstArgInterpFactoryConfigSchema import first_arg_interp_factory_config_desc
 from argrelay.plugin_interp.FuncTreeInterpFactoryConfigSchema import func_tree_interp_config_desc
+from argrelay.relay_server.UsageStatsEntrySchema import usage_stats_entry_desc
 from argrelay.runtime_data.ClientConfig import ClientConfig
 from argrelay.schema_config_core_client.ClientConfigSchema import client_config_desc, redundant_servers_
 from argrelay.schema_config_core_client.ConnectionConfigSchema import (
@@ -46,6 +47,7 @@ from argrelay.schema_config_interp.FuncEnvelopeSchema import func_envelope_desc
 from argrelay.schema_config_interp.FunctionEnvelopeInstanceDataSchema import function_envelope_instance_data_desc
 from argrelay.schema_config_interp.InitControlSchema import init_control_desc
 from argrelay.schema_config_interp.SearchControlSchema import search_control_desc
+from argrelay.schema_config_plugin.CheckEnvPluginConfigSchema import check_env_plugin_config_desc
 from argrelay.schema_config_plugin.PluginConfigSchema import plugin_config_desc
 from argrelay.schema_config_plugin.PluginEntrySchema import plugin_entry_desc
 from argrelay.schema_request.CallContextSchema import call_context_desc
@@ -96,6 +98,8 @@ class ThisTestClass(BaseTestClass):
         (line_no(), config_only_delegator_config_desc),
         (line_no(), func_config_desc),
         (line_no(), schema_plugin_check_evn_server_response_abstract_desc),
+        (line_no(), usage_stats_entry_desc),
+        (line_no(), check_env_plugin_config_desc),
 
         # FS_33_76_82_84 composite forest and its nodes:
         (line_no(), composite_forest_desc),

--- a/tests/offline_tests/test_infra/test_PopenMock.py
+++ b/tests/offline_tests/test_infra/test_PopenMock.py
@@ -75,6 +75,7 @@ resource_files.conf.bash
 run_argrelay_client
 run_argrelay_server
 run_max_tests.bash
+script_plugin.d
 shell_env.bash
 squash_and_push_branch.bash
 upgrade_env_packages.bash

--- a/tests/release_tests/test_pre_publish.py
+++ b/tests/release_tests/test_pre_publish.py
@@ -104,6 +104,8 @@ class ThisTestClass(BaseTestClass):
         *   `~/.argrelay.conf.d/argrelay_client.json`
         *   `~/.argrelay.conf.d/argrelay_server.yaml`
         *   `~/.argrelay.conf.d/argrelay_plugin.yaml`
+        *   `~/.argrelay.conf.d/check_env_plugin.conf.bash`
+        *   `~/.argrelay.conf.d/check_env_plugin.conf.yaml`
 
         Move them under different name to preserve or delete them completely.
 
@@ -116,6 +118,8 @@ class ThisTestClass(BaseTestClass):
             os.path.expanduser("~") + "/.argrelay.conf.d/argrelay_client.json",
             os.path.expanduser("~") + "/.argrelay.conf.d/argrelay_server.yaml",
             os.path.expanduser("~") + "/.argrelay.conf.d/argrelay_plugin.yaml",
+            os.path.expanduser("~") + "/.argrelay.conf.d/check_env_plugin.conf.bash",
+            os.path.expanduser("~") + "/.argrelay.conf.d/check_env_plugin.conf.yaml",
         ]:
             self.assertFalse(os.path.exists(file_path))
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,17 @@
 
 [tox]
+
 min_version = 4.0
+
 env_list =
+    # NOTE: Using full python names (`python3.7` instead of `py37`) works,
+    #       but it works wrongly - do not do this:
+    #       https://stackoverflow.com/a/68413752/441652
+    # Setting minimum supported Python version:
     py37
-    # TODO: Remove this - it works, but works wrongly:
-    # Using full Python name instead of `py37` to avoid this error:
-    # py37: skipped because could not find python interpreter with spec(s): py37
-    # https://stackoverflow.com/a/68413752/441652
-    #python3.7
 
 [testenv]
+
 passenv =
     # Runs some tests conditionally when invoked from `@/exe/dev_shell.bash`:
     ARGRELAY_DEV_SHELL
@@ -19,7 +21,9 @@ passenv =
     ARGRELAY_CLIENT_COMMAND
     # Avoid SSH passwords (e.g. for `git):
     SSH_AUTH_SOCK
+
 extras = tests
+
 # TODO: Ensure there is at least one test case discovered.
 commands =
     # run all offline tests only:

--- a/var/.gitignore
+++ b/var/.gitignore
@@ -5,3 +5,6 @@
 # See FS_93_18_57_91 client fail over to redundant servers:
 /argrelay_client.server_index
 
+# See FS_87_02_77_34 usage stats:
+/usage_stats
+


### PR DESCRIPTION
*   `checn_env`: 
    *   Split Bash part into `@/exe/script_plugin.d` plugins and `@/conf/check_env_plugin.conf.bash` config.
    *   Split `argrelay_plugin.yaml` and `check_env_plugin.conf.yaml`.
    *   Upgrade `*ClientLinkedCommands` to verify binding of argrelay-linked commands.
    *   Implement `*ArgrelayLocalVersionMismatch` to compare `argrelay_module_version` with `@/conf/env_packages.txt`.
    *   Implement `*ServerResponseValueVersion` to compare `client_version` and `server_version`.
    *   Implement `*ModuleVersion` to report `argrelay_module_version` (in addition to `argrelay_pip_version`).
    *   Implement `check_env_plugin.bash_version.bash`.
    *   Rename `argrelay_version` to `argrelay_pip_version`.
*   `usage_stats`:
    *   Implement `UsageStatsStore` with append-only file.
    *   Propagate `client_version`.
    *   Propagate `client_conf_target`.
    *   Propagate `client_user_uid`. 
*   Refactor file deployment by `@/exe/bootstrap_env.bash` (config and logic) to use full `src` and `dst` paths.
*   Implement internal `argrelay.__version__` and use it universally.
*   Run `stty sane` on exception to restore possibly affected terminal.
*   Define `ClientExitCode.ServerError`.
*   Print full stack tracks only once on exit.
*   Run commands non-interactively by `@/exe/dev_shell.bash` and print banner only for interactive shell.
*   Do not run tests by `@/exe/bootstrap_env.bash` to make installation look sane.
*   Do not run tests by `@/exe/publish_package.bash` to speed up release process.
*   Spec: `FS_87_02_77_34.usage_stats.md`.
*   Spec: `TODO_69_59_78_78.register_known_files_as_enum_with_metadata.md`.
