### PR TITLE
Propagate trailing URL on GET as initial GUI command line

### DIFF
--- a/docs/dev_notes/gui_tests_notes.md
+++ b/docs/dev_notes/gui_tests_notes.md
@@ -1,4 +1,20 @@
 
+# TL;DR
+
+Starting `cypress` (and running all commands) has to be done from this dir - the dir with all GUI tests:
+
+```sh
+cd argrelay.git/tests/gui_tests
+npx cypress open
+```
+
+Before running tests (manually), a server instance has to be started first
+(e.g. in foreground, in a separate terminal):
+
+```sh
+argrelay.git/exe/run_argrelay_server
+```
+
 # Install Cypress
 
 https://docs.cypress.io/guides/getting-started/installing-cypress

--- a/src/argrelay/relay_server/CustomFlaskApp.py
+++ b/src/argrelay/relay_server/CustomFlaskApp.py
@@ -141,6 +141,7 @@ def create_app() -> CustomFlaskApp:
         configure_project_page_url(flask_app.local_server.server_config.server_configurators),
         server_version,
         flask_app.local_server.server_config.gui_banner_config,
+        flask_app.local_server.server_config.default_gui_command,
         flask_app.local_server.server_start_time,
         # TODO: make AbstractConfiguration expose only these final methods (and any concatenation of strings, validation, should be hidden inside ConfiguratorDefault):
         configure_project_git_commit_time(flask_app.local_server.server_config.server_configurators),

--- a/src/argrelay/relay_server/gui_static/argrelay_style.css
+++ b/src/argrelay/relay_server/gui_static/argrelay_style.css
@@ -174,11 +174,40 @@ Output elements
 }
 
 /***********************************************************************************************************************
+Copy buttons
+***********************************************************************************************************************/
+
+.copy_buttons_container {
+    margin-top: 0;
+    display: flex;
+    justify-content: right;
+}
+
+.copy_button {
+    white-space: nowrap;
+    width: fit-content;
+    margin: 0 0 2px 0;
+    padding: 2px;
+    border-style: solid;
+    border-color: lightskyblue;
+    color: grey;
+    cursor: pointer;
+}
+
+.copy_command_button {
+    border-width: 0 0 1px 1px;
+}
+
+.copy_link_button {
+    border-width: 0 1px 1px 1px;
+}
+
+/***********************************************************************************************************************
 Legend
 ***********************************************************************************************************************/
 
 .legend_container {
-    margin-top: 0px;
+    margin-top: 0;
     display: flex;
     justify-content: right;
 }
@@ -212,6 +241,7 @@ Suggestion details
     border-style: solid;
     border-width: 1px;
     border-color: lightskyblue;
+    cursor: crosshair;
 }
 
 .input_part {

--- a/src/argrelay/relay_server/gui_templates/argrelay_main.html
+++ b/src/argrelay/relay_server/gui_templates/argrelay_main.html
@@ -15,6 +15,7 @@
     <script
         type="text/javascript"
         src="{{ url_for("static", filename = "argrelay_client.js") }}"
+        argrelay_gui_url="{{ url_for("blueprint_gui.basic_ui") }}"
         propose_arg_values_url="{{ url_for("blueprint_api.propose_arg_values") }}"
         describe_line_args_url="{{ url_for("blueprint_api.describe_line_args") }}"
         relay_line_args_url="{{ url_for("blueprint_api.relay_line_args") }}"
@@ -27,6 +28,8 @@
         project_git_commit_display_string="{{ project_git_commit_display_string }}"
         project_git_conf_dir_url="{{ project_git_conf_dir_url }}"
         project_git_conf_dir_display_string="{{ project_git_conf_dir_display_string }}"
+        command_line = "{{ command_line }}"
+
         defer
     ></script>
     <title>{{ project_title }}</title>
@@ -73,6 +76,7 @@
         <select
             id="command_history"
             data-cy="command_history"
+            title="commands are saved into the top of the history on Enter"
         >
         </select>
     </div>
@@ -89,8 +93,26 @@
             contenteditable="true"
             spellcheck="false"
             type="text"
-            placeholder="... type command selecting suggested args via Tab-auto-completion"
+            title=
+                "type command selecting suggested args via clicks or Tab-auto-completion"
+            placeholder=
+                "type command selecting suggested args via clicks or Tab-auto-completion"
         />
+    </div>
+
+    <div class="copy_buttons_container">
+        <div
+            id="id_copy_command_button"
+            class="copy_button copy_command_button"
+        >
+            copy command
+        </div>
+        <div
+            id="id_copy_link_button"
+            class="copy_button copy_link_button"
+        >
+            copy link
+        </div>
     </div>
 
     <div class="legend_container">

--- a/src/argrelay/relay_server/route_gui.py
+++ b/src/argrelay/relay_server/route_gui.py
@@ -16,6 +16,7 @@ def create_blueprint_gui(
     project_page_url: str,
     argrelay_version: str,
     gui_banner_config: GuiBannerConfig,
+    default_gui_command: str,
     server_start_time: int,
     project_git_commit_time: int,
     project_git_commit_url: str,
@@ -23,14 +24,25 @@ def create_blueprint_gui(
     project_git_conf_dir_url: str,
     project_git_conf_dir_display_string: str,
 ):
+    if default_gui_command is None or len(default_gui_command.strip()) == 0:
+        default_gui_command = "lay"
+    else:
+        default_gui_command = default_gui_command.strip()
+
     blueprint_gui = Blueprint(
         name = "blueprint_gui",
         import_name = __name__,
     )
 
-    # TODO: test and think if it is the right place
-    @blueprint_gui.route(ARGRELAY_GUI_PATH)
-    def basic_ui():
+    @blueprint_gui.route(f"{ARGRELAY_GUI_PATH}")
+    @blueprint_gui.route(f"{ARGRELAY_GUI_PATH}<path:command_line>")
+    def basic_ui(
+        command_line: str = "",
+    ):
+        if len(command_line) == 0:
+            command_line = default_gui_command
+        if len(command_line) > 0 and not command_line.endswith(" "):
+            command_line += " "
         return render_template(
             "argrelay_main.html",
             project_title = project_title,
@@ -46,6 +58,7 @@ def create_blueprint_gui(
             project_git_conf_dir_display_string = project_git_conf_dir_display_string,
             header_html = gui_banner_config.header_html,
             footer_html = gui_banner_config.footer_html,
+            command_line = command_line,
         )
 
     return blueprint_gui

--- a/src/argrelay/runtime_data/ServerConfig.py
+++ b/src/argrelay/runtime_data/ServerConfig.py
@@ -18,6 +18,7 @@ class ServerConfig:
     mongo_config: MongoConfig = field()
     query_cache_config: QueryCacheConfig = field()
     gui_banner_config: GuiBannerConfig = field()
+    default_gui_command: str = field()
     class_to_collection_map: dict = field()
     server_plugin_control: ServerPluginControl = field()
 

--- a/src/argrelay/schema_config_core_server/ServerConfigSchema.py
+++ b/src/argrelay/schema_config_core_server/ServerConfigSchema.py
@@ -18,6 +18,7 @@ connection_config_ = "connection_config"
 mongo_config_ = "mongo_config"
 query_cache_config_ = "query_cache_config"
 gui_banner_config_ = "gui_banner_config"
+default_gui_command_ = "default_gui_command"
 class_to_collection_map_ = "class_to_collection_map"
 server_plugin_control_ = "server_plugin_control"
 static_data_ = "static_data"
@@ -48,6 +49,11 @@ class ServerConfigSchema(ObjectSchema):
     gui_banner_config = fields.Nested(
         gui_banner_config_desc.dict_schema,
         required = True,
+    )
+
+    default_gui_command = fields.String(
+        required = False,
+        load_default = None,
     )
 
     # Related to FS_56_43_05_79 search diff collection:

--- a/tests/gui_tests/cypress/e2e/argrelay_gui/basic_checks.cy.js
+++ b/tests/gui_tests/cypress/e2e/argrelay_gui/basic_checks.cy.js
@@ -3,6 +3,10 @@
 describe('argrelay GUI', () => {
     beforeEach(() => {
         cy.visit('http://localhost:8787/argrelay_gui/')
+
+        cy
+            .get('[data-cy=command_line_input]')
+            .should('have.value', 'lay ')
     })
 
     it('has command line input ready', () => {
@@ -11,10 +15,13 @@ describe('argrelay GUI', () => {
             .should('have.class', 'io_state_client_synced_input')
         cy
             .get('#command_line_input')
-            .should('have.length', 1)
+            .invoke('val')
+            .should('have.length', 4)
         cy
             .get('#command_line_input')
-            .first()
-            .should('have.text', '')
+            .invoke('val')
+            .then((input_value) => {
+                expect(input_value).to.be.equal('lay ')
+            })
     })
 })

--- a/tests/gui_tests/cypress/e2e/argrelay_gui/command_history.cy.js
+++ b/tests/gui_tests/cypress/e2e/argrelay_gui/command_history.cy.js
@@ -69,4 +69,36 @@ describe('argrelay GUI', () => {
             .get('[data-cy=command_line_input]')
             .should('have.class', 'io_state_client_synced_input')
     })
+
+    it('entered command is always inserted to head (even if matches existing history entry)', {
+        // If cache is disabled and TD_38_03_48_51 large generated data set is used, it takes a while:
+        defaultCommandTimeout: 30_000
+    }, () => {
+
+        // This should be synced with `argrelay_client.js` for the test to fill in entire history:
+        const command_history_max_size = 10;
+        // Loop more than `command_history_max_size`:
+        const loop_count = command_history_max_size * 2;
+        for (let command_index = 0; command_index < loop_count; command_index++) {
+            // Enter different command initially then wrap to enter duplicates:
+            const cycling_index = command_index % command_history_max_size
+            const input_command = `lay goto host whatever_index${cycling_index}`
+            cy
+                .get('[data-cy=command_line_input]')
+                .focus()
+                .clear()
+                .type(`${input_command}{enter}`)
+            cy
+                .get('[data-cy=command_history]')
+                .children('option')
+                .then(all_options => {
+                    const text_lines = [...all_options]
+                        .map(option_item => option_item.text)
+                    expect(text_lines[0]).eq(`${input_command}`)
+                })
+            cy
+                .get('[data-cy=command_line_input]')
+                .should('have.class', 'io_state_client_synced_input')
+            }
+    })
 })

--- a/tests/gui_tests/cypress/e2e/argrelay_gui/input_output_basics.cy.js
+++ b/tests/gui_tests/cypress/e2e/argrelay_gui/input_output_basics.cy.js
@@ -3,13 +3,20 @@
 describe('argrelay GUI', () => {
     beforeEach(() => {
         cy.visit('http://localhost:8787/argrelay_gui/')
+
+        cy
+            .get('[data-cy=command_line_input]')
+            .should('have.value', 'lay ')
     })
 
     it('suggestions get listed on command input', {
         // If cache is disabled and TD_38_03_48_51 large generated data set is used, it takes a while:
         defaultCommandTimeout: 30_000
     }, () => {
-        const input_command = 'lay '
+
+        // Use `some_command` instead of `lay` (because `lay` is default and LRU-cached with quick response):
+        const input_command = 'some_command '
+
         cy
             .get('[data-cy=command_line_input]')
             .should('have.class', 'io_state_client_synced_input')
@@ -18,6 +25,8 @@ describe('argrelay GUI', () => {
             .focus()
             .clear()
             .type(`${input_command}`)
+
+        // A series of state transitions while talking to server:
         cy
             .get('[data-cy=command_line_input]')
             .should('have.class', 'io_state_pending_request_input')
@@ -27,6 +36,8 @@ describe('argrelay GUI', () => {
         cy
             .get('[data-cy=command_line_input]')
             .should('have.class', 'io_state_client_synced_input')
+
+        // Final (stable) output:
         cy
             .get('[data-cy=suggestion_output]')
             .children()


### PR DESCRIPTION
*   Use trailing URL chars on GET as an initial command line.
*   Propagate default GUI command from the server config.
*   Add "copy command" and "copy link" buttons.
*   Generate `client_uid` for GUI client.
*   Fix command history to move existing entry on top if reused.
