### PR TITLE
Allow unconsumed args for `intercept`

### DIFF
--- a/src/argrelay/_version.py
+++ b/src/argrelay/_version.py
@@ -1,4 +1,4 @@
 # See `docs/dev_notes/version_format.md`:
 # Implements this:
 # https://stackoverflow.com/a/7071358/441652
-__version__ = "0.7.14"
+__version__ = "0.7.15"

--- a/src/argrelay/plugin_delegator/InterceptDelegator.py
+++ b/src/argrelay/plugin_delegator/InterceptDelegator.py
@@ -9,7 +9,6 @@ from argrelay.enum_desc.SpecialFunc import SpecialFunc
 from argrelay.plugin_delegator.AbstractDelegator import get_func_id_from_invocation_input, get_func_id_from_interp_ctx
 from argrelay.plugin_delegator.AbstractJumpDelegator import AbstractJumpDelegator
 from argrelay.plugin_delegator.delegator_utils import set_default_to
-from argrelay.plugin_loader.client_invocation_utils import prohibit_unconsumed_args
 from argrelay.relay_server.LocalServer import LocalServer
 from argrelay.runtime_context.InterpContext import InterpContext
 from argrelay.schema_config_interp.DataEnvelopeSchema import instance_data_
@@ -21,9 +20,6 @@ from argrelay.schema_config_interp.FunctionEnvelopeInstanceDataSchema import (
 from argrelay.schema_config_interp.SearchControlSchema import populate_search_control
 from argrelay.schema_response.InvocationInput import InvocationInput
 from argrelay.schema_response.InvocationInputSchema import invocation_input_desc
-
-output_format_class_name = "OutputFormat"
-output_format_prop_name = "output_format"
 
 format_output_container_ipos_ = 1
 
@@ -38,6 +34,8 @@ class OutputFormat(Enum):
     text_format = auto()
     table_format = auto()
 
+output_format_class_name = OutputFormat.__name__
+output_format_prop_name = "output_format"
 
 class InterceptDelegator(AbstractJumpDelegator):
 
@@ -125,7 +123,7 @@ class InterceptDelegator(AbstractJumpDelegator):
         func_id = get_func_id_from_invocation_input(invocation_input)
         if func_id == SpecialFunc.func_id_intercept_invocation.name:
 
-            prohibit_unconsumed_args(invocation_input)
+            # NOTE: This function does not prohibit unrecognized args.
 
             output_format: OutputFormat = OutputFormat[invocation_input.envelope_containers[
                 format_output_container_ipos_

--- a/src/argrelay/relay_server/gui_static/argrelay_client.js
+++ b/src/argrelay/relay_server/gui_static/argrelay_client.js
@@ -17,6 +17,8 @@ const arg_container_temp = document.querySelector("#arg_container_temp")
 
 const remaining_item_temp = document.querySelector("#remaining_item_temp");
 
+const reset_all_elem = document.querySelector("#id_reset_all_button")
+
 const copy_command_elem = document.querySelector("#id_copy_command_button")
 const copy_link_elem = document.querySelector("#id_copy_link_button")
 
@@ -51,6 +53,7 @@ const static_client_conf_target = "_embedded_web_";
 const command_history_key = "command_history";
 const command_history_max_size = 10;
 const request_delay_ms = 500;
+const clipboard_disabled = "clipboard disabled";
 let command_history_list = [];
 let input_version = 0;
 
@@ -427,14 +430,9 @@ command_history_elem.addEventListener(
     handle_select_history,
 )
 
-copy_command_elem.addEventListener(
+reset_all_elem.addEventListener(
     "click",
-    handle_copy_command,
-)
-
-copy_link_elem.addEventListener(
-    "click",
-    handle_link_command,
+    handle_reset_all,
 )
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -475,6 +473,27 @@ let suggest_state = new suggest_state_class("search_state");
 let search_state = new search_state_class("search_state");
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+
+function set_clipboard_state() {
+    if (typeof (navigator.clipboard) === "undefined") {
+        copy_command_elem.title = clipboard_disabled;
+        copy_link_elem.title = clipboard_disabled;
+        copy_command_elem.classList.add("button_disabled");
+        copy_link_elem.classList.add("button_disabled");
+    } else {
+        copy_command_elem.addEventListener(
+            "click",
+            handle_copy_command,
+        )
+        copy_link_elem.addEventListener(
+            "click",
+            handle_link_command,
+        )
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // client_uid
 
 function generate_client_uid() {
@@ -486,6 +505,16 @@ function generate_client_uid() {
     } else {
         generated_client_uid_value = JSON.parse(generated_client_uid_value);
     }
+}
+
+function handle_reset_all(
+    input_event,
+) {
+    history.replaceState(null, "", argrelay_gui_url);
+    command_line_input_elem.value = "";
+    invocation_output.textContent = "";
+    on_command_line_change();
+    command_line_input_elem.focus();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -950,6 +979,7 @@ function display_project_git_commit_time() {
 // Set `command_line` to the initial value:
 command_line_input_elem.value = command_line
 
+set_clipboard_state();
 generate_client_uid();
 display_server_start_time();
 display_project_git_commit_time();

--- a/src/argrelay/relay_server/gui_static/argrelay_style.css
+++ b/src/argrelay/relay_server/gui_static/argrelay_style.css
@@ -174,6 +174,35 @@ Output elements
 }
 
 /***********************************************************************************************************************
+Base button
+***********************************************************************************************************************/
+
+.base_button {
+    white-space: nowrap;
+    width: fit-content;
+    margin: 0 0 2px 0;
+    padding: 2px;
+    border-style: solid;
+    border-color: lightskyblue;
+    color: grey;
+    cursor: pointer;
+}
+
+/***********************************************************************************************************************
+Reset button
+***********************************************************************************************************************/
+
+.reset_button_container {
+    margin-top: 0;
+    display: flex;
+    justify-content: right;
+}
+
+.reset_all_button {
+    border-width: 1px 1px 1px 1px;
+}
+
+/***********************************************************************************************************************
 Copy buttons
 ***********************************************************************************************************************/
 
@@ -183,15 +212,8 @@ Copy buttons
     justify-content: right;
 }
 
-.copy_button {
-    white-space: nowrap;
-    width: fit-content;
-    margin: 0 0 2px 0;
-    padding: 2px;
-    border-style: solid;
-    border-color: lightskyblue;
-    color: grey;
-    cursor: pointer;
+.button_disabled {
+    cursor: not-allowed;
 }
 
 .copy_command_button {

--- a/src/argrelay/relay_server/gui_templates/argrelay_main.html
+++ b/src/argrelay/relay_server/gui_templates/argrelay_main.html
@@ -67,6 +67,15 @@
         {{ header_html | safe }}
     </div>
 
+    <div class="reset_button_container">
+        <div
+            id="id_reset_all_button"
+            class="base_button reset_all_button"
+        >
+            reset all
+        </div>
+    </div>
+
     <div class="top_container">
         <div
             id="command_history_label"
@@ -103,13 +112,13 @@
     <div class="copy_buttons_container">
         <div
             id="id_copy_command_button"
-            class="copy_button copy_command_button"
+            class="base_button copy_command_button"
         >
             copy command
         </div>
         <div
             id="id_copy_link_button"
-            class="copy_button copy_link_button"
+            class="base_button copy_link_button"
         >
             copy link
         </div>

--- a/tests/online_tests/end_to_end/test_run_argrelay_client_server.py
+++ b/tests/online_tests/end_to_end/test_run_argrelay_client_server.py
@@ -180,10 +180,11 @@ apac
             ),
             (
                 line_no(), f"{self.default_bound_command} intercept this_arg_is_unknown_and_unconsumed".split(" "),
-                ClientExitCode.GeneralError.value,
+                ClientExitCode.ClientSuccess.value,
+                # There is output - ignore:
+                None,
                 "",
-                f"ERROR: this function prohibits unrecognized args (see {TermColor.remaining_token.value}highlighted{TermColor.reset_style.value} on Alt+Shift+Q results): {TermColor.remaining_token.value}this_arg_is_unknown_and_unconsumed{TermColor.reset_style.value}" + "\n",
-                "FS_88_66_66_73 intercept prohibits unconsumed args",
+                "FS_88_66_66_73 intercept does NOT prohibit unconsumed args",
             ),
             (
                 line_no(), f"{self.default_bound_command} goto repo this_arg_is_unknown_and_unconsumed".split(" "),


### PR DESCRIPTION
*   Because `intercept` deals with any func (with any arg list), unconsumed args should be allowed.
*   GUI: Add "reset all" button.
*   GUI: Detect disabled clipboard.
