### PR TITLE
Use `check_env` for GNU Readline properties and update the docs

### DIFF
--- a/data/ConfigOnlyLoader.default.data.yaml
+++ b/data/ConfigOnlyLoader.default.data.yaml
@@ -1,5 +1,5 @@
 
-# TODO_84_71_86_21: change to realistic example:
+# TODO: TODO_84_71_86_21: change to realistic example:
 -
     envelope_class: ConfigOnlyClass
     severity_level: INFO

--- a/docs/dev_notes/semver_notes.md
+++ b/docs/dev_notes/semver_notes.md
@@ -16,7 +16,7 @@ As `semver` suggests, there is no guarantee of compatibility for all `0.Y.Z` ver
 *   "important" changes increment `0.Y+1.Z`
 *   others (less "important") increment `0.Y.Z+1`
 
-TODO_78_94_31_68: Split argrelay into multiple packages.
+TODO: TODO_78_94_31_68: Split argrelay into multiple packages.
 This will make it simpler to track compatibilities if each interface is represented by a package with its definition:
 *   each package is smaller to track incompatible interface changes
 *   major version increase in one such interface dependency will cause increase of parent package major version

--- a/docs/feature_stories/FS_18_64_57_18.function_with_indefinite_input_data_envelopes_like_varargs.md
+++ b/docs/feature_stories/FS_18_64_57_18.function_with_indefinite_input_data_envelopes_like_varargs.md
@@ -16,7 +16,7 @@ the search result for the trailing `envelop_container` may contain number of `da
 
 # Possible future
 
-TODO_75_52_01_67: `arg_bucket`-s to support multiple var args:
+TODO: TODO_75_52_01_67: `arg_bucket`-s to support multiple var args:
 Note that it is logically possible to allow any `envelope_container` search for arbitrary `data_envelope`-s,
 but this requires some rules how to decide (using `arg_bucket`-s):
 *   where interrogation for args of curr `envelope_container` ends

--- a/docs/feature_stories/FS_36_17_84_44.check_env.md
+++ b/docs/feature_stories/FS_36_17_84_44.check_env.md
@@ -55,7 +55,7 @@ Checks:
 *   whether `PATH` env var reaches client and server binaries
 *   whether completion is configured in shell
 *   DONE: `@/conf` locations used
-*   any useful missing (or useless existing) settings in `~/.inputrc`
+*   DONE: any useful missing (or useless existing) settings in `~/.inputrc`
 *   DONE: server availability
 *   DONE: server version
 *   server and client compatibility

--- a/docs/feature_stories/FS_74_69_61_79.get_set_data_envelope.md
+++ b/docs/feature_stories/FS_74_69_61_79.get_set_data_envelope.md
@@ -23,6 +23,8 @@ The search criteria acts as "snapshot address" and data is always replaced entir
 
 REST API is trivial, if it does not need to be convenient for CLI, but it does have to be convenient for CLI.
 
+How the convenience requirement is resolved explained in the next sections.
+
 # Internal metadata for CLI
 
 All `data_envelope`-s can be scanned to create a `data_envelope`-s with metadata for get or set operations.
@@ -35,7 +37,7 @@ Its payload will have to be `index_props` of that `envelope_class`.
 # CLI `search_control`
 
 To avoid the need to specify FS_31_70_49_15 `search_control` for CLI,
-it has to be static able to search any `data_envelope` by their `index_prop`-s.
+it has to be static = be able to search any `data_envelope` by their `index_prop`-s.
 
 Some of the `search_control` fields:
 *   `collection_name` to select MongoDB collection

--- a/docs/task_refs/TODO_00_79_72_55.remove_static_data_from_server_config.md
+++ b/docs/task_refs/TODO_00_79_72_55.remove_static_data_from_server_config.md
@@ -1,5 +1,5 @@
 
-TODO_00_79_72_55: Remove `static_data` from `server_config`
+TODO: TODO_00_79_72_55: Remove `static_data` from `server_config`
 
 All data should be provided by plugins (if this need to be config, it has to be `plugin_config`).
 

--- a/docs/task_refs/TODO_04_84_79_11.reorganize_tests_for_CI.md
+++ b/docs/task_refs/TODO_04_84_79_11.reorganize_tests_for_CI.md
@@ -1,5 +1,5 @@
 
-TODO_04_84_79_11: reorganize tests for CI
+TODO: TODO_04_84_79_11: reorganize tests for CI
 
 Make it clear:
 *   what tests are meant be run in CI (including end-to-end which start local server)

--- a/docs/task_refs/TODO_08_25_32_95.redesign_class_to_collection_map.md
+++ b/docs/task_refs/TODO_08_25_32_95.redesign_class_to_collection_map.md
@@ -10,8 +10,27 @@ Yes, it served its initial purpose, but:
 
     Not needed because combination of these 2 factors eliminates the need to specify it:
 
-    *   Most of the time, each `envelope_class` has to be loaded into its own `collection_name` - why not?
+    *   Most of the time, each `envelope_class` has to be loaded into its own `collection_name`.
+
+        The only reason to combine multiple classes is the possibility to search them together.
+        But then, their search props has to be similar in that case.
+        That makes them belong to the same class (by duck typing), isn't it?
+
     *   Loading multiple `envelope_class`-es into single `collection_name` combines their sets of `index_prop`-s.
 
+        If `index_prop`-s are drastically different, why are they in the same search collection?
+        Searing them together is unlikely.
+
     In short, we can always rely on default mapping where `collection_name` = `envelope_class`.
+
+*   On the other hand, `class_to_collection_map` is the only way to know what collection to search for given class name.
+
+    But that is already set in `search_control` - once it is put there via `class_to_collection_map`,
+    it is never used again from `class_to_collection_map`.
+
+    In fact, server-internal `class_to_collection_map` is only used by loaders and delegators to sync:
+    *   Loaders load classes into correct collections.
+    *   Delegators set up `search_control` so that funcs search correct collections.
+
+    This can be left as convention (and flexibility to break it between loaders and delegators).
 

--- a/docs/task_refs/TODO_10_72_28_05.simpler_help_config_for_multiple_commands.md
+++ b/docs/task_refs/TODO_10_72_28_05.simpler_help_config_for_multiple_commands.md
@@ -1,5 +1,5 @@
 
-TODO_10_72_28_05: Simpler `help` config for any number of commands.
+TODO: TODO_10_72_28_05: Simpler `help` config for any number of commands.
 
 It also applies to `intercept` and `query_.
 

--- a/docs/task_refs/TODO_11_77_28_50.suggestions_in_all_responses.md
+++ b/docs/task_refs/TODO_11_77_28_50.suggestions_in_all_responses.md
@@ -1,5 +1,5 @@
 
-TODO_11_77_28_50: provide and assert Tab-suggestions in all responses
+TODO: TODO_11_77_28_50: provide and assert Tab-suggestions in all responses
 
 Currently, schema already allows this: ArgValues <- InterpResult <- InvocationInput.
 

--- a/docs/task_refs/TODO_26_08_72_06.interp_vs_delegator.md
+++ b/docs/task_refs/TODO_26_08_72_06.interp_vs_delegator.md
@@ -1,5 +1,5 @@
 
-TODO_26_08_72_06 clarify responsibilities and differences: interp vs delegator
+TODO: TODO_26_08_72_06 clarify responsibilities and differences: interp vs delegator
 
 This task is to think and see if FS_26_43_73_72 func tree interp (FT-interp) and delegator can
 converge into a single building block.

--- a/docs/task_refs/TODO_26_15_31_78.categorize_git_repo_existence.md
+++ b/docs/task_refs/TODO_26_15_31_78.categorize_git_repo_existence.md
@@ -1,5 +1,5 @@
 
-TODO_26_15_31_78: categorize git repo existence
+TODO: TODO_26_15_31_78: categorize git repo existence
 
 When loading git data by FS_67_16_61_97 git plugin, there can be several of specified repo:
 *   Path exists or not

--- a/docs/task_refs/TODO_27_61_22_18.make_shell_vars_local.md
+++ b/docs/task_refs/TODO_27_61_22_18.make_shell_vars_local.md
@@ -1,5 +1,5 @@
 
-TODO_27_61_22_18: make shell vars local
+TODO: TODO_27_61_22_18: make shell vars local
 
 Many shell script originally were written with non-local vars.
 However, now they class (e.g. if used with FS_57_36_37_48 multiple clients) for source-able scripts.

--- a/docs/task_refs/TODO_30_69_19_14.infinite_spinner.md
+++ b/docs/task_refs/TODO_30_69_19_14.infinite_spinner.md
@@ -4,7 +4,7 @@ TODO: TODO_30_69_19_14: client hangs with infinite spinner
 # Issue
 
 So far, there were only the reasons for occurrences of this bug
-when `os.fork`-ed client hangs on `import` inside `requests` library.
+when `os.fork`-ed client hangs on `import` inside `requests` library (on [`import encodings.idna`][import_encodings_idna]).
 
 # Status
 
@@ -51,3 +51,5 @@ File "<frozen importlib._bootstrap>", line 224, in _lock_unlock_module
 File “<frozen importlib._bootstrap>", line 120, in acquire
 KeyboardInterrupt
 ```
+
+[import_encodings_idna]: https://github.com/psf/requests/commit/d7227fbb7e07af35f23a0d370ab3b01661af9e40#commitcomment-146935826

--- a/docs/task_refs/TODO_32_99_70_35.JSONPath_to_verify_response_data.md
+++ b/docs/task_refs/TODO_32_99_70_35.JSONPath_to_verify_response_data.md
@@ -1,6 +1,5 @@
 
-
-TODO_32_99_70_35: figure out how JSONPath can be used for more compact and flexible assertions (via lambdas querying JSON parts)
+TODO: TODO_32_99_70_35: figure out how JSONPath can be used for more compact and flexible assertions (via lambdas querying JSON parts)
 
 Extend EnvMock to assert returned JSON via JSONPath:
 https://www.digitalocean.com/community/tutorials/python-jsonpath-examples

--- a/docs/task_refs/TODO_37_15_12_91.Popen_mock.md
+++ b/docs/task_refs/TODO_37_15_12_91.Popen_mock.md
@@ -1,5 +1,5 @@
 
-TODO_37_15_12_91: Add tests with config-only plugin which starts external process with Popen, but mock Popen by PopenMock to verify that.
+TODO: TODO_37_15_12_91: Add tests with config-only plugin which starts external process with Popen, but mock Popen by PopenMock to verify that.
 
 To support testing with external command invocation, implement Popen mock:
 *   DONE: Ability to specify calls which should be intercepted.

--- a/docs/task_refs/TODO_40_10_18_32.add_custom_base_to_all_schemas.md
+++ b/docs/task_refs/TODO_40_10_18_32.add_custom_base_to_all_schemas.md
@@ -1,6 +1,5 @@
 
-
-TODO_40_10_18_32: add custom base to all schemas
+TODO: TODO_40_10_18_32: add custom base to all schemas
 
 Some of the `*Schema` classes are already re-based from `Schema` to `ObjectSchema`
 to re-use `@post_load` `make_object`.

--- a/docs/task_refs/TODO_42_81_01_90.assert_data_instead_of_print_out.md
+++ b/docs/task_refs/TODO_42_81_01_90.assert_data_instead_of_print_out.md
@@ -1,5 +1,5 @@
 
-TODO_42_81_01_90: assert data instead of captured print out (stdout, stderr)
+TODO: TODO_42_81_01_90: assert data instead of captured print out (stdout, stderr)
 
 It should be possible to intercept data (via mock) and assert it in tests for all operations.
 Currently, only invocation data is intercepted.

--- a/docs/task_refs/TODO_43_41_95_86.use_server_logger_to_disable_stdout.md
+++ b/docs/task_refs/TODO_43_41_95_86.use_server_logger_to_disable_stdout.md
@@ -1,5 +1,5 @@
 
-TODO_43_41_95_86: use server logger to disable stdout
+TODO: TODO_43_41_95_86: use server logger to disable stdout
 
 Local test has to re-run printing for stdout capturing after receiving response from the server
 because capturing it earlier will also capture server output.

--- a/docs/task_refs/TODO_45_75_75_65.remove_instance_data_leave_envelop_payload.md
+++ b/docs/task_refs/TODO_45_75_75_65.remove_instance_data_leave_envelop_payload.md
@@ -1,6 +1,5 @@
 
-
-TODO_45_75_75_65 Merge `instance_data` into `envelop_payload`.
+TODO: TODO_45_75_75_65 Merge `instance_data` into `envelop_payload`.
 
 Instead of maintaining two data fields `instance_data` and `envelope_payload`, use `envelope_payload` only.
 

--- a/docs/task_refs/TODO_51_29_08_00.combine_interp_factory_with_interp.md
+++ b/docs/task_refs/TODO_51_29_08_00.combine_interp_factory_with_interp.md
@@ -1,2 +1,2 @@
 
-TODO_51_29_08_00: Move all Interp* and InterpFactory* classes into the same module.
+TODO: TODO_51_29_08_00: Move all Interp* and InterpFactory* classes into the same module.

--- a/docs/task_refs/TODO_54_68_18_12.support_defaults_for_config_only_delegator.md
+++ b/docs/task_refs/TODO_54_68_18_12.support_defaults_for_config_only_delegator.md
@@ -1,5 +1,5 @@
 
-TODO_54_68_18_12: Support defaults for config-only delegator
+TODO: TODO_54_68_18_12: Support defaults for config-only delegator
 
 NOTE: This is already implemented, but:
 *   TODO: Declare (dynamically via `eval`) local variables named according to the config to be able to reference it in templates.

--- a/docs/task_refs/TODO_64_79_28_85.make_publish_package_upgrade_env_packages_before_test.md
+++ b/docs/task_refs/TODO_64_79_28_85.make_publish_package_upgrade_env_packages_before_test.md
@@ -1,5 +1,5 @@
 
-TODO_64_79_28_85: make `publish_package.bash` upgrade all packages before test
+TODO: TODO_64_79_28_85: make `publish_package.bash` upgrade all packages before test
 
 Use special directory `release_env` where `env_packages.txt` is captured.
 

--- a/docs/task_refs/TODO_66_66_75_78.split_arg_and_prop_concepts.md
+++ b/docs/task_refs/TODO_66_66_75_78.split_arg_and_prop_concepts.md
@@ -1,5 +1,5 @@
 
-TODO_66_66_75_78: Split `arg` to `prop` concepts:
+TODO: TODO_66_66_75_78: Split `arg` to `prop` concepts:
 *   `arg` is about command line input
 *   `prop` is about search, envelopes, data backend
 

--- a/docs/task_refs/TODO_70_48_96_29.be_able_to_assert_remaining_arg_vals.md
+++ b/docs/task_refs/TODO_70_48_96_29.be_able_to_assert_remaining_arg_vals.md
@@ -1,7 +1,7 @@
 
-TODO_70_48_96_29: be able to assert remaining arg vals
+TODO: TODO_70_48_96_29: be able to assert remaining arg vals
 
 Do it via some kind of test builder where we can list them optionally (if not specified, not asserted).
 
-See also TODO_32_99_70_35: JSONPath to verify response data.
+See also TODO: TODO_32_99_70_35: JSONPath to verify response data.
 

--- a/docs/task_refs/TODO_74_73_60_93.support_expected_envelope_count_in_config_only_delegator.md
+++ b/docs/task_refs/TODO_74_73_60_93.support_expected_envelope_count_in_config_only_delegator.md
@@ -1,5 +1,5 @@
 
-TODO_74_73_60_93: Support expected envelope count in config-only delegator
+TODO: TODO_74_73_60_93: Support expected envelope count in config-only delegator
 
 Add config for commands in `ConfigOnlyDelegator` to set expected number of `data_envelope`-s.
 

--- a/docs/task_refs/TODO_75_52_01_67.arg_buckets_to_support_multiple_var_args.md
+++ b/docs/task_refs/TODO_75_52_01_67.arg_buckets_to_support_multiple_var_args.md
@@ -1,5 +1,5 @@
 
-TODO_75_52_01_67: `arg_bucket`-s to support multiple var args
+TODO: TODO_75_52_01_67: `arg_bucket`-s to support multiple var args
 
 Because FS_97_64_39_94 `arg_bucket`-s limit consumption per `envelope_container`,
 it is possible to support more than one FS_18_64_57_18 varargs - each `arg_bucket` specifying its own list.

--- a/docs/task_refs/TODO_78_94_31_68.split_argrelay_into_multiple_packages.md
+++ b/docs/task_refs/TODO_78_94_31_68.split_argrelay_into_multiple_packages.md
@@ -1,5 +1,5 @@
 
-TODO_78_94_31_68: split argrelay into multiple packages
+TODO: TODO_78_94_31_68: split argrelay into multiple packages
 
 The main benefit is to be able to:
 *   enforce relationship between packages

--- a/docs/task_refs/TODO_79_67_28_83.recursive_dict_schema.md
+++ b/docs/task_refs/TODO_79_67_28_83.recursive_dict_schema.md
@@ -1,5 +1,5 @@
 
-TODO_79_67_28_83: Express recursive dict schema.
+TODO: TODO_79_67_28_83: Express recursive dict schema.
 
 See `CompositeNodeSchema` - it is recursive.
 Can we express recursive dict of dict-s of dict-s with string-only keys?

--- a/docs/task_refs/TODO_80_99_84_41.intercept_has_no_suggestions_if_selected_via_func_id.md
+++ b/docs/task_refs/TODO_80_99_84_41.intercept_has_no_suggestions_if_selected_via_func_id.md
@@ -1,5 +1,4 @@
 
-
 TODO: TODO_80_99_84_41 `intercept` has no suggestions if selected via `func_id`
 
 Search TODO to see test cases.

--- a/docs/task_refs/TODO_81_49_24_81.json_or_repr_before_intercept_jump.md
+++ b/docs/task_refs/TODO_81_49_24_81.json_or_repr_before_intercept_jump.md
@@ -1,6 +1,5 @@
 
-
-TODO_81_49_24_81: Introduce `json` vs `repr` arg (default JSON) before `intercept` interp jumps interp tree.
+TODO: TODO_81_49_24_81: Introduce `json` vs `repr` arg (default JSON) before `intercept` interp jumps interp tree.
 
 This is to test interp tree with jump tree features work in flexible way.
 

--- a/docs/task_refs/TODO_96_01_13_29.multiple_bootstrap_stages_to_instantiate_configs.md
+++ b/docs/task_refs/TODO_96_01_13_29.multiple_bootstrap_stages_to_instantiate_configs.md
@@ -1,0 +1,25 @@
+
+TODO: TODO_96_01_13_29: multiple bootstrap stages to instantiate configs
+
+# Problem
+
+## Single high-level config source for multiple low-level configs
+
+In multi-language environment (for `argrelay`, at least Bash and Python) config files often
+contain identical information in different formats.
+
+FS_85_33_46_53: bootstrap process should have at least three distinct stages:
+*   minimal to set up Python venv with required dependencies
+*   use high-level config input (some YAML) to instantiate all other configs
+*   do anything else
+
+## Minimizing initial Bash bootstrap
+
+Current single `@/exe/bootstrap_env.bash` has to be self-sufficient - it cannot rely on any dependencies.
+
+Because it is single, it keeps running with the same minimal assumptions about environment:
+*   it has to continue running as Bash script
+*   it (mostly) cannot source outside files as they should be upgraded first by this same boostrap script
+
+With multiple bootstrap stages, next bootstrap stage can run in Python (easier to test) -
+this is similar to the split of FS_36_17_84_44 `check_env` script.

--- a/exe/bootstrap_env.bash
+++ b/exe/bootstrap_env.bash
@@ -375,7 +375,9 @@ then
     echo "It is required to install packages to extract artifacts from them." 1>&2
     echo "Provide \`${argrelay_dir}/exe/install_project.bash\`, for example (copy and paste and modify):" 1>&2
     echo "" 1>&2
-    # TODO: This matches content of default config stored in `argrelay` repo - try to deduplicate.
+    # TODO: TODO_96_01_13_29: multiple bootstrap stages to instantiate configs
+    #       Installing extra files can be left to later bootstrap stages when packages are already installed.
+    #       This matches content of default config stored in `argrelay` repo - try to deduplicate.
     cat << 'install_project_EOF'
 ########################################################################################################################
 # `argrelay` integration file: https://github.com/argrelay/argrelay
@@ -589,7 +591,9 @@ then
     echo "It is required to know list of configs to be installed." 1>&2
     echo "Provide \`${install_files_conf_path}\`, for example (copy and paste and modify):" 1>&2
     echo "" 1>&2
-    # TODO: This matches content of default config stored in `argrelay` repo - try to deduplicate.
+    # TODO: TODO_96_01_13_29: multiple bootstrap stages to instantiate configs
+    #       Installing extra files can be left to later bootstrap stages when packages are already installed.
+    #       This matches content of default config stored in `argrelay` repo - try to deduplicate.
     cat << 'config_files_conf_EOF'
 ########################################################################################################################
 # `argrelay` integration file: https://github.com/argrelay/argrelay
@@ -656,7 +660,9 @@ then
     echo "It is required to know list of resources to be installed." 1>&2
     echo "Provide \`${install_files_conf_path}\`, for example (copy and paste and modify):" 1>&2
     echo "" 1>&2
-    # TODO: This matches content of default config stored in `argrelay` repo - try to deduplicate.
+    # TODO: TODO_96_01_13_29: multiple bootstrap stages to instantiate configs
+    #       Installing extra files can be left to later bootstrap stages when packages are already installed.
+    #       This matches content of default config stored in `argrelay` repo - try to deduplicate.
     cat << 'resource_files_conf_EOF'
 ########################################################################################################################
 # `argrelay` integration file: https://github.com/argrelay/argrelay
@@ -819,7 +825,9 @@ then
     echo "It is required as custom build step for integration project, but can do nothing." 1>&2
     echo "Provide \`${argrelay_dir}/exe/build_project.bash\`, for example (copy and paste and modify):" 1>&2
     echo "" 1>&2
-    # TODO: This matches content of default config stored in `argrelay` repo - try to deduplicate.
+    # TODO: TODO_96_01_13_29: multiple bootstrap stages to instantiate configs
+    #       Installing extra files can be left to later bootstrap stages when packages are already installed.
+    #       This matches content of default config stored in `argrelay` repo - try to deduplicate.
     cat << 'build_project_EOF'
 ########################################################################################################################
 # `argrelay` integration file: https://github.com/argrelay/argrelay

--- a/exe/publish_package.bash
+++ b/exe/publish_package.bash
@@ -58,8 +58,8 @@ then
     exit 1
 fi
 
-# TODO_64_79_28_85: switch to `dst/release_env`
-# TODO_64_79_28_85: use upgrade_env_packages.bash
+# TODO: TODO_64_79_28_85: switch to `dst/release_env`
+# TODO: TODO_64_79_28_85: use upgrade_env_packages.bash
 
 # Clear venv (only to be restored in the next step):
 pip uninstall -y -r <( pip freeze )

--- a/src/argrelay/_version.py
+++ b/src/argrelay/_version.py
@@ -1,4 +1,4 @@
 # See `docs/dev_notes/version_format.md`:
 # Implements this:
 # https://stackoverflow.com/a/7071358/441652
-__version__ = "0.7.18.dev2"
+__version__ = "0.7.18"

--- a/src/argrelay/check_env/PluginCheckEnvClientLinkedCommands.py
+++ b/src/argrelay/check_env/PluginCheckEnvClientLinkedCommands.py
@@ -22,8 +22,6 @@ class PluginCheckEnvClientLinkedCommands(PluginCheckEnvAbstract):
     Then, it verifies `argrelay_dir` of the mapped client with the `argrelay_dir` of currently running process.
     """
 
-    shell_var_name: str = "argrelay_bind_command_basenames"
-
     # noinspection PyMethodMayBeStatic
     def execute_check(
         self,
@@ -39,7 +37,6 @@ class PluginCheckEnvClientLinkedCommands(PluginCheckEnvAbstract):
             bash_proc = subprocess.run(
                 args = [
                     dev_shell_path,
-                    # f"echo ${{argrelay_bind_command_basenames[@]}}",
                     f"echo ${{!argrelay_basename_to_client_path_map[@]}}",
                 ],
                 capture_output = True,
@@ -55,7 +52,7 @@ class PluginCheckEnvClientLinkedCommands(PluginCheckEnvAbstract):
                 result_category = ResultCategory.ExecutionFailure,
                 result_key = "client_linked_command",
                 result_value = str(shell_var_value),
-                result_message = f"Unable to retrieve keys of `argrelay_bind_command_basenames` under started: {dev_shell_path}",
+                result_message = f"Unable to retrieve keys of `argrelay_basename_to_client_path_map` under started: {dev_shell_path}",
             )]
         else:
             linked_commands: list[str] = shell_var_value.split()

--- a/src/argrelay/check_env/PluginCheckEnvReadline.py
+++ b/src/argrelay/check_env/PluginCheckEnvReadline.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from typing import Union
+
+from argrelay.check_env.CheckEnvResult import CheckEnvResult
+from argrelay.check_env.PluginCheckEnvAbstract import PluginCheckEnvAbstract
+from argrelay.enum_desc.ResultCategory import ResultCategory
+
+_common_banner = "Search about GNU Readline (`~/.inputrc`) or `bind` in Bash."
+_common_bell_explanation = "Bash sometimes gives terminal \"bell\" instead of showing auto-completion."
+
+
+class PluginCheckEnvReadlineAbstract(PluginCheckEnvAbstract):
+    """
+    This plugin checks config of Readline library:
+    https://en.wikipedia.org/wiki/GNU_Readline
+
+    Official Bash doc:
+    https://www.gnu.org/software/bash/manual/html_node/Readline-Init-File-Syntax.html
+
+    It may be configured via `~/.inputrc` and is used by Bash which can show its settings via `bind -v` command.
+
+    NOTE: Some of these settings may be forced by `@/exe/dev_shell.bash` (set in `@/exe/init_shell_env.bash`),
+          but this plugin cannot verify current Bash instance
+          (its properties are transient in the memory of its process).
+          Instead, it verifies configured properties set for each new Bash instance.
+    """
+
+    def __init__(
+        self,
+        plugin_instance_id: str,
+        plugin_config_dict: dict,
+        #
+        prop_name: str,
+        #
+        if_on_message: str,
+        if_on_category: ResultCategory,
+        #
+        if_off_message: str,
+        if_off_category: ResultCategory,
+    ):
+        super().__init__(
+            plugin_instance_id,
+            plugin_config_dict,
+        )
+        #
+        self.prop_name = prop_name
+        #
+        self.if_on_message = if_on_message
+        self.if_on_category = if_on_category
+        #
+        self.if_off_message = if_off_message
+        self.if_off_category = if_off_category
+
+    # noinspection PyMethodMayBeStatic
+    def execute_check(
+        self,
+        online_mode: Union[bool, None],
+    ) -> list[CheckEnvResult]:
+        try:
+            bash_proc = subprocess.run(
+                args = [
+                    "bash",
+                    "-c",
+                    "bind -v",
+                ],
+                capture_output = True,
+            )
+            assert bash_proc.returncode == 0
+            stdout_str = bash_proc.stdout.decode("utf-8")
+
+            prop_value = None
+            prop_regex = f"^set\\s*{self.prop_name}\\s*(\\S*)\\s*$"
+            for output_line in stdout_str.splitlines():
+                regex_match = re.search(prop_regex, output_line, re.M)
+                if regex_match:
+                    prop_value = regex_match.group(1).strip()
+        except:
+            prop_value = None
+
+        if "on" == prop_value:
+            return [CheckEnvResult(
+                result_category = self.if_on_category,
+                result_key = self.prop_name,
+                result_value = str(prop_value),
+                result_message = self.if_on_message,
+            )]
+        elif "off" == prop_value:
+            return [CheckEnvResult(
+                result_category = self.if_off_category,
+                result_key = self.prop_name,
+                result_value = str(prop_value),
+                result_message = self.if_off_message,
+            )]
+        elif prop_value is not None:
+            return [CheckEnvResult(
+                result_category = ResultCategory.ExecutionFailure,
+                result_key = self.prop_name,
+                result_value = str(prop_value),
+                result_message = f"Unknown value for `{prop_value}` in `bind -v` output.",
+            )]
+        else:
+            return [CheckEnvResult(
+                result_category = ResultCategory.ExecutionFailure,
+                result_key = self.prop_name,
+                result_value = str(prop_value),
+                result_message = f"Unable to parse `bind -v` output and find `{prop_value}`.",
+            )]
+
+
+class PluginCheckEnvReadlineShowAllIfAmbiguous(PluginCheckEnvReadlineAbstract):
+    """
+    See more: https://stackoverflow.com/a/42193784/441652
+    """
+
+    def __init__(
+        self,
+        plugin_instance_id: str,
+        plugin_config_dict: dict,
+    ):
+        prop_name = "show-all-if-ambiguous"
+        super().__init__(
+            plugin_instance_id,
+            plugin_config_dict,
+            prop_name = prop_name,
+            if_on_message = f"More convenient. {_common_banner}",
+            if_on_category = ResultCategory.VerificationSuccess,
+            if_off_message = f"Less convenient: if `{prop_name}` is off, {_common_bell_explanation} {_common_banner}",
+            if_off_category = ResultCategory.VerificationWarning,
+        )
+
+
+class PluginCheckEnvReadlineShowAllIfUnmodified(PluginCheckEnvReadlineAbstract):
+    """
+    See more: https://stackoverflow.com/a/42193784/441652
+    """
+
+    def __init__(
+        self,
+        plugin_instance_id: str,
+        plugin_config_dict: dict,
+    ):
+        prop_name = "show-all-if-unmodified"
+        super().__init__(
+            plugin_instance_id,
+            plugin_config_dict,
+            prop_name = prop_name,
+            if_on_message = f"More convenient. {_common_banner}",
+            if_on_category = ResultCategory.VerificationSuccess,
+            if_off_message = f"Less convenient: if `{prop_name}` is off, {_common_bell_explanation} {_common_banner}",
+            if_off_category = ResultCategory.VerificationWarning,
+        )
+
+
+class PluginCheckEnvReadlineSkipCompletedText(PluginCheckEnvReadlineAbstract):
+
+    def __init__(
+        self,
+        plugin_instance_id: str,
+        plugin_config_dict: dict,
+    ):
+        prop_name = "skip-completed-text"
+        super().__init__(
+            plugin_instance_id,
+            plugin_config_dict,
+            prop_name = prop_name,
+            if_on_message = f"More convenient. {_common_banner}",
+            if_on_category = ResultCategory.VerificationSuccess,
+            if_off_message = f"Less convenient: if `{prop_name}` is off, inserting completed CLI arg part will duplicate existing one. {_common_banner}",
+            if_off_category = ResultCategory.VerificationWarning,
+        )

--- a/src/argrelay/check_env/__main__.py
+++ b/src/argrelay/check_env/__main__.py
@@ -31,7 +31,7 @@ reset_style = TermColor.reset_style.value
 
 # Extra color scheme (available via Python code only):
 offline_color = f"{TermColor.back_light_gray.value}{TermColor.fore_dark_black.value}"
-offline_message = TermColor.fore_bright_blue.value
+offline_message = TermColor.fore_bright_magenta.value
 
 
 # TODO: TODO_67_33_03_53.add_check_env_test_support.md

--- a/src/argrelay/custom_integ/BaseConfigDelegator.py
+++ b/src/argrelay/custom_integ/BaseConfigDelegator.py
@@ -144,7 +144,8 @@ class BaseConfigDelegator(AbstractDelegator):
     ) -> bool:
         """
         FS_49_96_50_77: (part of implementation for config-only delegator) populates defaults
-        TODO_54_68_18_12: Support defaults for config-only delegator
+
+        TODO: TODO_54_68_18_12: Support defaults for config-only delegator
         """
         any_assignment = False
         if interp_ctx.curr_container_ipos > function_container_ipos_:

--- a/src/argrelay/custom_integ/ConfigOnlyDelegator.py
+++ b/src/argrelay/custom_integ/ConfigOnlyDelegator.py
@@ -41,8 +41,8 @@ class ConfigOnlyDelegator(BaseConfigDelegator):
     def invoke_action(
         invocation_input: InvocationInput,
     ):
-        # TODO_74_73_60_93: Support expected envelope count in config-only delegator:
-        # Use common static functions in `BaseConfigDelegator`.
+        # TODO: TODO_74_73_60_93: Support expected envelope count in config-only delegator:
+        #       Use common static functions in `BaseConfigDelegator`.
 
         # Keep this as it is supposed to be referenced in the `command_template`
         envelope_containers = invocation_input.envelope_containers

--- a/src/argrelay/custom_integ/ConfigOnlyDelegatorConfigSchema.py
+++ b/src/argrelay/custom_integ/ConfigOnlyDelegatorConfigSchema.py
@@ -69,16 +69,16 @@ class ConfigOnlyDelegatorEnvelopePayloadSchema(Schema):
 
     echo_command_on_stderr = fields.Boolean(
         required = False,
-        load_default = False,
+        load_default = True,
     )
 
-    # TODO_54_68_18_12: Support defaults for config-only delegator:
-    # Add a schema for this config but likely into _new_ `BaseConfigDelegatorEnvelopePayloadSchema`
-    # as it can be used with other configurable plugins even if they do not use
-    # `command_template` (as this `ConfigOnlyDelegatorEnvelopePayloadSchema` class does).
+    # TODO: TODO_54_68_18_12: Support defaults for config-only delegator:
+    #       Add a schema for this config but likely into _new_ `BaseConfigDelegatorEnvelopePayloadSchema`
+    #       as it can be used with other configurable plugins even if they do not use
+    #       `command_template` (as this `ConfigOnlyDelegatorEnvelopePayloadSchema` class does).
 
-    # TODO_74_73_60_93: Support expected envelope count in config-only delegator:
-    # Similar to TODO_54_68_18_12 (above), it should be part of _new_ `BaseConfigDelegatorEnvelopePayloadSchema`.
+    # TODO: TODO_74_73_60_93: Support expected envelope count in config-only delegator:
+    #       Similar to TODO_54_68_18_12 (above), it should be part of _new_ `BaseConfigDelegatorEnvelopePayloadSchema`.
 
 
 _config_only_func_config_dict_example = deepcopy(func_config_desc.dict_example)

--- a/src/argrelay/custom_integ/ServiceDelegator.py
+++ b/src/argrelay/custom_integ/ServiceDelegator.py
@@ -364,8 +364,8 @@ class ServiceDelegator(AbstractDelegator):
         elif func_id in [
             func_id_diff_service_,
         ]:
-            # TODO_75_52_01_67: `arg_bucket`-s to support multiple var args:
-            #                   query both service lists and compare them.
+            # TODO: TODO_75_52_01_67: `arg_bucket`-s to support multiple var args:
+            #       query both service lists and compare them.
 
             # Actual implementation is not defined for demo:
             return redirect_to_error(

--- a/src/argrelay/custom_integ_res/bootstrap_env.bash
+++ b/src/argrelay/custom_integ_res/bootstrap_env.bash
@@ -375,7 +375,9 @@ then
     echo "It is required to install packages to extract artifacts from them." 1>&2
     echo "Provide \`${argrelay_dir}/exe/install_project.bash\`, for example (copy and paste and modify):" 1>&2
     echo "" 1>&2
-    # TODO: This matches content of default config stored in `argrelay` repo - try to deduplicate.
+    # TODO: TODO_96_01_13_29: multiple bootstrap stages to instantiate configs
+    #       Installing extra files can be left to later bootstrap stages when packages are already installed.
+    #       This matches content of default config stored in `argrelay` repo - try to deduplicate.
     cat << 'install_project_EOF'
 ########################################################################################################################
 # `argrelay` integration file: https://github.com/argrelay/argrelay
@@ -589,7 +591,9 @@ then
     echo "It is required to know list of configs to be installed." 1>&2
     echo "Provide \`${install_files_conf_path}\`, for example (copy and paste and modify):" 1>&2
     echo "" 1>&2
-    # TODO: This matches content of default config stored in `argrelay` repo - try to deduplicate.
+    # TODO: TODO_96_01_13_29: multiple bootstrap stages to instantiate configs
+    #       Installing extra files can be left to later bootstrap stages when packages are already installed.
+    #       This matches content of default config stored in `argrelay` repo - try to deduplicate.
     cat << 'config_files_conf_EOF'
 ########################################################################################################################
 # `argrelay` integration file: https://github.com/argrelay/argrelay
@@ -656,7 +660,9 @@ then
     echo "It is required to know list of resources to be installed." 1>&2
     echo "Provide \`${install_files_conf_path}\`, for example (copy and paste and modify):" 1>&2
     echo "" 1>&2
-    # TODO: This matches content of default config stored in `argrelay` repo - try to deduplicate.
+    # TODO: TODO_96_01_13_29: multiple bootstrap stages to instantiate configs
+    #       Installing extra files can be left to later bootstrap stages when packages are already installed.
+    #       This matches content of default config stored in `argrelay` repo - try to deduplicate.
     cat << 'resource_files_conf_EOF'
 ########################################################################################################################
 # `argrelay` integration file: https://github.com/argrelay/argrelay
@@ -819,7 +825,9 @@ then
     echo "It is required as custom build step for integration project, but can do nothing." 1>&2
     echo "Provide \`${argrelay_dir}/exe/build_project.bash\`, for example (copy and paste and modify):" 1>&2
     echo "" 1>&2
-    # TODO: This matches content of default config stored in `argrelay` repo - try to deduplicate.
+    # TODO: TODO_96_01_13_29: multiple bootstrap stages to instantiate configs
+    #       Installing extra files can be left to later bootstrap stages when packages are already installed.
+    #       This matches content of default config stored in `argrelay` repo - try to deduplicate.
     cat << 'build_project_EOF'
 ########################################################################################################################
 # `argrelay` integration file: https://github.com/argrelay/argrelay

--- a/src/argrelay/custom_integ_res/dev_shell.bash
+++ b/src/argrelay/custom_integ_res/dev_shell.bash
@@ -54,7 +54,7 @@ set -u
 
 failure_color="\e[41m\e[97m"
 reset_color="\e[0m"
-banner_color="\e[94m"
+banner_color="\e[95m"
 
 # Indicate failure by color:
 function color_failure_only {
@@ -86,7 +86,7 @@ export ARGRELAY_DEV_SHELL
 if [[ "$#" -eq "0" ]]
 then
     # Interactive:
-    echo -e "${banner_color}INFO: keep starting nested \`@/exe/dev_shell.bash\` on demand or \`source\` this config by default in \`~/.bashrc\`: ${argrelay_dir}/exe/shell_env.bash${reset_color}" 1>&2
+    echo -e "${banner_color}INFO: avoid starting nested \`@/exe/dev_shell.bash\` on demand by \`source\`-ing this config in \`~/.bashrc\` by default: ${argrelay_dir}/exe/shell_env.bash${reset_color}" 1>&2
     exec bash --init-file <( echo "source ~/.bashrc && source ${argrelay_dir}/exe/init_shell_env.bash" )
 else
     # Non-interactive:

--- a/src/argrelay/custom_integ_res/init_shell_env.bash
+++ b/src/argrelay/custom_integ_res/init_shell_env.bash
@@ -73,6 +73,20 @@ else
     conf_status="[error]"
 fi
 
+# Set readline settings which are (arguably) more convenient.
+# These settings force-override those set by user,
+# but this is only for `@/exe/dev_shell.bash` (can be force-overridden again by `@/conf/dev_shell_env.bash`).
+# Official doc:
+# https://www.gnu.org/software/bash/manual/html_node/Readline-Init-File-Syntax.html
+# *   See more: https://stackoverflow.com/a/42193784/441652
+bind "set show-all-if-ambiguous on"
+# *   See more: https://stackoverflow.com/a/42193784/441652
+bind "set show-all-if-unmodified on"
+# *   Deduplicate string on insertion of completed part in the middle of an arg:
+bind "set skip-completed-text on"
+# *   Highlight by color first chars matching current prefix:
+bind "set colored-completion-prefix on"
+
 # Source extra config:
 if [[ -f "${argrelay_dir}/conf/dev_shell_env.bash" ]]
 then

--- a/src/argrelay/custom_integ_res/shell_env.bash
+++ b/src/argrelay/custom_integ_res/shell_env.bash
@@ -53,7 +53,7 @@ set -u
 # TODO: This is a stop gap workaround (to allow FS_57_36_37_48 multiple clients coexistence):
 #       Prefix all shared vars (e.g. `argrelay_dir`) set here with `argrelay_rc` and unset them on exit.
 #       With multiple clients, sourcing the second `@/exe/shell_env.bash` reset shared env vars used by the first.
-#       TODO_27_61_22_18: Long term solution is to make these vars local (not shared).
+#       See TODO_27_61_22_18: Long term solution is to make these vars local (not shared).
 argrelay_rc_script_source="${BASH_SOURCE[0]}"
 # It is expected that `@/exe/shell_env.bash` is sourced from the project dir.
 # The dir of this script:
@@ -144,7 +144,7 @@ function invoke_completion {
     # https://superuser.com/a/135654/176657
     # It is often convenient to recall what command lines used in previous queries - if not stored,
     # queries are not stored in the history (unless the command was also subsequently invoked).
-    # TODO_24_22_11_49: avoid removing last history command:
+    # TODO: TODO_24_22_11_49: avoid removing last history command:
     #       The following command to append (commented out) command line to the history
     #       removes the last command in the history. Why?
     #       See output `history -p '!-1'` at this point - it is not equal the truly last command,

--- a/src/argrelay/custom_integ_res/upgrade_env_packages.bash
+++ b/src/argrelay/custom_integ_res/upgrade_env_packages.bash
@@ -46,7 +46,7 @@ then
     exact_argrelay_version="${1}"
 fi
 
-# TODO_64_79_28_85: deduplicate this file with publish_package.bash (move upgrade function here from there).
+# TODO: TODO_64_79_28_85: deduplicate this file with publish_package.bash (move upgrade function here from there).
 
 # Switch to `@/` to avoid creating temporary dirs somewhere else:
 cd "${argrelay_dir}" || exit 1

--- a/src/argrelay/handler_response/ClientResponseHandlerDescribeLineArgs.py
+++ b/src/argrelay/handler_response/ClientResponseHandlerDescribeLineArgs.py
@@ -40,7 +40,7 @@ class ClientResponseHandlerDescribeLineArgs(ClientResponseHandlerAbstract):
         FS_02_25_41_81: Renders results `func_id_query_enum_items` (Alt+Shift+Q)
         """
 
-        # TODO_11_77_28_50: print suggestions in `InterpResult.arg_values`
+        # TODO: TODO_11_77_28_50: print suggestions in `InterpResult.arg_values`
 
         print()
 

--- a/src/argrelay/plugin_delegator/AbstractJumpDelegatorConfigSchema.py
+++ b/src/argrelay/plugin_delegator/AbstractJumpDelegatorConfigSchema.py
@@ -5,7 +5,7 @@ from argrelay.misc_helper_common.TypeDesc import TypeDesc
 single_func_id_ = "single_func_id"
 
 
-# TODO_40_10_18_32: add custom base to all schemas:
+# TODO: TODO_40_10_18_32: add custom base to all schemas:
 class AbstractJumpDelegatorConfigSchema(Schema):
     class Meta:
         unknown = RAISE

--- a/src/argrelay/plugin_interp/FuncTreeInterpFactory.py
+++ b/src/argrelay/plugin_interp/FuncTreeInterpFactory.py
@@ -144,8 +144,8 @@ class FuncTreeInterpFactory(AbstractInterpFactory):
         for func_id, func_envelope in func_ids_to_func_envelopes.items():
             if func_id not in self.func_ids_to_func_abs_paths:
                 # TODO: TODO_19_67_22_89: remove `ignored_func_ids_list` - load as `FuncState.fs_unplugged`:
-                # This `func_id` is not plugged into given tree.
-                # It will be loaded as `FuncState.fs_unplugged`.
+                #       This `func_id` is not plugged into given tree.
+                #       It will be loaded as `FuncState.fs_unplugged`.
                 continue
             func_abs_paths = self.func_ids_to_func_abs_paths[func_id]
             for func_abs_path in func_abs_paths:

--- a/src/argrelay/plugin_interp/FuncTreeInterpFactoryConfigSchema.py
+++ b/src/argrelay/plugin_interp/FuncTreeInterpFactoryConfigSchema.py
@@ -3,7 +3,7 @@ from marshmallow import Schema, RAISE
 from argrelay.misc_helper_common.TypeDesc import TypeDesc
 
 
-# TODO_40_10_18_32: add custom base to all schemas:
+# TODO: TODO_40_10_18_32: add custom base to all schemas:
 class FuncTreeInterpFactoryConfigSchema(Schema):
     class Meta:
         unknown = RAISE

--- a/src/argrelay/plugin_interp/InterpTreeInterpFactoryConfigSchema.py
+++ b/src/argrelay/plugin_interp/InterpTreeInterpFactoryConfigSchema.py
@@ -15,7 +15,7 @@ def validate_tree_node(interp_selector_sub_tree: dict):
         raise ValidationError(f"neither a str nor a dict: {interp_selector_sub_tree}")
 
 
-# TODO_40_10_18_32: add custom base to all schemas:
+# TODO: TODO_40_10_18_32: add custom base to all schemas:
 class InterpTreeInterpFactoryConfigSchema(Schema):
     class Meta:
         unknown = RAISE

--- a/src/argrelay/plugin_loader/client_invocation_utils.py
+++ b/src/argrelay/plugin_loader/client_invocation_utils.py
@@ -49,9 +49,9 @@ def prohibit_unconsumed_args(
     ii: InvocationInput,
 ) -> None:
     """
-    TODO TODO_86_57_50_38: Common delegator behavior: consider using delegator/func config to cause this error.
-                           Also, it can be caused on the server-side with redirection to ErrorDelegator
-                           (so that clients do not call that explicitly).
+    TODO: TODO_86_57_50_38: Common delegator behavior: consider using delegator/func config to cause this error.
+          Also, it can be caused on the server-side with redirection to ErrorDelegator
+          (so that clients do not call that explicitly).
     """
 
     unconsumed_args = filter_remaining_args(ii)

--- a/src/argrelay/relay_server/LocalServer.py
+++ b/src/argrelay/relay_server/LocalServer.py
@@ -213,7 +213,7 @@ class LocalServer:
         """
         This validation ensures there is no blank values (`None`, whitespace, etc.) in `index_prop`-s.
 
-        TODO_39_25_11_76: `data_envelope`-s with missing props.
+        TODO: TODO_39_25_11_76: `data_envelope`-s with missing props.
 
         See also FS_99_81_19_25 no space in options.
 
@@ -235,7 +235,7 @@ class LocalServer:
                     envelope_class = data_envelope[ReservedPropName.envelope_class.name]
 
                     if index_prop not in data_envelope:
-                        # TODO_39_25_11_76: `data_envelope`-s with missing props:
+                        # TODO: TODO_39_25_11_76: `data_envelope`-s with missing props:
                         # Let the `data_envelope` load without some `prop_name`-s from `index_prop`-s -
                         # if any of `data_envelope`-s have that `prop_name`, it will fail validation.
                         # It is allowed to have no `prop_name` for all `data_envelope` until at least one has it.
@@ -499,7 +499,7 @@ class LocalServer:
 
         This function only targets `ReservedEnvelopeClass.ClassFunction` (because loading funcs is special).
         There is no decision (yet) to populate missing `prop_value`-s for any `data_envelope`.
-        Instead, there is a validation to prevent missing `prop_name`-s - if it it fails,
+        Instead, there is a validation to prevent missing `prop_name`-s for other `data_envelope`-s - if it fails,
         the corresponding loader has to be fixed to provide seme set of `prop_name`-s for all `data_envelope`.
         """
 
@@ -553,7 +553,7 @@ class LocalServer:
         # At this moment, funcs have already been loaded on `AbstractPlugin.activate_plugin`.
         self._populate_func_missing_props()
 
-        # TODO_00_79_72_55: Remove `static_data` from `server_config`:
+        # TODO: TODO_00_79_72_55: Remove `static_data` from `server_config`:
         # Initial step: load funcs and any data from config:
         self._load_mongo_data_step(
             "config_data",
@@ -677,7 +677,7 @@ class LocalServer:
         MongoClientWrapper.store_envelopes(
             mongo_db,
             self.cleaned_mongo_collections,
-            # TODO_00_79_72_55: Remove `static_data` from `server_config`:
+            # TODO: TODO_00_79_72_55: Remove `static_data` from `server_config`:
             self.server_config.static_data,
             load_state,
         )

--- a/src/argrelay/relay_server/gui_static/argrelay_client.js
+++ b/src/argrelay/relay_server/gui_static/argrelay_client.js
@@ -19,6 +19,7 @@ const remaining_item_temp = document.querySelector("#remaining_item_temp");
 
 const reset_all_elem = document.querySelector("#id_reset_all_button")
 
+const pending_spinner_elem = document.querySelector("#id_pending_spinner")
 const copy_command_elem = document.querySelector("#id_copy_command_button")
 const copy_link_elem = document.querySelector("#id_copy_link_button")
 
@@ -54,7 +55,8 @@ const static_client_conf_target = "_embedded_web_";
 
 const command_history_key = "command_history";
 const command_history_max_size = 10;
-const request_delay_ms = 500;
+// NOTE: Match it with `animation-duration` in `*.css` file:
+const request_delay_ms = 800;
 const clipboard_disabled = "clipboard disabled";
 let command_history_list = [];
 let input_version = 0;
@@ -273,7 +275,7 @@ class abstract_state_class {
         throw new Error("it must be overridden")
     }
 
-    map_io_state_to_elem_class(some_io_state) {
+    map_io_state_to_command_line_input_elem_class(some_io_state) {
         throw new Error("it must be overridden")
     }
 
@@ -312,21 +314,48 @@ class suggest_state_class extends abstract_state_class {
 
     map_io_state_to_gui_state() {
         super.map_io_state_to_gui_state()
+
+        // Set color:
         for (const some_io_state of [
             "client_synced",
             "pending_request",
             "pending_response",
             "request_failed",
         ]) {
-            if (some_io_state === this.io_state) {
-                command_line_input_elem.classList.add(this.map_io_state_to_elem_class(some_io_state));
-            } else {
-                command_line_input_elem.classList.remove(this.map_io_state_to_elem_class(some_io_state));
+            for (const elem_obj of [
+                command_line_input_elem,
+                pending_spinner_elem,
+            ]) {
+                if (some_io_state === this.io_state) {
+                    elem_obj.classList.add(this.map_io_state_to_command_line_input_elem_class(some_io_state));
+                } else {
+                    elem_obj.classList.remove(this.map_io_state_to_command_line_input_elem_class(some_io_state));
+                }
             }
+        }
+
+        // Set spinner animation:
+        if ([
+            "pending_request",
+            "pending_response",
+        ].includes(this.io_state)) {
+            pending_spinner_elem.classList.remove("sinner_paused");
+        } else {
+            pending_spinner_elem.classList.add("sinner_paused");
+        }
+
+        // Set animation direction:
+        if ("pending_request" === this.io_state) {
+            pending_spinner_elem.classList.add("forward_spin");
+            pending_spinner_elem.classList.remove("backward_spin");
+        }
+        if ("pending_response" === this.io_state) {
+            pending_spinner_elem.classList.add("backward_spin");
+            pending_spinner_elem.classList.remove("forward_spin");
         }
     }
 
-    map_io_state_to_elem_class(some_io_state) {
+    map_io_state_to_command_line_input_elem_class(some_io_state) {
         switch (some_io_state) {
             case "client_synced":
                 return "io_state_client_synced_input"

--- a/src/argrelay/relay_server/gui_static/argrelay_style.css
+++ b/src/argrelay/relay_server/gui_static/argrelay_style.css
@@ -323,3 +323,47 @@ Search outline details
 .no_data {
     color: grey;
 }
+
+/***********************************************************************************************************************
+Pending spinner
+***********************************************************************************************************************/
+
+.sinner_paused {
+    animation-play-state: paused;
+}
+
+.forward_spin {
+    animation-direction: normal;
+    /* NOTE: Match it with `request_delay_ms` in `*.js` file: */
+    animation-duration: 0.8s;
+}
+
+.backward_spin {
+    animation-direction: reverse;
+    animation-duration: 0.4s;
+}
+
+.animated_spinner:before {
+    content: "\025E4";
+    animation-name: spinner_frames;
+    animation-iteration-count: infinite;
+    animation-duration: inherit;
+    animation-play-state: inherit;
+    animation-direction: inherit;
+}
+
+@keyframes spinner_frames {
+  0% {
+    content: "\025E4";
+  }
+  25% {
+    content: "\025E5";
+  }
+  50% {
+    content: "\025E2";
+  }
+  75% {
+    content: "\025E3";
+  }
+}
+

--- a/src/argrelay/relay_server/gui_templates/argrelay_main.html
+++ b/src/argrelay/relay_server/gui_templates/argrelay_main.html
@@ -111,6 +111,10 @@
 
     <div class="copy_buttons_container">
         <div
+            id="id_pending_spinner"
+            class="animated_spinner">
+        </div>
+        <div
             id="id_copy_command_button"
             class="base_button copy_command_button"
         >

--- a/src/argrelay/runtime_data/ServerConfig.py
+++ b/src/argrelay/runtime_data/ServerConfig.py
@@ -25,7 +25,7 @@ class ServerConfig:
 
     server_plugin_control: ServerPluginControl = field()
 
-    # TODO_00_79_72_55: remove in the future:
+    # TODO: TODO_00_79_72_55: remove in the future:
     static_data: StaticData = field()
 
     plugin_instances: dict[str, "AbstractPluginServer"] = field(default_factory = lambda: {})

--- a/src/argrelay/sample_conf/argrelay_plugin.yaml
+++ b/src/argrelay/sample_conf/argrelay_plugin.yaml
@@ -179,7 +179,7 @@ plugin_instance_entries:
         plugin_module_name: argrelay.custom_integ.ConfigOnlyDelegator
         plugin_class_name: ConfigOnlyDelegator
         plugin_config:
-            # TODO_84_71_86_21: change to realistic examples:
+            # TODO: TODO_84_71_86_21: change to realistic examples:
             func_configs:
                 func_id_print_with_severity_level:
                     func_envelope:

--- a/src/argrelay/sample_conf/check_env_plugin.conf.yaml
+++ b/src/argrelay/sample_conf/check_env_plugin.conf.yaml
@@ -59,3 +59,17 @@ check_env_plugin_instance_entries:
         plugin_module_name: argrelay.check_env.PluginCheckEnvServerResponseValueStartTime
         plugin_class_name: PluginCheckEnvServerResponseValueStartTime
 
+    PluginCheckEnvReadlineShowAllIfAmbiguous.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvReadline
+        plugin_class_name: PluginCheckEnvReadlineShowAllIfAmbiguous
+
+    PluginCheckEnvReadlineShowAllIfUnmodified.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvReadline
+        plugin_class_name: PluginCheckEnvReadlineShowAllIfUnmodified
+
+    PluginCheckEnvReadlineSkipCompletedText.default:
+        plugin_side: PluginClientSideOnly
+        plugin_module_name: argrelay.check_env.PluginCheckEnvReadline
+        plugin_class_name: PluginCheckEnvReadlineSkipCompletedText

--- a/src/argrelay/schema_config_core_server/EnvelopeCollectionSchema.py
+++ b/src/argrelay/schema_config_core_server/EnvelopeCollectionSchema.py
@@ -27,7 +27,7 @@ class EnvelopeCollectionSchema(ObjectSchema):
         load_default = [],
     )
 
-    # TODO_00_79_72_55: do not store `data_envelopes`
+    # TODO: TODO_00_79_72_55: do not store `data_envelopes`
     data_envelopes = fields.List(
         fields.Nested(data_envelope_desc.dict_schema),
         required = False,

--- a/src/argrelay/schema_config_core_server/ServerConfigSchema.py
+++ b/src/argrelay/schema_config_core_server/ServerConfigSchema.py
@@ -74,7 +74,7 @@ class ServerConfigSchema(ObjectSchema):
         required = True,
     )
 
-    # TODO_00_79_72_55: remove in the future:
+    # TODO: TODO_00_79_72_55: remove in the future:
     static_data = fields.Nested(
         static_data_desc.dict_schema,
         required = False,

--- a/src/argrelay/schema_config_core_server/StaticDataSchema.py
+++ b/src/argrelay/schema_config_core_server/StaticDataSchema.py
@@ -11,7 +11,7 @@ from argrelay.schema_config_core_server.EnvelopeCollectionSchema import envelope
 envelope_collections_ = "envelope_collections"
 
 
-# TODO_00_79_72_55: remove in the future:
+# TODO: TODO_00_79_72_55: remove in the future:
 class StaticDataSchema(ObjectSchema):
     class Meta:
         unknown = RAISE

--- a/src/argrelay/schema_config_interp/DataEnvelopeSchema.py
+++ b/src/argrelay/schema_config_interp/DataEnvelopeSchema.py
@@ -19,7 +19,7 @@ Not required field with unique id for `data_envelope`.
 If provided, it is given to MongoDB as `mongo_id_` (otherwise, if not provided, MongoDB auto-generates one).
 """
 
-# TODO_45_75_75_65: Merge `instance_data` into `envelop_payload`:
+# TODO: TODO_45_75_75_65: Merge `instance_data` into `envelop_payload`:
 instance_data_ = "instance_data"
 """
 Data specific to `envelope_class`.
@@ -54,7 +54,7 @@ class DataEnvelopeSchema(Schema):
     Each envelope class may define its own schema for that data.
     For example, `ReservedEnvelopeClass.ClassFunction` defines `FunctionEnvelopeInstanceDataSchema`.
     """
-    # TODO_45_75_75_65: Merge `instance_data` into `envelop_payload`:
+    # TODO: TODO_45_75_75_65: Merge `instance_data` into `envelop_payload`:
     instance_data = fields.Dict(
         required = False,
     )
@@ -63,7 +63,7 @@ class DataEnvelopeSchema(Schema):
     Arbitrary schemaless data (payload) wrapped by `DataEnvelopeSchema`.
     It is not inspected by `argrelay` layer (unlike, `instance_data`) - instead, it is passed on custom app layer.
     """
-    # TODO_45_75_75_65: Merge `instance_data` into `envelop_payload`:
+    # TODO: TODO_45_75_75_65: Merge `instance_data` into `envelop_payload`:
     envelope_payload = fields.Dict(
         required = False,
     )

--- a/src/argrelay/schema_config_interp/FunctionEnvelopeInstanceDataSchema.py
+++ b/src/argrelay/schema_config_interp/FunctionEnvelopeInstanceDataSchema.py
@@ -13,7 +13,7 @@ delegator_plugin_instance_id_ = "delegator_plugin_instance_id"
 search_control_list_ = "search_control_list"
 
 
-# TODO_45_75_75_65: Merge `instance_data` into `envelop_payload`:
+# TODO: TODO_45_75_75_65: Merge `instance_data` into `envelop_payload`:
 class FunctionEnvelopeInstanceDataSchema(Schema):
     """
     Schema for :class:`DataEnvelopeSchema.instance_data` of :class:`ReservedEnvelopeClass.ClassFunction`

--- a/src/argrelay/schema_response/ArgValuesSchema.py
+++ b/src/argrelay/schema_response/ArgValuesSchema.py
@@ -15,7 +15,7 @@ _arg_values_example = {
 }
 
 
-# TODO_11_77_28_50: Make it possible to verify proposed arg_values in all `ServerAction`-s.
+# TODO: TODO_11_77_28_50: Make it possible to verify proposed arg_values in all `ServerAction`-s.
 # Append space to the command line (for surrogate token delimiter) in case of `ServerAction.RelayLineArgs`
 # to populate proposed arg_values to allow unconditionally assert proposed values in all tests
 # (for all `ServerAction`-s).

--- a/src/argrelay/test_infra/EnvMockBuilder.py
+++ b/src/argrelay/test_infra/EnvMockBuilder.py
@@ -99,8 +99,8 @@ class EnvMockBuilder:
 
     *   Simple selection of test data - see usage of: `set_test_data_ids_to_load`
 
-    *   TODO_42_81_01_90: Verify `ArgValues` on `ServerAction.DescribeLineArgs` (without verifying printed output) by intercepting call to `ClientResponseHandlerProposeArgValues.render_values`.
-    *   TODO_42_81_01_90: Verify `InterpResult` on `ServerAction.ProposeArgValues` (without verifying printed output) by intercepting call to `ClientResponseHandlerDescribeLineArgs.render_result`.
+    *   TODO: TODO_42_81_01_90: Verify `ArgValues` on `ServerAction.DescribeLineArgs` (without verifying printed output) by intercepting call to `ClientResponseHandlerProposeArgValues.render_values`.
+    *   TODO: TODO_42_81_01_90: Verify `InterpResult` on `ServerAction.ProposeArgValues` (without verifying printed output) by intercepting call to `ClientResponseHandlerDescribeLineArgs.render_result`.
     *   Verifying `InvocationInput` on `ServerAction.RelayLineArgs` - see usage of:
 
         *   `invoke_action_func_full_name`

--- a/src/argrelay/test_infra/InOutTestClass.py
+++ b/src/argrelay/test_infra/InOutTestClass.py
@@ -14,7 +14,7 @@ from argrelay.test_infra.EnvMockBuilder import EnvMockBuilder
 
 
 class InOutTestClass(BaseTestClass):
-    # TODO_32_99_70_35: Make generic validator be able to verify payload (not only `interp_ctx` passed from local client) - JSONPath?
+    # TODO: TODO_32_99_70_35: Make generic validator be able to verify payload (not only `interp_ctx` passed from local client) - JSONPath?
 
     # TODO: Wrap input into Dataclass which in turn can be created via builder (to have ability pre-build defaults for a set of tests).
     def verify_response_data(
@@ -73,7 +73,7 @@ class InOutTestClass(BaseTestClass):
                 )
 
             if expected_container_ipos_to_used_arg_bucket is not None:
-                # TODO_32_99_70_35: candidate for generic library of JSONPath verifiers:
+                # TODO: TODO_32_99_70_35: candidate for generic library of JSONPath verifiers:
                 for envelope_container_ipos, envelope_container in enumerate(envelope_containers):
                     expected_used_arg_bucket = expected_container_ipos_to_used_arg_bucket[envelope_container_ipos]
                     self.assertEqual(

--- a/src/argrelay/test_infra/LocalTestClass.py
+++ b/src/argrelay/test_infra/LocalTestClass.py
@@ -97,7 +97,7 @@ class LocalTestClass(InOutTestClass):
             interp_ctx: InterpContext = command_obj.interp_ctx
             call_ctx: CallContext = command_obj.call_ctx
 
-            # TODO_32_99_70_35: (JSONPath?) Currently, this verifier ensures what things exists.
+            # TODO: TODO_32_99_70_35: (JSONPath?) Currently, this verifier ensures what things exists.
             #       Add a way to ensure what things do not exist.
             #       For example,
             #       * no `data_envelope` number N.

--- a/src/argrelay/test_infra/RemoteTestClass.py
+++ b/src/argrelay/test_infra/RemoteTestClass.py
@@ -64,7 +64,7 @@ class RemoteTestClass(ClientServerTestClass):
 
             call_ctx = command_obj.call_ctx
 
-            # TODO_32_99_70_35: (JSONPath?) Currently, this verifier ensures what things exists.
+            # TODO: TODO_32_99_70_35: (JSONPath?) Currently, this verifier ensures what things exists.
             #       Add a way to ensure what things do not exist.
             #       For example,
             #       * no `data_envelope` number N.

--- a/tests/env_tests/test_MongoClient_missing_collections.py
+++ b/tests/env_tests/test_MongoClient_missing_collections.py
@@ -1,0 +1,22 @@
+from offline_tests.mongo_query import test_MongoClient_missing_collections
+
+
+class ThisTestClass(test_MongoClient_missing_collections.ThisTestClass):
+    """
+    Reconfigures existing tests to run against real MongoDB.
+    """
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        super(
+            ThisTestClass,
+            self,
+        ).__init__(
+            *args,
+            **kwargs,
+        )
+
+        self.use_mongomock = False

--- a/tests/offline_tests/mongo_query/MongoClientTestClass.py
+++ b/tests/offline_tests/mongo_query/MongoClientTestClass.py
@@ -34,14 +34,14 @@ class MongoClientTestClass(BaseTestClass):
 
     def setUp(self):
         super().setUp()
-        self.col_proxy = self.create_collection_proxy(self.col_name)
+        self.col_proxy = self.select_collection_proxy(self.col_name)
         self.remove_all_data(self.col_proxy)
 
     def tearDown(self):
         super().tearDown()
         self.remove_all_data(self.col_proxy)
 
-    def create_collection_proxy(
+    def select_collection_proxy(
         self,
         col_name: str,
     ):
@@ -65,7 +65,7 @@ class MongoClientTestClass(BaseTestClass):
     def show_all_envelopes(
         col_proxy: Collection,
     ):
-        print("show_all_envelopes:")
+        print(f"show_all_envelopes [{col_proxy.name}]:")
         for data_envelope in col_proxy.find():
             print("data_envelope: ", data_envelope)
 
@@ -75,6 +75,7 @@ class MongoClientTestClass(BaseTestClass):
     ):
         col_proxy.delete_many({})
         col_proxy.drop_indexes()
+        col_proxy.drop()
 
     @staticmethod
     def index_props(

--- a/tests/offline_tests/mongo_query/test_MongoClient_distinct_values_search.py
+++ b/tests/offline_tests/mongo_query/test_MongoClient_distinct_values_search.py
@@ -10,6 +10,8 @@ class ThisTestClass(MongoClientTestClass):
         """
         Example to search distinct values for each field individually in single query:
         https://stackoverflow.com/a/63595331/441652
+
+        This query is used in by `QueryEngine` in case of `DistinctValuesQuery.native_aggregate`.
         """
 
         index_props = [

--- a/tests/offline_tests/mongo_query/test_MongoClient_missing_collections.py
+++ b/tests/offline_tests/mongo_query/test_MongoClient_missing_collections.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from argrelay.custom_integ.ServicePropName import ServicePropName
+from offline_tests.mongo_query.MongoClientTestClass import MongoClientTestClass
+
+
+class ThisTestClass(MongoClientTestClass):
+
+    # noinspection PyMethodMayBeStatic
+    def test_querying_non_exising_collection(self):
+        """
+        This tests assumption that querying non-existing collections does not fail.
+        """
+
+        self.show_all_envelopes(self.col_proxy)
+
+        print("query 1:")
+        for data_envelope in self.col_proxy.find(
+            {
+                ServicePropName.access_type.name: "rw",
+                ServicePropName.live_status.name: "red",
+            }
+        ):
+            print("data_envelope: ", data_envelope)

--- a/tests/offline_tests/plugin_delegator/test_HelpDelegator.py
+++ b/tests/offline_tests/plugin_delegator/test_HelpDelegator.py
@@ -35,7 +35,7 @@ class ThisTestClass(LocalTestClass):
                     0: {},  # help func envelope itself
                     1: {
                         # (goto, desc, list) x (host, service) external functions:
-                        # TODO_32_99_70_35: (JSONPath?) Universal verifier: be able to verify arbitrary data on `EnvelopeContainer`, not only assigned types to values.
+                        # TODO: TODO_32_99_70_35: (JSONPath?) Universal verifier: be able to verify arbitrary data on `EnvelopeContainer`, not only assigned types to values.
                         # "found_count": 6
                     },
                 },
@@ -147,7 +147,7 @@ some_command list service {SpecialChar.NoPropValue.value} {TermColor.known_envel
 
                     invocation_input: InvocationInput = EnvMockBuilder.invocation_input
 
-                # TODO_43_41_95_86: use server logger to disable stdout:
+                # TODO: TODO_43_41_95_86: use server logger to disable stdout:
                 #       Running print again with capturing `stdout`.
                 #       Executing end-to-end above may generate
                 #       noise output on `stdout`/`stderr` by local server logic.

--- a/tests/offline_tests/relay_demo/test_relay_demo.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo.py
@@ -531,7 +531,7 @@ class ThisTestClass(LocalTestClass):
                 line_no(), "some_command goto service s_b prod qwer-pd-2 |", CompType.DescribeArgs,
                 "If current command search results in ambiguous results (more than one `data_envelope`), "
                 "it should still work.",
-                # TODO_32_99_70_35: Use generalized validator asserting payload (for this case it is fine) instead of entire stdout str - JSONPath?
+                # TODO: TODO_32_99_70_35: Use generalized validator asserting payload (for this case it is fine) instead of entire stdout str - JSONPath?
                 None,
             ),
             (
@@ -678,7 +678,7 @@ class ThisTestClass(LocalTestClass):
                 line_no(), "some_command goto|", CompType.PrefixShown,
                 0,
                 {
-                    # TODO_32_99_70_35: How to specify that some specific props are not assigned?
+                    # TODO: TODO_32_99_70_35: How to specify that some specific props are not assigned?
                 },
                 "No assignment for incomplete token (token pointed by the cursor) in completion mode",
             ),
@@ -721,7 +721,7 @@ class ThisTestClass(LocalTestClass):
                 {
                     f"{func_envelope_path_step_prop_name(0)}": AssignedValue("some_command", ArgSource.InitValue),
                     f"{func_envelope_path_step_prop_name(1)}": AssignedValue("goto", ArgSource.ExplicitPosArg),
-                    # TODO_32_99_70_35: How to specify that some specific props are not assigned?
+                    # TODO: TODO_32_99_70_35: How to specify that some specific props are not assigned?
                 },
                 # TODO: Fix this: "service" must be recognized even if in double quotes:
                 "FS_92_75_93_01: Register a bug that \"service\" token is not recognized while in double quotes.",
@@ -1188,7 +1188,7 @@ class ThisTestClass(LocalTestClass):
                 # Output is not specified - not to be asserted:
                 return
 
-            # TODO_43_41_95_86: use server logger to disable stdout:
+            # TODO: TODO_43_41_95_86: use server logger to disable stdout:
             #       Running print again with capturing `stdout`.
             #       Executing end-to-end above may generate
             #       noise output on `stdout`/`stderr` by local server logic.

--- a/tests/offline_tests/relay_demo/test_relay_demo_TD_76_09_29_31_overlapped.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_TD_76_09_29_31_overlapped.py
@@ -180,7 +180,7 @@ class ThisTestClass(LocalTestClass):
                     },
                     3: None,
                 },
-                # TODO_70_48_96_29: add verification of consumed and remaining tokens
+                # TODO: TODO_70_48_96_29: add verification of consumed and remaining tokens
                 "TD_76_09_29_31 overlapped: "
                 "Both geo_region and host_name are correctly assigned. "
                 "All values assigned - no more suggestions. ",

--- a/tests/offline_tests/relay_demo/test_relay_demo_TD_99_99_88_75_mutually_exclusive.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_TD_99_99_88_75_mutually_exclusive.py
@@ -171,7 +171,7 @@ class ThisTestClass(LocalTestClass):
                 },
                 "TD_99_99_88_75: `host-b-*` are suggested as according to "
                 "FS_76_29_13_28: user input priority, `emea` is eaten first, and "
-                # TODO_70_48_96_29: be able to assert remaining arg vals:
+                # TODO: TODO_70_48_96_29: be able to assert remaining arg vals:
                 "FS_44_36_84_88: `qa` become remaining "
                 "(rather than becoming FS_51_67_38_37 impossible arg combination)",
             ),
@@ -199,7 +199,7 @@ class ThisTestClass(LocalTestClass):
                 },
                 "TD_99_99_88_75: `host-a-*` are suggested as according to "
                 "FS_76_29_13_28: user input priority, `qa` is eaten first, and "
-                # TODO_70_48_96_29: be able to assert remaining arg vals:
+                # TODO: TODO_70_48_96_29: be able to assert remaining arg vals:
                 "FS_44_36_84_88: `emea` become remaining "
                 "(rather than becoming FS_51_67_38_37 impossible arg combination)",
             ),
@@ -227,7 +227,7 @@ class ThisTestClass(LocalTestClass):
                 },
                 "TD_99_99_88_75: `host-a-*` are suggested as according to "
                 "FS_76_29_13_28: user input priority, `apac` is eaten first, and "
-                # TODO_70_48_96_29: be able to assert remaining arg vals:
+                # TODO: TODO_70_48_96_29: be able to assert remaining arg vals:
                 "FS_44_36_84_88: `dev` become remaining "
                 "(rather than becoming FS_51_67_38_37 impossible arg combination)",
             ),
@@ -258,7 +258,7 @@ class ThisTestClass(LocalTestClass):
                 },
                 "TD_99_99_88_75: `host-b-*` are suggested as according to "
                 "FS_76_29_13_28: user input priority, `dev` is eaten first, and "
-                # TODO_70_48_96_29: be able to assert remaining arg vals:
+                # TODO: TODO_70_48_96_29: be able to assert remaining arg vals:
                 "FS_44_36_84_88: `apac` become remaining "
                 "(rather than becoming FS_51_67_38_37 impossible arg combination)",
             ),

--- a/tests/offline_tests/relay_demo/test_relay_demo_not_hidden_funcs.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_not_hidden_funcs.py
@@ -159,7 +159,7 @@ class ThisTestClass(LocalTestClass):
         """
         This test relies on `ConfigOnlyDelegator` to remove some `prop_name`-s in its `func_envelope`.
 
-        TODO_39_25_11_76: `data_envelope`-s with missing props.
+        TODO: TODO_39_25_11_76: `data_envelope`-s with missing props.
 
         The validation should prevent using any `func_envelope` which does not contain `prop_name`-s
         used by some of `search_control`-s anywhere (e.g. by `search_control` used by some plugin).

--- a/tests/offline_tests/relay_demo/test_relay_demo_trees.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_trees.py
@@ -90,49 +90,49 @@ tree_path_selector_2: ? intercept help goto desc list host service repo commit
             (
                 line_no(), "some_command |", CompType.DescribeArgs,
                 "Ensure it provides `some_command` as first `InitValue` prop.",
-                # TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
+                # TODO: TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
                 None,
             ),
             (
                 line_no(), "some_command |", CompType.DescribeArgs,
                 "Ensure it provides `some_command` as first `InitValue` prop.",
-                # TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
+                # TODO: TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
                 None,
             ),
             (
                 line_no(), "some_command intercept |", CompType.DescribeArgs,
                 "Ensure `intercept` works for `CompType.DescribeArgs`.",
-                # TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
+                # TODO: TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
                 None,
             ),
             (
                 line_no(), "some_command intercept help |", CompType.DescribeArgs,
                 "Ensure `intercept` of `help` works for `CompType.DescribeArgs`.",
-                # TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
+                # TODO: TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
                 None,
             ),
             (
                 line_no(), "some_command intercept help |", CompType.DescribeArgs,
                 "Ensure `help` of `intercept` works for `CompType.DescribeArgs`.",
-                # TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
+                # TODO: TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
                 None,
             ),
             (
                 line_no(), "# some_command intercept help |", CompType.DescribeArgs,
                 "Commented line: selecting `NoopInterpFactory` by default should not fail.",
-                # TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
+                # TODO: TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
                 None,
             ),
             (
                 line_no(), "some_command intercept intercept help |", CompType.DescribeArgs,
                 "Doubling of `intercept` should work.",
-                # TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
+                # TODO: TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
                 None,
             ),
             (
                 line_no(), "some_command subtree help |", CompType.DescribeArgs,
                 "Help for `subtree` should work.",
-                # TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
+                # TODO: TODO_42_81_01_90: implement asserting data for `CompType.DescribeArgs` to make it easier to assert:
                 None,
             ),
         ]
@@ -167,7 +167,7 @@ tree_path_selector_2: ? intercept help goto desc list host service repo commit
                         # Output is not specified - not to be asserted:
                         continue
 
-                    # TODO_43_41_95_86: use server logger to disable stdout:
+                    # TODO: TODO_43_41_95_86: use server logger to disable stdout:
                     #       Running print again with capturing `stdout`.
                     #       Executing end-to-end above may generate
                     #       noise output on `stdout`/`stderr` by local server logic.

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -1,5 +1,5 @@
 
-TODO_04_84_79_11: Update/change categories to include:
+TODO: TODO_04_84_79_11: Update/change categories to include:
     *   split `offline_tests`:
         *   in_process_tests - tests which do not start other processes to communicate with
         *   local_tests - tests which may start other processes to communicate with (potentially occupying port numbers)


### PR DESCRIPTION
*   Implement `check_env` verification for GNU Readline settings:
    *   `show-all-if-ambiguous`
    *   `show-all-if-unmodified`
    *   `skip-completed-text`
*   Prefix all existing `TODO_` with `TODO: ` to syntax highlight them.
*   Force convenient GNU Readline settings in `@/exe/dev_shell.bash`.
*   Implement animated spinner for GUI.
*   Make `echo_command_on_stderr` true by default for `ConfigOnlyDelegator`.
*   Spec: `TODO_96_01_13_29.multiple_bootstrap_stages_to_instantiate_configs.md`.
