### PR TITLE
Use explicit `import encodings.idna` ahead of fork

### DIFF
--- a/docs/task_refs/TODO_30_69_19_14.infinite_spinner.md
+++ b/docs/task_refs/TODO_30_69_19_14.infinite_spinner.md
@@ -8,10 +8,15 @@ when `os.fork`-ed client hangs on `import` inside `requests` library (on [`impor
 
 # Status
 
-Hang on `import` is fixed by using `urllib3` instead of `requests`.
+The fix for hanging on `import` has not been confirmed.
 
-There are still some changes needed to update existing tests (currently disabled)
-which rely on `requests` + `responses` libraries. Also, setting `signal.alarm` and handling it should be cleaned up.
+But the issue is alleviated with an alarm signal set before attempt to `import`.
+This tells about issue immediately (within a second), and user can retry
+rather than waiting and guessing why response takes long time.
+
+Current **attempt** to fix it is to `import encodings.idna` in parent process explicitly ahead.
+The hypothesis is that it has something to do with both parent and child importing it at the same time.
+Importing it ahead might avoid that concurrency - similar to [`import encodings.idna`][import_encodings_idna] there.
 
 # Workaround
 
@@ -45,11 +50,31 @@ File "/venv/lib/python3.11/site-packages/requests/sessions.py”, line 15, in <m
 from .adapters import HTTPAdapter
 File "/venv/lib/python3.11/site-packages/requests/adapters.py”, line 44, in <module>
 from .models import Response
-File "/venv/lib/python3.11/site-packages/requests/models. py”, line 13, in <module>
+File "/venv/lib/python3.11/site-packages/requests/models.py”, line 13, in <module>
 import encodings.idna  # noqa: F401
 File "<frozen importlib._bootstrap>", line 224, in _lock_unlock_module
 File “<frozen importlib._bootstrap>", line 120, in acquire
 KeyboardInterrupt
 ```
+
+# Attempt to fix it by swapping `requests` with `urllib3`
+
+This worsened the situation (and was reverted) - `urllib3` also failed on `idna`-related import:
+
+```
+  File "/venv/1ib/python3.11/site-packages/urllib3/connection.py”, line 199, in _new_conn
+    sock = connection.create_connection(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/venv/lib/python3.11/site-packages/urllib3/util/connection.py”, line 56, in create_connection
+    host.encode("idna")
+  File "/usr/lib/python3.11/encodings/_init_.py", Tine 99, in search_function
+    mod = __import__('encodings.' + modname, fromlist=_import_tail,
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File “<frozen importlib._bootstrap>", line 224, in _lock_unlock_module
+  File “<frozen importlib._bootstrap>", line 120, in acquire
+KeyboardInterrupt
+```
+
+But `urllib3` hangs during request - there is no simple way to separate hang via alert signal anymore.
 
 [import_encodings_idna]: https://github.com/psf/requests/commit/d7227fbb7e07af35f23a0d370ab3b01661af9e40#commitcomment-146935826

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,6 @@ import setuptools
 
 tests_require = [
     "tox",
-    # TODO: TODO_30_69_19_14: client hangs with infinite spinner
-    #       Rewrite test to avoid using `requests` + `responses`.
     "responses",
     "mongomock",
     "pandas",
@@ -157,7 +155,7 @@ See: https://github.com/argrelay/argrelay
         "GitPython",
         # Use `mongomock` as replacement for Mongo DB in simple prod cases:
         "mongomock",
-        "urllib3",
+        "requests",
         "cachetools",
     ],
     tests_require = tests_require,

--- a/src/argrelay/_version.py
+++ b/src/argrelay/_version.py
@@ -1,4 +1,4 @@
 # See `docs/dev_notes/version_format.md`:
 # Implements this:
 # https://stackoverflow.com/a/7071358/441652
-__version__ = "0.7.18"
+__version__ = "0.7.19"

--- a/src/argrelay/relay_client/__main__.py
+++ b/src/argrelay/relay_client/__main__.py
@@ -48,6 +48,13 @@ def run_client():
 
     w_pipe_end = None
     if is_split_mode:
+        # TODO: TODO_30_69_19_14: infinite spinner
+        #       Perform `import encodings.idna` explicitly ahead of fork.
+        #       Similar to this:
+        #       https://github.com/psf/requests/commit/d7227fbb7e07af35f23a0d370ab3b01661af9e40#commitcomment-146935826
+        # noinspection PyUnresolvedReferences
+        import encodings.idna
+
         from argrelay.relay_client.proc_splitter import split_process
         (
             is_parent,

--- a/src/argrelay/relay_server/gui_templates/argrelay_main.html
+++ b/src/argrelay/relay_server/gui_templates/argrelay_main.html
@@ -112,7 +112,9 @@
     <div class="copy_buttons_container">
         <div
             id="id_pending_spinner"
-            class="animated_spinner">
+            class="animated_spinner"
+            title="Spinner for states `pending` IO"
+        >
         </div>
         <div
             id="id_copy_command_button"

--- a/tests/offline_tests/relay_client/test_client_side_fail_over.py
+++ b/tests/offline_tests/relay_client/test_client_side_fail_over.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import unittest
 from dataclasses import asdict, replace
 from typing import Union
 
@@ -24,9 +23,7 @@ from argrelay.test_infra.EnvMockBuilder import LiveServerEnvMockBuilder
 
 random_byte_value = b"\x07"
 
-# TODO: TODO_30_69_19_14: client hangs with infinite spinner
-#       Rewrite test to avoid using `requests`.
-@unittest.skip
+
 class ThisTestClass(BaseTestClass):
     """
     Test FS_93_18_57_91 client fail over to redundant servers.

--- a/tests/offline_tests/relay_client/test_relay_client.py
+++ b/tests/offline_tests/relay_client/test_relay_client.py
@@ -1,4 +1,3 @@
-import unittest
 from copy import deepcopy
 
 import responses
@@ -23,9 +22,6 @@ from argrelay.test_infra.BaseTestClass import BaseTestClass
 from argrelay.test_infra.EnvMockBuilder import LiveServerEnvMockBuilder
 
 
-# TODO: TODO_30_69_19_14: client hangs with infinite spinner
-#       Rewrite test to avoid using `requests`.
-@unittest.skip
 class ThisTestClass(BaseTestClass):
     """
     Client-only test via mocked `responses` lib (without spanning `argrelay` server).


### PR DESCRIPTION

*   Revert attempt to fix TODO_30_69_19_14 client spinner hangs by using `urllib3` instead of `requests`.
*   Try explicit `import encodings.idna` ahead of fork instead.
