### PR TITLE
Allow selecting remaining args out of interrogation order in GUI

### DIFF
--- a/docs/task_refs/TODO_10_06_46_37.list_arg_value_consumption_stop_options.md
+++ b/docs/task_refs/TODO_10_06_46_37.list_arg_value_consumption_stop_options.md
@@ -1,0 +1,12 @@
+
+TODO: TODO_10_06_46_37: list arg value consumption stop options
+
+With FS_13_51_07_97 list arg value, the `data_envelope` may already be singled out,
+but list arg values are still not locked (as this `data_envelope` has list of values).
+Should we still suggest them to interrogate user or not?
+
+It might be needed to leave it to the delegator plugin decision:
+*   or stop on singled out
+*   or stop on all coordinates specified
+*   or stop on specified coordinates (then the rest may not be specified even if not singled out)
+

--- a/docs/task_refs/TODO_80_99_84_41.intercept_has_no_suggestions_if_selected_via_func_id.md
+++ b/docs/task_refs/TODO_80_99_84_41.intercept_has_no_suggestions_if_selected_via_func_id.md
@@ -1,0 +1,9 @@
+
+
+TODO: TODO_80_99_84_41 `intercept` has no suggestions if selected via `func_id`
+
+Search TODO to see test cases.
+
+It might be something to do with `jump_tree` (generated via FS_33_76_82_84 composite forest)
+having no relevant entry in that case.
+

--- a/src/argrelay/_version.py
+++ b/src/argrelay/_version.py
@@ -1,4 +1,4 @@
 # See `docs/dev_notes/version_format.md`:
 # Implements this:
 # https://stackoverflow.com/a/7071358/441652
-__version__ = "0.7.13"
+__version__ = "0.7.14"

--- a/src/argrelay/check_env/__main__.py
+++ b/src/argrelay/check_env/__main__.py
@@ -13,6 +13,7 @@ from argrelay.enum_desc.PluginSide import PluginSide
 from argrelay.enum_desc.PluginType import PluginType
 from argrelay.enum_desc.ResultCategory import ResultCategory
 from argrelay.enum_desc.TermColor import TermColor
+from argrelay.relay_client.client_utils import handle_main_exception
 from argrelay.runtime_context.PluginClientAbstract import instantiate_client_plugin
 from argrelay.runtime_data.CheckEnvPluginConfig import CheckEnvPluginConfig
 from argrelay.runtime_data.PluginEntry import PluginEntry
@@ -35,6 +36,13 @@ offline_message = TermColor.fore_bright_blue.value
 
 # TODO: TODO_67_33_03_53.add_check_env_test_support.md
 def main():
+    # noinspection PyBroadException
+    try:
+        return check_env_logic()
+    except BaseException as e1:
+        handle_main_exception(e1)
+
+def check_env_logic():
     argrelay_dir: str = os.path.realpath(os.path.abspath(sys.argv[1]))
     misc_helper_common.set_argrelay_dir(argrelay_dir)
 

--- a/src/argrelay/plugin_delegator/ErrorDelegator.py
+++ b/src/argrelay/plugin_delegator/ErrorDelegator.py
@@ -1,5 +1,3 @@
-import sys
-
 from argrelay.enum_desc.ClientExitCode import ClientExitCode
 from argrelay.misc_helper_common import eprint
 from argrelay.plugin_delegator.AbstractDelegator import AbstractDelegator
@@ -36,4 +34,4 @@ class ErrorDelegator(AbstractDelegator):
             if error_code_ in invocation_input.custom_plugin_data:
                 error_code = invocation_input.custom_plugin_data[error_code_]
         eprint(error_message)
-        sys.exit(error_code)
+        exit(error_code)

--- a/src/argrelay/relay_client/__main__.py
+++ b/src/argrelay/relay_client/__main__.py
@@ -7,6 +7,7 @@ from argrelay.enum_desc.ProcRole import ProcRole
 from argrelay.enum_desc.ServerAction import ServerAction
 from argrelay.misc_helper_common import get_config_path
 from argrelay.misc_helper_common.ElapsedTime import ElapsedTime
+from argrelay.relay_client.client_utils import handle_main_exception
 from argrelay.runtime_data.ClientConfig import ClientConfig
 from argrelay.runtime_data.ConnectionConfig import ConnectionConfig
 
@@ -18,17 +19,7 @@ def main():
     try:
         return run_client()
     except BaseException as e1:
-        # noinspection PyBroadException
-        try:
-            # Avoid leaving terminal in unexpected state.
-            # For example, due to some terminal control chars printed by client partially,
-            # the terminal may be left in mode which does not echo back chars typed by the user.
-            if sys.stdout.isatty() or sys.stderr.isatty():
-                import os
-                os.system("stty sane")
-        except BaseException as e2:
-            pass
-        raise e1
+        handle_main_exception(e1)
 
 
 def run_client():

--- a/src/argrelay/relay_client/client_utils.py
+++ b/src/argrelay/relay_client/client_utils.py
@@ -1,0 +1,15 @@
+import sys
+
+
+def handle_main_exception(e1):
+    # noinspection PyBroadException
+    try:
+        # Avoid leaving terminal in unexpected state.
+        # For example, due to some terminal control chars printed by client partially,
+        # the terminal may be left in mode which does not echo back chars typed by the user.
+        if sys.stdout.isatty() or sys.stderr.isatty():
+            import os
+            os.system("stty sane")
+    except BaseException as e2:
+        pass
+    raise e1

--- a/src/argrelay/relay_server/gui_static/argrelay_client.js
+++ b/src/argrelay/relay_server/gui_static/argrelay_client.js
@@ -15,6 +15,8 @@ const suggested_item_temp = document.querySelector("#suggested_item_temp");
 const envelope_container_temp = document.querySelector("#envelope_container_temp")
 const arg_container_temp = document.querySelector("#arg_container_temp")
 
+const remaining_item_temp = document.querySelector("#remaining_item_temp");
+
 const copy_command_elem = document.querySelector("#id_copy_command_button")
 const copy_link_elem = document.querySelector("#id_copy_link_button")
 
@@ -600,6 +602,13 @@ function on_suggestion_click(
     use_selected_suggestion(suggested_item_elem);
 }
 
+function on_remaining_click(
+    input_event,
+) {
+    const remaining_item_elem = input_event.target;
+    use_selected_remaining(remaining_item_elem);
+}
+
 function use_selected_suggestion(suggested_item_elem) {
     if (!suggested_item_elem.classList.contains("suggested_item")) {
         // handle by parent:
@@ -607,7 +616,7 @@ function use_selected_suggestion(suggested_item_elem) {
         return
     }
 
-    // Concatenate inner text of all span elements without outter formatting whitespaces:
+    // Concatenate inner text of all span elements without outer formatting whitespaces:
     let suggested_text = "";
     for (const span_child of suggested_item_elem.children) {
         suggested_text += span_child.textContent;
@@ -623,6 +632,16 @@ function use_selected_suggestion(suggested_item_elem) {
 
     // Selecting exact suggestions always completes token - append space to suggest next:
     const replacement_string = suggestion_only + " ";
+    complete_curr_token(command_line_input_elem, replacement_string);
+}
+
+function use_selected_remaining(remaining_item_elem) {
+
+    // Concatenate inner text of all span elements without outer formatting whitespaces:
+    const remaining_only = remaining_item_elem.textContent;
+
+    // Selecting exact suggestions always completes token - append space to suggest next:
+    const replacement_string = remaining_only + " ";
     complete_curr_token(command_line_input_elem, replacement_string);
 }
 
@@ -835,11 +854,17 @@ function populate_envelope_containers(
                 }
                 arg_value_elem.textContent = "?";
                 arg_source_elem.textContent = "";
-                remaining_values_elem.textContent = envelope_container.remaining_types_to_values[arg_type].join(" ")
+                for (const remaining_value of envelope_container.remaining_types_to_values[arg_type]) {
+                    const remaining_item_elem = remaining_item_temp.content.cloneNode(true).children[0];
+                    remaining_item_elem.addEventListener(
+                        "click",
+                        on_remaining_click,
+                    );
+                    remaining_item_elem.textContent = remaining_value;
+                    remaining_values_elem.append(remaining_item_elem);
+                }
 
                 arg_type_elem.classList.add("unknown_arg_value");
-                arg_type_elem.classList.add("unknown_arg_value");
-                remaining_values_elem.classList.add("suggested_arg_value");
             } else {
                 arg_type_elem.textContent = arg_type + ": ";
                 // See: SpecialChar.NoPropValue:

--- a/src/argrelay/relay_server/gui_static/argrelay_style.css
+++ b/src/argrelay/relay_server/gui_static/argrelay_style.css
@@ -225,6 +225,21 @@ Legend
 }
 
 /***********************************************************************************************************************
+Click-able arg
+***********************************************************************************************************************/
+
+.selectable_item {
+    white-space: nowrap;
+    width: fit-content;
+    margin: 0 2px 2px 0;
+    padding: 2px;
+    border-style: solid;
+    border-width: 1px;
+    border-color: lightskyblue;
+    cursor: crosshair;
+}
+
+/***********************************************************************************************************************
 Suggestion details
 ***********************************************************************************************************************/
 
@@ -234,14 +249,6 @@ Suggestion details
 }
 
 .suggested_item {
-    white-space: nowrap;
-    width: fit-content;
-    margin: 0 2px 2px 0;
-    padding: 2px;
-    border-style: solid;
-    border-width: 1px;
-    border-color: lightskyblue;
-    cursor: crosshair;
 }
 
 .input_part {
@@ -282,7 +289,12 @@ Search outline details
     color: darkorange;
 }
 
-.suggested_arg_value {
+.remaining_values {
+    display: inline-flex;
+    flex-wrap: wrap;
+}
+
+.remaining_item {
     color: blue;
 }
 

--- a/src/argrelay/relay_server/gui_templates/argrelay_main.html
+++ b/src/argrelay/relay_server/gui_templates/argrelay_main.html
@@ -162,6 +162,7 @@
        <div
            id="describe_output"
            class="output_box"
+           data-cy="remaining_output"
        >
        </div>
     </div>
@@ -210,7 +211,11 @@
     </template>
 
     <template id="suggested_item_temp">
-        <div class="suggested_item"><span class="input_part"></span><span class="incomplete_part"></span><span class="unique_part"></span><span class="comment_part"></span></div>
+        <div class="selectable_item suggested_item"><span class="input_part"></span><span class="incomplete_part"></span><span class="unique_part"></span><span class="comment_part"></span></div>
+    </template>
+
+    <template id="remaining_item_temp">
+        <span class="selectable_item remaining_item"></span>
     </template>
 
 </body>

--- a/tests/gui_tests/cypress/e2e/argrelay_gui/input_output_basics.cy.js
+++ b/tests/gui_tests/cypress/e2e/argrelay_gui/input_output_basics.cy.js
@@ -33,11 +33,11 @@ describe('argrelay GUI', () => {
         cy
             .get('[data-cy=command_line_input]')
             .should('have.class', 'io_state_pending_response_input')
+        // Final (stable) output:
         cy
             .get('[data-cy=command_line_input]')
             .should('have.class', 'io_state_client_synced_input')
 
-        // Final (stable) output:
         cy
             .get('[data-cy=suggestion_output]')
             .children()
@@ -58,5 +58,86 @@ describe('argrelay GUI', () => {
                 expect(suggested_strings).to.include('list')
                 expect(suggested_strings).to.include('no_data')
             })
+    })
+
+    it('suggestions get listed on command input', {
+        // If cache is disabled and TD_38_03_48_51 large generated data set is used, it takes a while:
+        defaultCommandTimeout: 30_000
+    }, () => {
+
+        // This test will select (out of order) the following line by clicking remaining items:
+        const input_command_first_arg = 'lay'
+        const input_command_args = [
+            'func_id_list_service',
+            'duplicates',
+            'active',
+            'sss',
+        ]
+        const input_command_last_arg = 'dc.44'
+
+        // Initial (stable) output:
+        cy
+            .get('[data-cy=command_line_input]')
+            .should('have.class', 'io_state_client_synced_input')
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // first arg
+
+        cy
+            .get('[data-cy=command_line_input]')
+            .focus()
+            .clear()
+            .type(`${input_command_first_arg} `)
+        // Final (stable) output:
+        cy
+            .get('[data-cy=command_line_input]')
+            .should('have.class', 'io_state_client_synced_input')
+        // Has suggestions:
+            cy
+                .get('[data-cy=suggestion_output]')
+                .get('.suggested_item')
+                .then(suggested_elems => {
+                    expect(suggested_elems).to.have.length.greaterThan(0)
+                });
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // mid args
+
+        for (const input_arg of input_command_args) {
+            cy
+                .get('[data-cy=remaining_output]')
+                .get('.remaining_item')
+                .contains(input_arg)
+                .click()
+            // Final (stable) output:
+            cy
+                .get('[data-cy=command_line_input]')
+                .should('have.class', 'io_state_client_synced_input')
+            // Has suggestions:
+            cy
+                .get('[data-cy=suggestion_output]')
+                .get('.suggested_item')
+                .then(suggested_elems => {
+                    expect(suggested_elems).to.have.length.greaterThan(0)
+                });
+        }
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // last arg
+        cy
+            .get('[data-cy=remaining_output]')
+            .get('.remaining_item')
+            .contains(input_command_last_arg)
+            .click()
+        // Final (stable) output:
+        cy
+            .get('[data-cy=command_line_input]')
+            .should('have.class', 'io_state_client_synced_input')
+
+        // Has no more suggestions:
+        cy
+            .get('[data-cy=suggestion_output]')
+            .get('.suggested_item')
+            .should('have.length', 0)
     })
 })

--- a/tests/offline_tests/plugin_delegator/test_InterceptorDelegator.py
+++ b/tests/offline_tests/plugin_delegator/test_InterceptorDelegator.py
@@ -3,6 +3,7 @@ from argrelay.enum_desc.ArgSource import ArgSource
 from argrelay.enum_desc.CompType import CompType
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.enum_desc.ReservedPropName import ReservedPropName
+from argrelay.enum_desc.SpecialFunc import SpecialFunc
 from argrelay.plugin_delegator.InterceptDelegator import output_format_class_name, OutputFormat, output_format_prop_name
 from argrelay.plugin_interp.FuncTreeInterpFactory import func_envelope_path_step_prop_name
 from argrelay.runtime_data.AssignedValue import AssignedValue
@@ -67,6 +68,7 @@ class ThisTestClass(LocalTestClass):
                 None,
                 "Completion continues to be driven by function selected via `goto` and `service`.",
             ),
+            # TODO: TODO_10_06_46_37: list arg value consumption stop options
             # (
             #     line_no(),
             #     "some_command intercept goto service s_b prod dc.77 |",
@@ -77,7 +79,6 @@ class ThisTestClass(LocalTestClass):
             #     ],
             #     None,
             #     None,
-            #     # TODO: FS_13_51_07_97 list arg value: the `data_envelope` is singled out, but list arg values should still be suggested (or not?):
             #     "FS_13_51_07_97 list arg value: singled out `data_envelope` with list arg value "
             #     "will still show all options of the list "
             #     "because explicit selection of one of these values from singled out `data_envelop` "
@@ -267,6 +268,38 @@ class ThisTestClass(LocalTestClass):
                 },
                 None,
                 "Prepend `intercept` by another `intercept` multiple times.",
+            ),
+            (
+                line_no(),
+                "some_command func_id_intercept_invocation intercept |",
+                CompType.PrefixShown,
+                [
+                    # TODO: TODO_80_99_84_41 `intercept` has no suggestions if selected via `func_id`
+                ],
+                {
+                    0: {
+                        ReservedPropName.envelope_class.name: AssignedValue(
+                            ReservedEnvelopeClass.ClassFunction.name,
+                            ArgSource.InitValue,
+                        ),
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue("intercept", ArgSource.ExplicitPosArg),
+                        ReservedPropName.func_id.name: AssignedValue(
+                            SpecialFunc.func_id_intercept_invocation.name,
+                            ArgSource.ExplicitPosArg
+                        )
+                    },
+                    1: {
+                        ReservedPropName.envelope_class.name: AssignedValue(
+                            output_format_class_name,
+                            ArgSource.InitValue,
+                        ),
+                        output_format_prop_name: AssignedValue(OutputFormat.json_format.name, ArgSource.DefaultValue),
+                    },
+                    2: None,
+                },
+                None,
+                "TODO: TODO_80_99_84_41 `intercept` has no suggestions if selected via `func_id`",
             ),
         ]
 

--- a/tests/offline_tests/relay_client/test_imports_ProposeArgValuesRemoteOptimizedClientCommand.py
+++ b/tests/offline_tests/relay_client/test_imports_ProposeArgValuesRemoteOptimizedClientCommand.py
@@ -134,8 +134,12 @@ class ThisTestClass(BaseTestClass):
             "argrelay.enum_desc.ServerAction",
             "argrelay.misc_helper_common",
             "argrelay.misc_helper_common.ElapsedTime",
+            "argrelay.relay_client.client_utils",
             "argrelay.runtime_data.ClientConfig",
             "argrelay.runtime_data.ConnectionConfig",
+            "sys"
+        ],
+        "argrelay.relay_client.client_utils": [
             "sys"
         ],
         "argrelay.relay_client.proc_splitter": [


### PR DESCRIPTION
*   Make remaining items click-able in GUI describe output.
*   Handle top level exception similarly in client `main`-s func.
*   Spec `TODO_10_06_46_37.list_arg_value_consumption_stop_options.md`.
*   SPec `TODO_80_99_84_41.intercept_has_no_suggestions_if_selected_via_func_id.md`.
