### PR TITLE
Implement read-only metadata query func

### DIFF
--- a/docs/feature_stories/FS_56_43_05_79.search_diff_collection.md
+++ b/docs/feature_stories/FS_56_43_05_79.search_diff_collection.md
@@ -4,6 +4,8 @@ feature_title: search diff collection
 feature_status: TEST
 ---
 
+TODO: TODO_08_25_32_95: redesign `class_to_collection_map`
+
 # Feature description
 
 To load data, `argrelay` server can use multiple MongoDB connections - see `MongoClientWrapper.store_envelopes`.
@@ -20,7 +22,6 @@ class_to_collection_map:
     ClassCluster: ClassCluster
     ClassHost: ClassHost
     ClassService: ClassService
-    access_type: access_type
 ```
 
 # Plugin behavior

--- a/docs/feature_stories/FS_74_69_61_79.get_set_data_envelope.md
+++ b/docs/feature_stories/FS_74_69_61_79.get_set_data_envelope.md
@@ -4,11 +4,49 @@ feature_title: get set data envelope
 feature_status: TODO
 ---
 
+TODO: Maybe rename "get set data envelope" to "get set envelope_container"?
+
 Currently, the data is populated by plugins running inside the server process during start-up.
 
 There should be a way to update data out of the server process, to get/set envelope:
 *   CLI command
 *   REST API call
+
+# Addressing approach
+
+The data should be manipulated via `envelope_container`-s which specifies search criteria to
+get or set all `data_envelope`-s matching the criteria - this is the only way to avoid exposing internal ids.
+
+The search criteria acts as "snapshot address" and data is always replaced entirely for the selected snapshot.
+
+# General idea
+
+REST API is trivial, if it does not need to be convenient for CLI, but it does have to be convenient for CLI.
+
+# Internal metadata for CLI
+
+All `data_envelope`-s can be scanned to create a `data_envelope`-s with metadata for get or set operations.
+
+Metadata `data_envelope` will have to provide (describe) each `envelope_class` loaded so far:
+*   `collection_name`
+*   `envelope_class`
+Its payload will have to be `index_props` of that `envelope_class`.
+
+# CLI `search_control`
+
+To avoid the need to specify FS_31_70_49_15 `search_control` for CLI,
+it has to be static able to search any `data_envelope` by their `index_prop`-s.
+
+Some of the `search_control` fields:
+*   `collection_name` to select MongoDB collection
+*   `envelope_class` from `ReservedPropName` to select set of `index_prop`-s
+*   N x `index_prop` with some deterministic order
+
+# Payload with `data_envelope`-s
+
+The payload for each operation (get or set) is a list of `data_envelope`-s.
+
+For CLI, the payload maybe split per line with individual `data_envelope` JSON.
 
 # See also
 

--- a/docs/task_refs/TODO_08_25_32_95.redesign_class_to_collection_map.md
+++ b/docs/task_refs/TODO_08_25_32_95.redesign_class_to_collection_map.md
@@ -1,0 +1,17 @@
+
+TODO: TODO_08_25_32_95: redesign `class_to_collection_map`
+
+It makes little sense, it should make more.
+
+It was created for the single "technical" purpose - to FS_56_43_05_79 search diff collection.
+Yes, it served its initial purpose, but:
+
+*   It is not needed in most of the cases.
+
+    Not needed because combination of these 2 factors eliminates the need to specify it:
+
+    *   Most of the time, each `envelope_class` has to be loaded into its own `collection_name` - why not?
+    *   Loading multiple `envelope_class`-es into single `collection_name` combines their sets of `index_prop`-s.
+
+    In short, we can always rely on default mapping where `collection_name` = `envelope_class`.
+

--- a/src/argrelay/_version.py
+++ b/src/argrelay/_version.py
@@ -1,4 +1,4 @@
 # See `docs/dev_notes/version_format.md`:
 # Implements this:
 # https://stackoverflow.com/a/7071358/441652
-__version__ = "0.7.15"
+__version__ = "0.7.16"

--- a/src/argrelay/check_env/PluginCheckEnvServerIndex.py
+++ b/src/argrelay/check_env/PluginCheckEnvServerIndex.py
@@ -57,9 +57,17 @@ class PluginCheckEnvServerIndex(PluginCheckEnvAbstract):
                 result_message = f"It is not a file: {at_path}",
             )]
         else:
-            return [CheckEnvResult(
-                result_category = ResultCategory.VerificationWarning,
-                result_key = _server_index_field_name,
-                result_value = str(None),
-                result_message = f"The client has not been used to create this file yet: {at_path}",
-            )]
+            if os.getenv("ARGRELAY_BOOTSTRAP_ENV") is None:
+                return [CheckEnvResult(
+                    result_category = ResultCategory.VerificationWarning,
+                    result_key = _server_index_field_name,
+                    result_value = str(None),
+                    result_message = f"The client has not been used to create this file yet: {at_path}",
+                )]
+            else:
+                return [CheckEnvResult(
+                    result_category = ResultCategory.VerificationSuccess,
+                    result_key = _server_index_field_name,
+                    result_value = str(None),
+                    result_message = f"Running with `ARGRELAY_BOOTSTRAP_ENV` - ignoring missing file: {at_path}",
+                )]

--- a/src/argrelay/check_env/__main__.py
+++ b/src/argrelay/check_env/__main__.py
@@ -42,6 +42,7 @@ def main():
     except BaseException as e1:
         handle_main_exception(e1)
 
+
 def check_env_logic():
     argrelay_dir: str = os.path.realpath(os.path.abspath(sys.argv[1]))
     misc_helper_common.set_argrelay_dir(argrelay_dir)

--- a/src/argrelay/custom_integ/ConfigOnlyLoader.py
+++ b/src/argrelay/custom_integ/ConfigOnlyLoader.py
@@ -75,7 +75,8 @@ class ConfigOnlyLoader(AbstractLoader):
         ]
 
         init_envelop_collections(
-            self.server_config,
+            self.server_config.class_to_collection_map,
+            self.server_config.static_data.envelope_collections,
             class_names,
             lambda _collection_name, _class_name: collection_name_to_index_props_map[_collection_name],
         )

--- a/src/argrelay/custom_integ/GitRepoLoader.py
+++ b/src/argrelay/custom_integ/GitRepoLoader.py
@@ -99,10 +99,11 @@ class GitRepoLoader(AbstractLoader):
         ]
 
         init_envelop_collections(
-            self.server_config,
+            self.server_config.class_to_collection_map,
+            self.server_config.static_data.envelope_collections,
             class_names,
             # Same index fields for all collections (can be fine-tuned later):
-            lambda collection_name, class_name: [enum_item.name for enum_item in GitRepoPropName]
+            lambda collection_name, class_name: [enum_item.name for enum_item in GitRepoPropName],
         )
 
         repo_envelopes = static_data.envelope_collections[

--- a/src/argrelay/custom_integ/ServiceDelegator.py
+++ b/src/argrelay/custom_integ/ServiceDelegator.py
@@ -21,18 +21,15 @@ from argrelay.plugin_delegator.AbstractDelegator import (
     get_func_id_from_interp_ctx,
     get_func_id_from_invocation_input,
 )
-from argrelay.plugin_delegator.ErrorDelegator import ErrorDelegator
 from argrelay.plugin_delegator.ErrorDelegatorCustomDataSchema import (
     error_message_,
     error_code_,
-    error_delegator_custom_data_desc,
     error_delegator_stub_custom_data_example,
 )
-from argrelay.plugin_delegator.delegator_utils import set_default_to
+from argrelay.plugin_delegator.delegator_utils import set_default_to, redirect_to_error, redirect_to_no_func_error
 from argrelay.plugin_loader.client_invocation_utils import prohibit_unconsumed_args
 from argrelay.relay_server.LocalServer import LocalServer
 from argrelay.runtime_context.InterpContext import InterpContext
-from argrelay.runtime_data.PluginConfig import PluginConfig
 from argrelay.runtime_data.ServerConfig import ServerConfig
 from argrelay.schema_config_interp.DataEnvelopeSchema import (
     instance_data_,
@@ -53,40 +50,6 @@ access_container_ipos_ = 2
 
 diff_service_container_left_ipos_ = 1
 diff_service_container_right_ipos_ = 2
-
-
-def redirect_to_no_func_error(
-    interp_ctx,
-    plugin_config,
-):
-    return redirect_to_error(
-        interp_ctx,
-        plugin_config,
-        "ERROR: objects cannot be searched until function is fully qualified",
-        1,
-    )
-
-
-def redirect_to_error(
-    interp_ctx,
-    plugin_config: PluginConfig,
-    error_message,
-    error_code,
-):
-    # Redirect to `ErrorDelegator`:
-    # TODO: TODO_62_75_33_41: Do not hardcode plugin instance id (instance of `ErrorDelegator`):
-    delegator_plugin_instance_id = f"{ErrorDelegator.__name__}.default"
-    custom_plugin_data = {
-        error_message_: error_message,
-        error_code_: error_code,
-    }
-    error_delegator_custom_data_desc.validate_dict(custom_plugin_data)
-    invocation_input = InvocationInput.with_interp_context(
-        interp_ctx,
-        delegator_plugin_entry = plugin_config.plugin_instance_entries[delegator_plugin_instance_id],
-        custom_plugin_data = custom_plugin_data,
-    )
-    return invocation_input
 
 
 class ServiceDelegator(AbstractDelegator):

--- a/src/argrelay/enum_desc/DataOperation.py
+++ b/src/argrelay/enum_desc/DataOperation.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class DataOperation(Enum):
+    """
+    `DataOperation` defines server API to manipulate data at its backend.
+
+    Implements FS_74_69_61_79 get set data envelope.
+
+    For user operations on command line see `ServerAction`.
+    """
+
+    get_data_envelopes = "/get_data_envelopes/"
+
+    set_data_envelopes = "/set_data_envelopes/"

--- a/src/argrelay/enum_desc/ReservedEnvelopeClass.py
+++ b/src/argrelay/enum_desc/ReservedEnvelopeClass.py
@@ -11,6 +11,14 @@ class ReservedEnvelopeClass(Enum):
     ClassFunction = auto()
 
     ClassHelp = auto()
+    """
+    See FS_71_87_33_52 help_hint.
+    """
+
+    ClassCollectionMeta = auto()
+    """
+    See FS_74_69_61_79 get set data envelope.
+    """
 
     def __str__(self):
         return self.name

--- a/src/argrelay/enum_desc/ReservedPropName.py
+++ b/src/argrelay/enum_desc/ReservedPropName.py
@@ -6,6 +6,8 @@ class ReservedPropName(Enum):
     Some of the `data_envelope` props used to implement various `argrelay` features.
     """
 
+    collection_name = auto()
+
     envelope_class = auto()
 
     func_id = auto()

--- a/src/argrelay/enum_desc/ServerAction.py
+++ b/src/argrelay/enum_desc/ServerAction.py
@@ -3,9 +3,13 @@ from enum import Enum
 
 class ServerAction(Enum):
     """
+    `ServerAction`-s are specific to operations on command line (primary purpose of `argrelay`).
+
     Defines both:
     *   `ServerAction` in REST API URL path for server request (via enum item value)
     *   `ServerAction` in server request payload (via enum item name)
+
+    See `DataOperation` to perform data updates.
     """
 
     ProposeArgValues = "/propose_arg_values/"

--- a/src/argrelay/enum_desc/SpecialFunc.py
+++ b/src/argrelay/enum_desc/SpecialFunc.py
@@ -35,3 +35,8 @@ class SpecialFunc(Enum):
     """
     Implements FS_02_25_41_81 `func_id_query_enum_items`.
     """
+
+    func_id_get_data_envelopes = auto()
+    """
+    Implements FS_74_69_61_79 get set data envelope.
+    """

--- a/src/argrelay/mongo_data/LoadProgressState.py
+++ b/src/argrelay/mongo_data/LoadProgressState.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class LoadProgressState:
+    """
+    State and stats to track `data_envelope`-s loading progress.
+    """
+    envelope_per_col_i: int = field(default = 0)
+    envelope_per_col_n: int = field(default = 0)
+    total_envelope_i: int = field(default = 0)
+    total_envelope_n: int = field(default = 0)

--- a/src/argrelay/mongo_data/MongoClientWrapper.py
+++ b/src/argrelay/mongo_data/MongoClientWrapper.py
@@ -8,6 +8,7 @@ from pymongo.collection import Collection
 from pymongo.database import Database
 
 from argrelay.misc_helper_common import eprint
+from argrelay.mongo_data.LoadProgressState import LoadProgressState
 from argrelay.mongo_data.MongoConfig import MongoConfig
 from argrelay.runtime_data.EnvelopeCollection import EnvelopeCollection
 from argrelay.runtime_data.StaticData import StaticData
@@ -29,31 +30,29 @@ def store_envelopes(
     mongo_db: Database,
     cleaned_mongo_collections: set[str],
     static_data: StaticData,
-    total_envelope_n: int,
-    curr_envelope_i: int,
+    load_state: LoadProgressState,
 ):
     # Calculate total:
     for mongo_collection in static_data.envelope_collections:
         envelope_collection: EnvelopeCollection = static_data.envelope_collections[
             mongo_collection
         ]
-        total_envelope_n += len(envelope_collection.data_envelopes)
+        load_state.total_envelope_n += len(envelope_collection.data_envelopes)
 
     # Index all:
     for mongo_collection in static_data.envelope_collections:
         envelope_collection: EnvelopeCollection = static_data.envelope_collections[
             mongo_collection
         ]
-        curr_envelope_i += store_envelope_collection(
+        store_envelope_collection(
             mongo_db,
             cleaned_mongo_collections,
             mongo_collection,
             envelope_collection,
-            curr_envelope_i,
-            total_envelope_n,
+            load_state,
         )
 
-    assert curr_envelope_i == total_envelope_n
+    assert load_state.total_envelope_i == load_state.total_envelope_n
 
 
 def store_envelope_collection(
@@ -61,23 +60,23 @@ def store_envelope_collection(
     cleaned_mongo_collections: set[str],
     mongo_collection: str,
     envelope_collection: EnvelopeCollection,
-    curr_envelope_i: int,
-    total_envelope_n: int,
-) -> int:
+    load_state: LoadProgressState,
+) -> None:
     col_proxy: Collection = mongo_db[mongo_collection]
     if mongo_collection not in cleaned_mongo_collections:
         col_proxy.delete_many({})
         col_proxy.drop_indexes()
         cleaned_mongo_collections.add(mongo_collection)
 
-    base_curr_envelope_i: int = curr_envelope_i
-    envelope_per_col_i: int = 0
-    log_index_progress(mongo_collection, envelope_per_col_i, curr_envelope_i, total_envelope_n)
+    base_total_envelope_i: int = load_state.total_envelope_i
+    load_state.envelope_per_col_i = 0
+    load_state.envelope_per_col_n = len(envelope_collection.data_envelopes)
+    log_index_progress(mongo_collection, load_state)
     for data_envelope in envelope_collection.data_envelopes:
-        if curr_envelope_i % 1_000 == 0:
-            log_index_progress(mongo_collection, envelope_per_col_i, curr_envelope_i, total_envelope_n)
-        curr_envelope_i += 1
-        envelope_per_col_i += 1
+        if load_state.total_envelope_i > 0 and load_state.total_envelope_i % 1_000 == 0:
+            log_index_progress(mongo_collection, load_state)
+        load_state.total_envelope_i += 1
+        load_state.envelope_per_col_i += 1
         envelope_to_store = deepcopy(data_envelope)
 
         try:
@@ -92,37 +91,43 @@ def store_envelope_collection(
             # Rethrow previous error:
             raise
 
-    log_index_progress(mongo_collection, envelope_per_col_i, curr_envelope_i, total_envelope_n)
+    log_index_progress(mongo_collection, load_state)
 
-    assert envelope_per_col_i == curr_envelope_i - base_curr_envelope_i
-    return envelope_per_col_i
+    assert load_state.envelope_per_col_i == load_state.total_envelope_i - base_total_envelope_i
 
 
 def log_index_progress(
     mongo_collection: str,
-    envelope_per_col_i: int,
-    curr_envelope_i: int,
-    total_envelope_n: int,
+    load_state: LoadProgressState,
 ):
     try:
-        assert envelope_per_col_i <= curr_envelope_i <= total_envelope_n
+        assert load_state.envelope_per_col_i <= load_state.envelope_per_col_n
+        assert load_state.total_envelope_i <= load_state.total_envelope_n
+        assert load_state.envelope_per_col_n <= load_state.total_envelope_n
     finally:
         eprint(
-            f"collection: {mongo_collection}: indexed envelopes: {envelope_per_col_i}/{curr_envelope_i}/{total_envelope_n}..."
+            f"collection: {mongo_collection}: indexed envelopes: "
+            f"{load_state.envelope_per_col_i}/{load_state.envelope_per_col_n} "
+            f"{load_state.total_envelope_i}/{load_state.total_envelope_n} "
+            "..."
         )
 
 
 def log_validation_progress(
     validation_step: str,
     mongo_collection: str,
-    curr_envelope_i: int,
-    total_envelope_n: int,
+    load_state: LoadProgressState,
 ):
     try:
-        assert curr_envelope_i <= total_envelope_n
+        assert load_state.envelope_per_col_i <= load_state.envelope_per_col_n
+        assert load_state.total_envelope_i <= load_state.total_envelope_n
+        assert load_state.envelope_per_col_n <= load_state.total_envelope_n
     finally:
         eprint(
-            f"validation step: {validation_step}: collection: {mongo_collection}: validated envelopes: {curr_envelope_i}/{total_envelope_n}..."
+            f"validation step: {validation_step}: collection: {mongo_collection}: validated envelopes: "
+            f"{load_state.envelope_per_col_i}/{load_state.envelope_per_col_n} "
+            f"{load_state.total_envelope_i}/{load_state.total_envelope_n} "
+            f"..."
         )
 
 

--- a/src/argrelay/plugin_delegator/AbstractDelegator.py
+++ b/src/argrelay/plugin_delegator/AbstractDelegator.py
@@ -73,12 +73,20 @@ class AbstractDelegator(AbstractPluginServer):
 
     def run_search_control(
         self,
+        interp_ctx: "InterpContext",
         function_data_envelope: dict,
-    ) -> list[SearchControl]:
+        func_param_container_offset: int,
+    ) -> Union[SearchControl, None]:
         """
         Implements FS_31_70_49_15 `search_control`.
         """
-        return self.extract_search_control_from_function_data_envelope(function_data_envelope)
+        search_control_list: list[SearchControl] = self.extract_search_control_from_function_data_envelope(
+            function_data_envelope,
+        )
+        if func_param_container_offset < len(search_control_list):
+            return search_control_list[func_param_container_offset]
+        else:
+            return None
 
     def run_init_control(
         self,

--- a/src/argrelay/plugin_delegator/HelpDelegator.py
+++ b/src/argrelay/plugin_delegator/HelpDelegator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from argrelay.custom_integ.ServiceDelegator import redirect_to_no_func_error
+from argrelay.plugin_delegator.delegator_utils import redirect_to_no_func_error
 from argrelay.enum_desc.FuncState import FuncState
 from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
 from argrelay.enum_desc.ReservedPropName import ReservedPropName

--- a/src/argrelay/plugin_delegator/InterceptDelegator.py
+++ b/src/argrelay/plugin_delegator/InterceptDelegator.py
@@ -34,8 +34,10 @@ class OutputFormat(Enum):
     text_format = auto()
     table_format = auto()
 
+
 output_format_class_name = OutputFormat.__name__
 output_format_prop_name = "output_format"
+
 
 class InterceptDelegator(AbstractJumpDelegator):
 

--- a/src/argrelay/plugin_delegator/MetadataDelegator.py
+++ b/src/argrelay/plugin_delegator/MetadataDelegator.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+from typing import Union
+
+from argrelay.plugin_delegator.delegator_utils import redirect_to_no_func_error
+from argrelay.enum_desc.FuncState import FuncState
+from argrelay.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay.enum_desc.ReservedPropName import ReservedPropName
+from argrelay.enum_desc.SpecialFunc import SpecialFunc
+from argrelay.plugin_delegator.AbstractDelegator import (
+    AbstractDelegator,
+    get_func_id_from_invocation_input,
+    get_func_id_from_interp_ctx,
+)
+from argrelay.plugin_loader.client_invocation_utils import prohibit_unconsumed_args
+from argrelay.relay_server.LocalServer import LocalServer
+from argrelay.runtime_context.InterpContext import InterpContext
+from argrelay.runtime_context.SearchControl import SearchControl
+from argrelay.runtime_data.ServerConfig import ServerConfig
+from argrelay.schema_config_core_server.EnvelopeCollectionSchema import index_props_
+from argrelay.schema_config_interp.DataEnvelopeSchema import (
+    instance_data_,
+    envelope_payload_,
+)
+from argrelay.schema_config_interp.FunctionEnvelopeInstanceDataSchema import (
+    delegator_plugin_instance_id_,
+    search_control_list_,
+    func_id_,
+)
+from argrelay.schema_config_interp.SearchControlSchema import populate_search_control, search_control_desc
+from argrelay.schema_response.InvocationInput import InvocationInput
+
+collection_name_container_ipos_ = 1
+data_envelope_container_ipos_ = 2
+
+
+class MetadataDelegator(AbstractDelegator):
+    """
+    Implements FS_74_69_61_79 get set data envelope.
+    """
+
+    def __init__(
+        self,
+        server_config: ServerConfig,
+        plugin_instance_id: str,
+        plugin_config_dict: dict,
+    ):
+        super().__init__(
+            server_config,
+            plugin_instance_id,
+            plugin_config_dict,
+        )
+
+    def get_supported_func_envelopes(
+        self,
+    ) -> list[dict]:
+
+        class_to_collection_map: dict = self.server_config.class_to_collection_map
+
+        collection_search_control = populate_search_control(
+            class_to_collection_map,
+            ReservedEnvelopeClass.ClassCollectionMeta.name,
+            [
+                {"collection": ReservedPropName.collection_name.name},
+            ],
+        )
+
+        func_envelopes = []
+
+        given_function_envelope = {
+            instance_data_: {
+                func_id_: SpecialFunc.func_id_get_data_envelopes.name,
+                delegator_plugin_instance_id_: self.plugin_instance_id,
+                search_control_list_: [
+                    collection_search_control,
+                ],
+            },
+            ReservedPropName.envelope_class.name: ReservedEnvelopeClass.ClassFunction.name,
+            ReservedPropName.help_hint.name: "Get `data_envelope`-s based on their `index_prop`-s.",
+            ReservedPropName.func_state.name: FuncState.fs_alpha.name,
+            ReservedPropName.func_id.name: SpecialFunc.func_id_get_data_envelopes.name,
+        }
+        func_envelopes.append(given_function_envelope)
+
+        return func_envelopes
+
+    def run_search_control(
+        self,
+        interp_ctx: InterpContext,
+        function_data_envelope: dict,
+        func_param_container_offset: int,
+    ) -> Union[SearchControl, None]:
+        """
+        Provides `search_control` based on `index_prop` for FS_74_69_61_79 get set data envelope.
+        """
+        search_control_list: list[SearchControl] = self.extract_search_control_from_function_data_envelope(
+            function_data_envelope,
+        )
+        if func_param_container_offset < len(search_control_list):
+            return search_control_list[func_param_container_offset]
+        elif func_param_container_offset == len(search_control_list):
+            collection_name_container = interp_ctx.envelope_containers[collection_name_container_ipos_]
+            collection_name_container.data_envelopes = (
+                interp_ctx
+                .query_engine
+                .query_data_envelopes_for(collection_name_container)
+            )
+            if len(collection_name_container.data_envelopes) != 1:
+                return None
+            else:
+                index_props: list[str] = collection_name_container.data_envelopes[0][envelope_payload_][index_props_]
+                collection_name = collection_name_container.data_envelopes[0][ReservedPropName.collection_name.name]
+
+                keys_to_types_list: list[dict] = []
+                for index_prop in index_props:
+                    # For metadata: arg name is the same as prop name:
+                    keys_to_types_list.append({index_prop: index_prop})
+
+                # Construct `search_control` dynamically:
+                data_envelope_search_control_dict = populate_search_control(
+                    self.server_config.class_to_collection_map,
+                    # TODO: TODO_08_25_32_95: redesign `class_to_collection_map`:
+                    #       We specify `collection_name` instead of `class_name` while assuming they always match.
+                    collection_name,
+                    keys_to_types_list,
+                )
+                data_envelope_search_control_obj = search_control_desc.dict_schema.load(
+                    data_envelope_search_control_dict,
+                )
+                return data_envelope_search_control_obj
+
+        else:
+            return None
+
+    def run_invoke_control(
+        self,
+        interp_ctx: InterpContext,
+        local_server: LocalServer,
+    ) -> InvocationInput:
+
+        assert interp_ctx.is_func_found(), "the (first) function envelope must be found"
+
+        func_id = get_func_id_from_interp_ctx(interp_ctx)
+
+        vararg_container_ipos = data_envelope_container_ipos_
+
+        if func_id in [
+            SpecialFunc.func_id_get_data_envelopes.name,
+        ]:
+            # Verify that func is selected and all what is left to do is to query 0...N objects:
+            if interp_ctx.curr_container_ipos >= vararg_container_ipos:
+                # Search `data_envelope`-s based on existing args on command line:
+                vararg_container = interp_ctx.envelope_containers[vararg_container_ipos]
+                vararg_container.data_envelopes = (
+                    local_server
+                    .get_query_engine()
+                    .query_data_envelopes_for(vararg_container)
+                )
+
+                # Plugin to invoke on client side:
+                delegator_plugin_instance_id = self.plugin_instance_id
+                # Package into `InvocationInput` payload object:
+                invocation_input = InvocationInput.with_interp_context(
+                    interp_ctx,
+                    delegator_plugin_entry = local_server.plugin_config.plugin_instance_entries[
+                        delegator_plugin_instance_id
+                    ],
+                    custom_plugin_data = {},
+                )
+                return invocation_input
+            else:
+                return redirect_to_no_func_error(
+                    interp_ctx,
+                    local_server.server_config,
+                )
+        else:
+            # Plugin is given a function name it does not know:
+            raise RuntimeError
+
+    @staticmethod
+    def invoke_action(
+        invocation_input: InvocationInput,
+    ):
+        func_id = get_func_id_from_invocation_input(invocation_input)
+        if func_id == SpecialFunc.func_id_get_data_envelopes.name:
+            prohibit_unconsumed_args(invocation_input)
+            for data_envelope in invocation_input.envelope_containers[data_envelope_container_ipos_].data_envelopes:
+                print(json.dumps(data_envelope))

--- a/src/argrelay/runtime_context/InterpContext.py
+++ b/src/argrelay/runtime_context/InterpContext.py
@@ -171,11 +171,13 @@ class InterpContext:
     ) -> list[int]:
         return arg_buckets_to_token_ipos_list(self.consumed_arg_buckets)
 
-    def alloc_searchable_containers(
+    def alloc_searchable_container(
         self,
-        search_control_list: list[SearchControl],
+        base_container_ipos: int,
+        func_param_container_offset: int,
+        search_control: SearchControl,
     ):
-        for search_control in search_control_list:
+        if (base_container_ipos + func_param_container_offset + 1) >= len(self.envelope_containers):
             envelope_container = EnvelopeContainer(search_control)
             self.envelope_containers.append(envelope_container)
 

--- a/src/argrelay/runtime_data/EnvelopeCollection.py
+++ b/src/argrelay/runtime_data/EnvelopeCollection.py
@@ -13,7 +13,7 @@ class EnvelopeCollection:
     See also `EnvelopeCollectionSchema`.
     """
 
-    index_props: list = field()
+    index_props: list[str] = field()
     """
     Lists fields of `data_envelop` which are to be indexed by MongoDB for given collection.
     """

--- a/src/argrelay/runtime_data/ServerConfig.py
+++ b/src/argrelay/runtime_data/ServerConfig.py
@@ -19,7 +19,10 @@ class ServerConfig:
     query_cache_config: QueryCacheConfig = field()
     gui_banner_config: GuiBannerConfig = field()
     default_gui_command: str = field()
-    class_to_collection_map: dict = field()
+
+    # TODO: TODO_08_25_32_95: redesign `class_to_collection_map`:
+    class_to_collection_map: dict[str, str] = field()
+
     server_plugin_control: ServerPluginControl = field()
 
     # TODO_00_79_72_55: remove in the future:

--- a/src/argrelay/runtime_data/StaticData.py
+++ b/src/argrelay/runtime_data/StaticData.py
@@ -17,5 +17,7 @@ class StaticData:
     """
     MondoDB collection name to its `EnvelopeCollection`.
 
-    Collection name is normally (but not necessarily) matching one of the `ReservedPropName.envelope_class`.
+    TODO: TODO_08_25_32_95: redesign `class_to_collection_map`:
+    Collection name is normally (but not necessarily) matching
+    the value of `ReservedPropName.envelope_class` prop.
     """

--- a/src/argrelay/sample_conf/argrelay_plugin.yaml
+++ b/src/argrelay/sample_conf/argrelay_plugin.yaml
@@ -17,6 +17,7 @@ plugin_instance_entries:
             -   InterceptDelegator.default
             -   HelpDelegator.default
             -   QueryEnumDelegator.default
+            -   MetadataDelegator.default
             -   ServiceDelegator.default
             -   GitRepoDelegator.default
             -   ConfigOnlyDelegator.default
@@ -188,6 +189,10 @@ plugin_instance_entries:
             -   FuncTreeInterpFactory.default
         plugin_config:
             single_func_id: func_id_query_enum_items
+
+    MetadataDelegator.default:
+        plugin_module_name: argrelay.plugin_delegator.MetadataDelegator
+        plugin_class_name: MetadataDelegator
 
     ServiceDelegator.default:
         plugin_module_name: argrelay.custom_integ.ServiceDelegator

--- a/src/argrelay/sample_conf/argrelay_server.yaml
+++ b/src/argrelay/sample_conf/argrelay_server.yaml
@@ -70,7 +70,6 @@ class_to_collection_map:
     ClassCluster: ClassCluster
     ClassHost: ClassHost
     ClassService: ClassService
-    access_type: access_type
 
 server_plugin_control:
     first_interp_factory_id: FirstArgInterpFactory.default
@@ -106,6 +105,12 @@ server_plugin_control:
                         node_type: interp_tree_node
                         plugin_instance_id: FuncTreeInterpFactory.default
                         sub_tree:
+                            "meta":
+                                node_type: tree_path_node
+                                sub_tree:
+                                    "get":
+                                        node_type: func_tree_node
+                                        func_id: func_id_get_data_envelopes
                             "echo":
                                 node_type: func_tree_node
                                 func_id: func_id_echo_args

--- a/src/argrelay/schema_config_core_server/EnvelopeCollectionSchema.py
+++ b/src/argrelay/schema_config_core_server/EnvelopeCollectionSchema.py
@@ -52,7 +52,8 @@ envelope_collection_desc = TypeDesc(
 
 
 def init_envelop_collections(
-    server_config: ServerConfig,
+    class_to_collection_map: dict[str, str],
+    envelope_collections: dict[str, EnvelopeCollection],
     class_names: Collection[str],
     get_index_props: Callable[[str, str], list[str]],
 ):
@@ -64,9 +65,10 @@ def init_envelop_collections(
     *   association of `collection_name` with its data as `EnvelopeCollection` (default = new and empty)
     *   list of `index_prop`-s for each `EnvelopeCollection` via `get_index_props`
 
+    # TODO: TODO_08_25_32_95: redesign `class_to_collection_map`:
+
     By default, class_name is mapped into collection_name which matches as string that class_name.
     """
-    class_to_collection_map: dict = server_config.class_to_collection_map
 
     for class_name in class_names:
         # Default collection_name == class_name (unless overridden = specified in config explicitly):
@@ -75,7 +77,7 @@ def init_envelop_collections(
             class_name,
         )
         collection_name = class_to_collection_map[class_name]
-        envelope_collection = server_config.static_data.envelope_collections.setdefault(
+        envelope_collection = envelope_collections.setdefault(
             collection_name,
             EnvelopeCollection(
                 index_props = [],

--- a/tests/gui_tests/cypress/e2e/argrelay_gui/input_output_basics.cy.js
+++ b/tests/gui_tests/cypress/e2e/argrelay_gui/input_output_basics.cy.js
@@ -41,11 +41,11 @@ describe('argrelay GUI', () => {
         cy
             .get('[data-cy=suggestion_output]')
             .children()
-            .should('have.length', 11)
+            .should('have.length', 12)
             .then(suggested_elems => {
                 const suggested_strings = [...suggested_elems]
                     .map(suggested_elem => suggested_elem.textContent)
-                expect(suggested_strings).to.have.length(11)
+                expect(suggested_strings).to.have.length(12)
                 expect(suggested_strings).to.include('desc')
                 expect(suggested_strings).to.include('duplicates')
                 expect(suggested_strings).to.include('config')
@@ -56,6 +56,7 @@ describe('argrelay GUI', () => {
                 expect(suggested_strings).to.include('help')
                 expect(suggested_strings).to.include('intercept')
                 expect(suggested_strings).to.include('list')
+                expect(suggested_strings).to.include('meta')
                 expect(suggested_strings).to.include('no_data')
             })
     })

--- a/tests/offline_tests/composite_forest/test_CompositeForestExtractor.py
+++ b/tests/offline_tests/composite_forest/test_CompositeForestExtractor.py
@@ -360,6 +360,9 @@ class ThisTestClass(LocalTestClass):
         func_tree_main = {
             "echo": "func_id_echo_args",
             "no_data": "func_id_no_data",
+            "meta": {
+                "get": SpecialFunc.func_id_get_data_envelopes.name,
+            },
             "goto": {
                 "repo": "func_id_goto_git_repo",
                 "host": "func_id_goto_host",

--- a/tests/offline_tests/plugin_delegator/test_InterceptorDelegator.py
+++ b/tests/offline_tests/plugin_delegator/test_InterceptorDelegator.py
@@ -35,6 +35,7 @@ class ThisTestClass(LocalTestClass):
                     "help",
                     "intercept",
                     "list",
+                    "meta",
                     "no_data",
                 ],
                 None,

--- a/tests/offline_tests/plugin_delegator/test_MetadataDelegator.py
+++ b/tests/offline_tests/plugin_delegator/test_MetadataDelegator.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Union
+
+from argrelay.client_command_local.ClientCommandLocal import ClientCommandLocal
+from argrelay.enum_desc.CompType import CompType
+from argrelay.relay_client import __main__
+from argrelay.runtime_data.AssignedValue import AssignedValue
+from argrelay.schema_request.CallContextSchema import call_context_desc
+from argrelay.test_infra import line_no_from_ctor
+from argrelay.test_infra.CustomTestCase import ShellInputTestCase
+from argrelay.test_infra.CustomVerifier import ServerActionVerifier, ProposeArgValuesVerifier
+from argrelay.test_infra.EnvMockBuilder import LocalClientEnvMockBuilder
+from argrelay.test_infra.LocalTestClass import LocalTestClass
+
+
+class ThisTestClass(LocalTestClass):
+    same_test_data_per_class = "TD_63_37_05_36"  # demo
+
+    def test_FS_74_69_61_79_func_id_get_data_envelopes(self):
+        """
+        Test FS_74_69_61_79 get set data envelope.
+        """
+
+        test_cases = [
+            ThisTestCase(
+                "For `help` even `internal` functions are allowed.",
+                "some_command meta get ClassAccessType |",
+                CompType.PrefixShown,
+                {},
+                ProposeArgValuesVerifier(self),
+            )
+            .set_expected_suggestions(
+                [
+                    "ro",
+                    "rw",
+                ]
+            ),
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case):
+                self.verify_output_with_new_server_via_local_client(
+                    self.__class__.same_test_data_per_class,
+                    test_case.test_line,
+                    test_case.comp_type,
+                    test_case.expected_suggestions,
+                    test_case.container_ipos_to_expected_assignments,
+                    None,
+                    None,
+                )
+
+                env_mock_builder = (
+                    LocalClientEnvMockBuilder()
+                    .set_command_line(test_case.command_line)
+                    .set_cursor_cpos(test_case.cursor_cpos)
+                    .set_comp_type(test_case.comp_type)
+                    .set_test_data_ids_to_load([
+                        self.__class__.same_test_data_per_class,
+                    ])
+                )
+                with env_mock_builder.build():
+                    command_obj = __main__.main()
+                    assert isinstance(command_obj, ClientCommandLocal)
+
+                    test_case.sever_action_verifier.verify_all(call_context_desc.dict_schema.dumps(
+                        command_obj.interp_ctx.parsed_ctx,
+                    ))
+
+
+class ThisTestCase(ShellInputTestCase):
+
+    def __init__(
+        self,
+        case_comment: str,
+        test_line: str,
+        comp_type: CompType,
+        container_ipos_to_expected_assignments: dict[int, dict[str, AssignedValue]],
+        sever_action_verifier: ServerActionVerifier,
+    ):
+        super().__init__(
+            line_no = line_no_from_ctor(),
+            case_comment = case_comment,
+        )
+        self.set_test_line(test_line)
+        self.set_comp_type(comp_type)
+
+        self.container_ipos_to_expected_assignments = container_ipos_to_expected_assignments
+        self.sever_action_verifier = sever_action_verifier
+
+        self.expected_suggestions: Union[list[str], None] = None
+
+    def set_expected_suggestions(
+        self,
+        given_expected_suggestions: list[str],
+    ):
+        assert self.expected_suggestions is None
+        self.expected_suggestions = given_expected_suggestions
+        return self

--- a/tests/offline_tests/plugin_delegator/test_QueryEnumDelegator.py
+++ b/tests/offline_tests/plugin_delegator/test_QueryEnumDelegator.py
@@ -33,6 +33,7 @@ class ThisTestClass(LocalTestClass):
                     "help",
                     "intercept",
                     "list",
+                    "meta",
                     "no_data",
                 ],
                 None,

--- a/tests/offline_tests/plugin_interp/test_InterpTreeInterpFactory.py
+++ b/tests/offline_tests/plugin_interp/test_InterpTreeInterpFactory.py
@@ -67,6 +67,7 @@ class ThisTestClass(LocalTestClass):
                     "help",
                     "intercept",
                     "list",
+                    "meta",
                     "no_data",
                 ],
                 {},

--- a/tests/offline_tests/relay_demo/test_GitRepoLoader_offline.py
+++ b/tests/offline_tests/relay_demo/test_GitRepoLoader_offline.py
@@ -327,6 +327,9 @@ class ThisTestClass(LocalTestClass):
 
                             is_empty = False
                             if prop_name_existence:
+                                # TODO: TODO_00_79_72_55: Remove `static_data` from `server_config`:
+                                #       This test assumes that last loaded `static_data` can be inspected.
+                                #       Now, this requires a hack - see `_generate_and_load_meta_data`.
                                 assert prop_name in static_data.envelope_collections[class_name].index_props
                             else:
                                 # Do not assert it as loader over-specifies index fields at the moment:

--- a/tests/offline_tests/relay_demo/test_relay_demo.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo.py
@@ -54,6 +54,7 @@ class ThisTestClass(LocalTestClass):
                     "help",
                     "intercept",
                     "list",
+                    "meta",
                     "no_data",
                 ],
                 # TODO: Maybe we should suggest selection for `internal` func like `intercept` as well?
@@ -539,13 +540,13 @@ class ThisTestClass(LocalTestClass):
                 "FS_41_40_39_44: TODO: suggest from interp tree.",
                 f"""
 {TermColor.consumed_token.value}some_command{TermColor.reset_style.value} 
-{ReservedEnvelopeClass.ClassFunction.name}: {TermColor.found_count_n.value}37{TermColor.reset_style.value}
+{ReservedEnvelopeClass.ClassFunction.name}: {TermColor.found_count_n.value}39{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: some_command {TermColor.other_assigned_arg_value.value}[{ArgSource.InitValue.name}]{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.remaining_value.value}*{func_envelope_path_step_prop_name(1)}: ?{TermColor.reset_style.value} config desc diff duplicates echo enum goto help intercept list no_data 
-{" " * indent_size}{TermColor.remaining_value.value}{func_envelope_path_step_prop_name(2)}: ?{TermColor.reset_style.value} commit config desc diff double_execution echo goto help host intercept list no_data print_with_exit print_with_io_redirect print_with_level repo service tag {SpecialChar.NoPropValue.value} 
-{" " * indent_size}{TermColor.remaining_value.value}{func_envelope_path_step_prop_name(3)}: ?{TermColor.reset_style.value} commit double_execution host print_with_exit print_with_io_redirect print_with_level repo service tag {SpecialChar.NoPropValue.value} 
+{" " * indent_size}{TermColor.remaining_value.value}*{func_envelope_path_step_prop_name(1)}: ?{TermColor.reset_style.value} config desc diff duplicates echo enum goto help intercept list meta no_data 
+{" " * indent_size}{TermColor.remaining_value.value}{func_envelope_path_step_prop_name(2)}: ?{TermColor.reset_style.value} commit config desc diff double_execution echo get goto help host intercept list meta no_data print_with_exit print_with_io_redirect print_with_level repo service tag {SpecialChar.NoPropValue.value} 
+{" " * indent_size}{TermColor.remaining_value.value}{func_envelope_path_step_prop_name(3)}: ?{TermColor.reset_style.value} commit double_execution get host print_with_exit print_with_io_redirect print_with_level repo service tag {SpecialChar.NoPropValue.value} 
 {" " * indent_size}{TermColor.remaining_value.value}{ReservedPropName.func_state.name}: ?{TermColor.reset_style.value} {FuncState.fs_alpha} {FuncState.fs_beta} {FuncState.fs_demo} {FuncState.fs_gamma} {FuncState.fs_ignorable} 
-{" " * indent_size}{TermColor.remaining_value.value}{ReservedPropName.func_id.name}: ?{TermColor.reset_style.value} func_id_desc_git_commit func_id_desc_git_tag func_id_desc_host func_id_desc_service func_id_diff_service func_id_double_execution func_id_echo_args func_id_goto_git_repo func_id_goto_host func_id_goto_service func_id_help_hint func_id_intercept_invocation func_id_list_host func_id_list_service func_id_no_data func_id_print_with_exit_code func_id_print_with_io_redirect func_id_print_with_severity_level func_id_query_enum_items 
+{" " * indent_size}{TermColor.remaining_value.value}{ReservedPropName.func_id.name}: ?{TermColor.reset_style.value} func_id_desc_git_commit func_id_desc_git_tag func_id_desc_host func_id_desc_service func_id_diff_service func_id_double_execution func_id_echo_args func_id_get_data_envelopes func_id_goto_git_repo func_id_goto_host func_id_goto_service func_id_help_hint func_id_intercept_invocation func_id_list_host func_id_list_service func_id_no_data func_id_print_with_exit_code func_id_print_with_io_redirect func_id_print_with_severity_level func_id_query_enum_items 
 """,
             ),
             (

--- a/tests/offline_tests/relay_demo/test_relay_demo_not_hidden_funcs.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_not_hidden_funcs.py
@@ -30,6 +30,10 @@ from argrelay.test_infra.LocalTestClass import LocalTestClass
 class ThisTestClass(LocalTestClass):
     same_test_data_per_class = "TD_63_37_05_36"  # demo
 
+    def test_start_server(self):
+        env_mock_builder = LocalClientEnvMockBuilder().set_reset_local_server(True)
+        self._start_server(env_mock_builder)
+
     def test_arg_assignments_does_not_hide_funcs(self):
         test_cases = [
             (

--- a/tests/offline_tests/relay_demo/test_relay_demo_trees.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_trees.py
@@ -55,6 +55,7 @@ tree_path_selector_2: ? intercept help goto desc list host service repo commit
                     "help",
                     "intercept",
                     "list",
+                    "meta",
                     "no_data",
                 ],
                 "Basic test.",


### PR DESCRIPTION

*   Implement `func_id_get_data_envelopes` (pending `func_id_set_data_envelopes`).
*   Implement `MetadataDelegator` with dynamic `search_control` (one `envelope_container` at a time).
*   Populate `ClassCollectionMeta` envelopes on server start by inspecting loaded data.
*   Define metadata actions in `DataOperation` enum.
*   Run disabled `@/exe/check_env.bash` together with `@/exe/bootstrap_env.bash`.
*   Move `redirect_to_error` to `delegator_utils`.
*   Spec `TODO_08_25_32_95.redesign_class_to_collection_map.md`.
