### PR TITLE
Improve `data_model` validation

### DIFF
--- a/docs/feature_stories/FS_45_08_22_15.data_model_manipulation.md
+++ b/docs/feature_stories/FS_45_08_22_15.data_model_manipulation.md
@@ -4,14 +4,39 @@ feature_title: data model manipulation
 feature_status: PARTIAL
 ---
 
-TODO: Move details about metadata from FS_74_69_61_79 get set data envelope here.
-
 TODO: TODO_08_25_32_95: redesign `class_to_collection_map`:
       This FS_45_08_22_15 data model manipulation API should replace `class_to_collection_map`.
 
 # Intro
 
 This feature describes a data model manipulation API (AKA metadata to define data).
+
+# DML vs DDL
+
+*   If FS_74_69_61_79 get set `data_envelope` is about DML (Data Manipulation Language),
+*   then FS_45_08_22_15 data model manipulation is about DDL (Data Definition Language).
+
+But none of it is "Language", it is rather an API (as there is no syntax).
+
+# Declared `data_model`
+
+All `data_envelope`-s could be scanned to infer `data_model` for get or set operations.
+
+However, the approach is to declare `data_model` so that `data_envelope`-s could be validated against.
+
+# Condition
+
+REST API (and `data_model`) would be trivial, if it was not needed to be convenient for CLI.
+But it does have to be convenient for CLI, so API has to be well thought.
+
+How the convenience requirement is resolved explained in the next sections.
+
+# CLI-friendly `data_model`
+
+A special metadata `data_envelope` will have to provide (describe) other `data_envelope`-s loaded so far:
+*   `collection_name`
+*   `envelope_class`
+Its payload will have to be `index_props` of that `collection_name`.
 
 # Validation
 
@@ -24,12 +49,14 @@ will be validated against that.
 If `collection_name` is often (and can likely be always) matches `class_name` of all `data_envelope`-s,
 why do we need to have `class_name`?
 
-| category   | `class_name`                  | `collection_name`                |
-|------------|-------------------------------|----------------------------------|
-| defines    | schema for `envelope_payload` | `data_model` with `index_prop`-s |
-| concept of | `argrelay` framework          | `mongodb` data backend           |
+| category   | `class_name`                  | `collection_name`                                    |
+|------------|-------------------------------|------------------------------------------------------|
+| defines    | schema for `envelope_payload` | `data_model` with `index_prop`-s for `data_envelope` |
+| concept of | `argrelay` framework          | `mongodb` data backend                               |
 
 It just happens that when we want to search within `collection_name`, we normally expect the same `class_name`.
+
+TODO: TODO_98_35_14_72: exclude `class_name` from `search_control`
 
 But it is possible to store within same `collection_name` and search with the same `index_prop`-s
 different `class_name`-s (with different `envelope_payload` schema).

--- a/docs/feature_stories/FS_74_69_61_79.get_set_data_envelope.md
+++ b/docs/feature_stories/FS_74_69_61_79.get_set_data_envelope.md
@@ -7,7 +7,7 @@ feature_status: PARTIAL
 TODO: Maybe rename "get set data envelope" to "get set envelope_container"?
       Actually, it is all about selecting a snapshot of `data_envelope`-s - maybe "get set snapshot"?
 
-TODO: Split metadata details into FS_45_08_22_15 data model manipulation.
+# Intro
 
 Currently, the data is populated by plugins running inside the server process during start-up.
 
@@ -20,22 +20,12 @@ There should be a way to update data out of the server process, to get/set envel
 The data should be manipulated via `envelope_container`-s which specifies search criteria to
 get or set all `data_envelope`-s matching the criteria - this is the only way to avoid exposing internal ids.
 
-The search criteria acts as "snapshot address" and data is always replaced entirely for the selected snapshot.
+The search criteria acts as "snapshot address".
+All `data_envelope`-s in the selected snapshot are always replaced entirely.
 
-# General idea
+# Data model
 
-REST API is trivial, if it does not need to be convenient for CLI, but it does have to be convenient for CLI.
-
-How the convenience requirement is resolved explained in the next sections.
-
-# Internal metadata for CLI
-
-All `data_envelope`-s can be scanned to create a `data_envelope`-s with metadata for get or set operations.
-
-Metadata `data_envelope` will have to provide (describe) each `envelope_class` loaded so far:
-*   `collection_name`
-*   `envelope_class`
-Its payload will have to be `index_props` of that `envelope_class`.
+See FS_45_08_22_15 data model manipulation.
 
 # CLI `search_control`
 

--- a/docs/task_refs/TODO_98_35_14_72.exclude_class_name_from_search_control.md
+++ b/docs/task_refs/TODO_98_35_14_72.exclude_class_name_from_search_control.md
@@ -1,0 +1,6 @@
+
+TODO: TODO_98_35_14_72: exclude `class_name` from `search_control`
+
+Based on FS_45_08_22_15 data model manipulation, `search_control` specifies what to search in collection.
+And `class_name` is often included, but it is not necessarily needed.
+There should be a way to search collections with multiple `class_name`-s in it without specifying which one. 

--- a/src/argrelay/_version.py
+++ b/src/argrelay/_version.py
@@ -1,4 +1,4 @@
 # See `docs/dev_notes/version_format.md`:
 # Implements this:
 # https://stackoverflow.com/a/7071358/441652
-__version__ = "0.7.20"
+__version__ = "0.7.21"

--- a/src/argrelay/custom_integ/GitRepoEntryConfigSchema.py
+++ b/src/argrelay/custom_integ/GitRepoEntryConfigSchema.py
@@ -7,12 +7,12 @@ from argrelay.misc_helper_common.TypeDesc import TypeDesc
 
 repo_rel_path_ = "repo_rel_path"
 is_repo_enabled_ = "is_repo_enabled"
+# TODO: Add `load_repo_repos_` as well:
 load_repo_tags_ = "load_repo_tags"
 load_repo_commits_ = "load_repo_commits"
 load_tags_last_days_ = "load_tags_last_days"
 load_commits_max_count_ = "load_commits_max_count"
 envelope_properties_ = "envelope_properties"
-
 
 class GitRepoEntryConfigSchema(Schema):
     class Meta:

--- a/src/argrelay/custom_integ/GitRepoLoader.py
+++ b/src/argrelay/custom_integ/GitRepoLoader.py
@@ -22,6 +22,9 @@ from argrelay.custom_integ.GitRepoLoaderConfigSchema import (
     load_git_commits_default_,
     repo_entries_,
     load_git_tags_default_,
+    class_name_repo_,
+    class_name_tag_,
+    class_name_commit_,
 )
 from argrelay.custom_integ.GitRepoPropName import GitRepoPropName
 from argrelay.custom_integ.git_utils import is_git_repo
@@ -74,24 +77,62 @@ class GitRepoLoader(AbstractLoader):
         self,
     ) -> list[DataModel]:
 
+        class_name_repo = self.plugin_config_dict[class_name_repo_]
+        class_name_tag = self.plugin_config_dict[class_name_tag_]
+        class_name_commit = self.plugin_config_dict[class_name_commit_]
+
         return [
             DataModel(
-                collection_name = GitRepoEnvelopeClass.ClassGitRepo.name,
-                class_name = GitRepoEnvelopeClass.ClassGitRepo.name,
-                # TODO: TODO_89_50_17_63: fine-tune list of `index_props`:
-                index_props = [e.name for e in GitRepoPropName],
+                collection_name = class_name_repo,
+                class_name = class_name_repo,
+                index_props = [
+                    GitRepoPropName.git_repo_alias.name,
+                    GitRepoPropName.git_repo_root_abs_path.name,
+                    GitRepoPropName.git_repo_root_rel_path.name,
+                    GitRepoPropName.git_repo_root_base_name.name,
+                    GitRepoPropName.git_repo_content_type.name,
+                    GitRepoPropName.git_repo_object_category.name,
+                ],
             ),
             DataModel(
-                collection_name = GitRepoEnvelopeClass.ClassGitTag.name,
-                class_name = GitRepoEnvelopeClass.ClassGitTag.name,
-                # TODO: TODO_89_50_17_63: fine-tune list of `index_props`:
-                index_props = [e.name for e in GitRepoPropName],
+                collection_name = class_name_tag,
+                class_name = class_name_tag,
+                index_props = [
+                    GitRepoPropName.git_repo_alias.name,
+                    GitRepoPropName.git_repo_root_abs_path.name,
+                    GitRepoPropName.git_repo_root_rel_path.name,
+                    GitRepoPropName.git_repo_root_base_name.name,
+                    GitRepoPropName.git_repo_content_type.name,
+                    GitRepoPropName.git_repo_tag_name.name,
+                    GitRepoPropName.git_repo_commit_id.name,
+                    GitRepoPropName.git_repo_short_commit_id.name,
+                    GitRepoPropName.git_repo_commit_message.name,
+                    GitRepoPropName.git_repo_commit_author_name.name,
+                    GitRepoPropName.git_repo_commit_author_email.name,
+                    GitRepoPropName.git_repo_commit_date.name,
+                    GitRepoPropName.git_repo_commit_time.name,
+                    GitRepoPropName.git_repo_object_category.name,
+                ],
             ),
             DataModel(
-                collection_name = GitRepoEnvelopeClass.ClassGitCommit.name,
-                class_name = GitRepoEnvelopeClass.ClassGitCommit.name,
-                # TODO: TODO_89_50_17_63: fine-tune list of `index_props`:
-                index_props = [e.name for e in GitRepoPropName],
+                collection_name = class_name_commit,
+                class_name = class_name_commit,
+                index_props = [
+                    GitRepoPropName.git_repo_alias.name,
+                    GitRepoPropName.git_repo_root_abs_path.name,
+                    GitRepoPropName.git_repo_root_rel_path.name,
+                    GitRepoPropName.git_repo_root_base_name.name,
+                    GitRepoPropName.git_repo_content_type.name,
+                    GitRepoPropName.git_repo_tag_name.name,
+                    GitRepoPropName.git_repo_commit_id.name,
+                    GitRepoPropName.git_repo_short_commit_id.name,
+                    GitRepoPropName.git_repo_commit_message.name,
+                    GitRepoPropName.git_repo_commit_author_name.name,
+                    GitRepoPropName.git_repo_commit_author_email.name,
+                    GitRepoPropName.git_repo_commit_date.name,
+                    GitRepoPropName.git_repo_commit_time.name,
+                    GitRepoPropName.git_repo_object_category.name,
+                ],
             ),
         ]
 
@@ -116,12 +157,16 @@ class GitRepoLoader(AbstractLoader):
         Scan `base_path` recursively and load metadata about all Git repos found.
         """
 
+        class_name_repo = self.plugin_config_dict[class_name_repo_]
+        class_name_tag = self.plugin_config_dict[class_name_tag_]
+        class_name_commit = self.plugin_config_dict[class_name_commit_]
+
         class_to_collection_map: dict = self.server_config.class_to_collection_map
 
         class_names = [
-            GitRepoEnvelopeClass.ClassGitRepo.name,
-            GitRepoEnvelopeClass.ClassGitTag.name,
-            GitRepoEnvelopeClass.ClassGitCommit.name,
+            class_name_repo,
+            class_name_tag,
+            class_name_commit,
         ]
 
         init_envelop_collections(
@@ -133,13 +178,13 @@ class GitRepoLoader(AbstractLoader):
         )
 
         repo_envelopes = static_data.envelope_collections[
-            class_to_collection_map[GitRepoEnvelopeClass.ClassGitRepo.name]
+            class_to_collection_map[class_name_repo]
         ].data_envelopes
         tag_envelopes = static_data.envelope_collections[
-            class_to_collection_map[GitRepoEnvelopeClass.ClassGitTag.name]
+            class_to_collection_map[class_name_tag]
         ].data_envelopes
         commit_envelopes = static_data.envelope_collections[
-            class_to_collection_map[GitRepoEnvelopeClass.ClassGitCommit.name]
+            class_to_collection_map[class_name_commit]
         ].data_envelopes
 
         load_git_commits_default = self.plugin_config_dict[load_git_commits_default_]
@@ -192,11 +237,11 @@ class GitRepoLoader(AbstractLoader):
                 repo_envelope: dict = copy.deepcopy(repo_entry[envelope_properties_])
 
                 repo_envelope.update({
-                    envelope_id_: f"{repo_root_abs_path}:{GitRepoEnvelopeClass.ClassGitRepo.name}",
+                    envelope_id_: f"{repo_root_abs_path}:{class_name_repo}",
                     envelope_payload_: {
                         repo_root_abs_path_: repo_root_abs_path,
                     },
-                    ReservedPropName.envelope_class.name: GitRepoEnvelopeClass.ClassGitRepo.name,
+                    ReservedPropName.envelope_class.name: class_name_repo,
                     GitRepoPropName.git_repo_root_rel_path.name: repo_root_rel_path,
                     GitRepoPropName.git_repo_root_abs_path.name: repo_root_abs_path,
                     GitRepoPropName.git_repo_root_base_name.name: repo_root_base_name,
@@ -232,10 +277,10 @@ class GitRepoLoader(AbstractLoader):
                         tag_envelope: dict = copy.deepcopy(repo_entry[envelope_properties_])
 
                         tag_envelope.update({
-                            envelope_id_: f"{repo_root_abs_path}:{GitRepoEnvelopeClass.ClassGitTag.name}:{git_tag.name}",
+                            envelope_id_: f"{repo_root_abs_path}:{class_name_tag}:{git_tag.name}",
                             envelope_payload_: {
                             },
-                            ReservedPropName.envelope_class.name: GitRepoEnvelopeClass.ClassGitTag.name,
+                            ReservedPropName.envelope_class.name: class_name_tag,
                             GitRepoPropName.git_repo_root_rel_path.name: repo_root_rel_path,
                             GitRepoPropName.git_repo_root_abs_path.name: repo_root_abs_path,
                             GitRepoPropName.git_repo_root_base_name.name: repo_root_base_name,
@@ -276,10 +321,10 @@ class GitRepoLoader(AbstractLoader):
                         commit_envelope: dict = copy.deepcopy(repo_entry[envelope_properties_])
 
                         commit_envelope.update({
-                            envelope_id_: f"{repo_root_abs_path}:{GitRepoEnvelopeClass.ClassGitCommit.name}:{git_commit.hexsha}",
+                            envelope_id_: f"{repo_root_abs_path}:{class_name_commit}:{git_commit.hexsha}",
                             envelope_payload_: {
                             },
-                            ReservedPropName.envelope_class.name: GitRepoEnvelopeClass.ClassGitCommit.name,
+                            ReservedPropName.envelope_class.name: class_name_commit,
                             GitRepoPropName.git_repo_root_rel_path.name: repo_root_rel_path,
                             GitRepoPropName.git_repo_root_abs_path.name: repo_root_abs_path,
                             GitRepoPropName.git_repo_root_base_name.name: repo_root_base_name,
@@ -333,7 +378,7 @@ class GitRepoLoader(AbstractLoader):
         data_envelope: dict,
     ) -> list[str]:
         object_class = data_envelope[ReservedPropName.envelope_class.name]
-        if object_class == GitRepoEnvelopeClass.ClassGitTag.name:
+        if object_class == self.plugin_config_dict[class_name_tag_]:
             return self.categorize_git_tag(data_envelope)
         return []
 

--- a/src/argrelay/custom_integ/GitRepoLoaderConfigSchema.py
+++ b/src/argrelay/custom_integ/GitRepoLoaderConfigSchema.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 from marshmallow import Schema, RAISE, fields
 
 from argrelay.custom_integ.GitRepoEntryConfigSchema import git_repo_entry_config_desc
+from argrelay.custom_integ.GitRepoEnvelopeClass import GitRepoEnvelopeClass
 from argrelay.misc_helper_common.TypeDesc import TypeDesc
 
+class_name_repo_ = "class_name_repo"
+class_name_tag_ = "class_name_tag"
+class_name_commit_ = "class_name_commit"
+
+# TODO: Add `load_git_repos_default` as well:
 load_git_tags_default_ = "load_git_tags_default"
 load_git_commits_default_ = "load_git_commits_default"
 repo_entries_ = "repo_entries"
@@ -14,6 +20,21 @@ class GitRepoLoaderConfigSchema(Schema):
     class Meta:
         unknown = RAISE
         strict = True
+
+    class_name_repo = fields.String(
+        required = False,
+        load_default = GitRepoEnvelopeClass.ClassGitRepo.name,
+    )
+
+    class_name_tag = fields.String(
+        required = False,
+        load_default = GitRepoEnvelopeClass.ClassGitTag.name,
+    )
+
+    class_name_commit = fields.String(
+        required = False,
+        load_default = GitRepoEnvelopeClass.ClassGitCommit.name,
+    )
 
     load_git_tags_default = fields.Boolean(
         required = False,
@@ -43,6 +64,9 @@ git_repo_loader_config_desc = TypeDesc(
     dict_schema = GitRepoLoaderConfigSchema(),
     ref_name = GitRepoLoaderConfigSchema.__name__,
     dict_example = {
+        class_name_repo_: GitRepoEnvelopeClass.ClassGitRepo.name,
+        class_name_tag_: GitRepoEnvelopeClass.ClassGitTag.name,
+        class_name_commit_: GitRepoEnvelopeClass.ClassGitCommit.name,
         load_git_tags_default_: False,
         load_git_commits_default_: False,
         repo_entries_: {

--- a/src/argrelay/mongo_data/ProgressTracker.py
+++ b/src/argrelay/mongo_data/ProgressTracker.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from typing import Collection
+
+from argrelay.misc_helper_common import eprint
+from argrelay.schema_config_interp.SearchControlSchema import envelope_class_
 
 
 @dataclass
@@ -8,29 +14,235 @@ class ProgressTracker:
     """
     envelope_per_col_i: int = field(default = 0)
     envelope_per_col_n: int = field(default = 0)
+    base_total_envelope_i: int = field(default = 0)
     total_envelope_i: int = field(default = 0)
     total_envelope_n: int = field(default = 0)
 
-    def assert_intermediate_progress(
+    # Number of envelopes loaded per `collection_name`:
+    collection_sizes: dict[str, int] = field(default_factory = dict)
+
+    # TODO: Provide a way to exclude some collection_name and envelope_classes from
+    #       requirement of being part of `search_control`.
+    #       For example, `ReservedEnvelopeClass.ClassHelp` is used internally (may not be used by `search_control`).
+    unused_index_props_per_class_per_collection: dict[str, dict[str, set[str]]] = field(default_factory = lambda: {})
+
+    dangling_search_props_per_class_per_collection: dict[str, dict[str, set[str]]] = field(default_factory = lambda: {})
+
+    def track_unused_index_props_per_collection_unused_by_search_control(
+        self,
+        collection_name: str,
+        # TODO: TODO_98_35_14_72: exclude `class_name` from `search_control`:
+        class_name: str,
+        index_props: Collection[str],
+    ):
+        """
+        TODO: deduplicate with `track_dangling_search_props_per_collection_undefined_by_data_model`
+        """
+        assert len(index_props) > 0
+        if len(index_props) == 1:
+            if envelope_class_ in index_props:
+                # Do not report `envelope_class` `search_prop` as unused because it is currently implicitly
+                # added to be search even if `search_control` does not list that.
+                # TODO: TODO_98_35_14_72: exclude `class_name` from `search_control`:
+                #       Eventually (when `class_name` is removed from `search_control` data structure as bespoke field),
+                #       it has to be explicitly listed in `search_control`
+                #       to avoid finding object of different `envelope_class`.
+                return
+
+        self.unused_index_props_per_class_per_collection.setdefault(
+            collection_name,
+            {},
+        ).setdefault(
+            class_name,
+            set(),
+        ).update(index_props)
+
+        prop_names = " ".join(index_props)
+        eprint(
+            f"`data_model` components not used by any `search_control`: "
+            f"`collection_name` [{collection_name}] "
+            # TODO: TODO_98_35_14_72: exclude `class_name` from `search_control`:
+            f"`class_name` [{class_name}] "
+            f"`index_props`: {prop_names} "
+        )
+
+    def track_dangling_search_props_per_collection_undefined_by_data_model(
+        self,
+        collection_name: str,
+        # TODO: TODO_98_35_14_72: exclude `class_name` from `search_control`:
+        class_name: str,
+        search_props: Collection[str],
+    ):
+        """
+        TODO: deduplicate with `track_unused_index_props_per_collection_unused_by_search_control`
+        """
+        assert len(search_props) > 0
+        self.dangling_search_props_per_class_per_collection.setdefault(
+            collection_name,
+            {},
+        ).setdefault(
+            class_name,
+            set(),
+        ).update(search_props)
+
+        prop_names = " ".join(search_props)
+        error_message = (
+            f"`collection_name` [{collection_name}] "
+            # TODO: TODO_98_35_14_72: exclude `class_name` from `search_control`:
+            f"`class_name` [{class_name}] "
+            f"`search_props`: {prop_names} "
+        )
+        if self.collection_sizes.get(collection_name, 0) == 0:
+            eprint(
+                f"`search_control` components not in `data_model` (but ignoring as collection is empty now): " +
+                error_message
+            )
+        else:
+            raise ValueError(
+                f"`search_control` components not in `data_model`: " +
+                error_message
+            )
+
+    def report_collection_sizes(
+        self,
+    ):
+        for collection_name, collection_size in self.collection_sizes.items():
+            if collection_size != 0:
+                eprint(f"`collection_name` [{collection_name}] size: {collection_size}")
+        for collection_name, collection_size in self.collection_sizes.items():
+            if collection_size == 0:
+                eprint(f"`data_model` declares `collection_name` [{collection_name}] but it is empty")
+
+    def _assert_intermediate_progress(
         self,
     ):
         assert self.envelope_per_col_i <= self.envelope_per_col_n
         assert self.envelope_per_col_n <= self.total_envelope_n
         assert self.total_envelope_i <= self.total_envelope_n
 
-    def assert_collection_final_progress(
+    def _assert_collection_final_progress(
         self,
     ):
-        self.assert_intermediate_progress()
+        self._assert_intermediate_progress()
         assert self.envelope_per_col_i == self.envelope_per_col_n
 
-    def assert_total_final_progress(
+    def _assert_total_final_progress(
         self,
     ):
-        self.assert_collection_final_progress()
+        self._assert_collection_final_progress()
         if self.total_envelope_i != self.total_envelope_n:
             raise AssertionError(
                 f"`total_envelope_i` [{self.total_envelope_i}] == "
                 f"`total_envelope_n` [{self.total_envelope_n}] "
                 f"(not true)"
+            )
+
+    def track_collection_size_increment(
+        self,
+        collection_name: str,
+        increment_size: int,
+    ):
+        """
+        Track collection size increment by each store step (after each loader plugin).
+
+        NOTE: It is assumed each loader appends only (does not override existing `data_envelope`-s).
+        """
+        curr_size = self.collection_sizes.setdefault(collection_name, 0)
+        self.collection_sizes[collection_name] = curr_size + increment_size
+
+    def track_collection_indexing_start(
+        self,
+        collection_name: str,
+        increment_size: int,
+    ):
+        self.base_total_envelope_i: int = self.total_envelope_i
+        self.envelope_per_col_i = 0
+        self.envelope_per_col_n = increment_size
+        self.log_collection_indexing_progress(collection_name)
+
+        assert increment_size <= self.collection_sizes[collection_name]
+
+    def track_collection_indexing_stop(
+        self,
+        collection_name: str,
+    ):
+        assert self.envelope_per_col_i == self.total_envelope_i - self.base_total_envelope_i
+        self.log_collection_indexing_progress(collection_name)
+
+    def track_collection_indexing_increment(
+        self,
+        collection_name: str,
+    ):
+        if self.total_envelope_i > 0 and self.total_envelope_i % 1_000 == 0:
+            self.log_collection_indexing_progress(collection_name)
+        self.total_envelope_i += 1
+        self.envelope_per_col_i += 1
+
+    def log_collection_indexing_progress(
+        self,
+        collection_name: str,
+    ):
+        try:
+            self._assert_intermediate_progress()
+        finally:
+            eprint(
+                f"collection: {collection_name}: indexed envelopes: "
+                f"{self.envelope_per_col_i}/{self.envelope_per_col_n} "
+                f"{self.total_envelope_i}/{self.total_envelope_n} "
+                "..."
+            )
+
+    def track_total_validation_start(
+        self,
+    ):
+        self.total_envelope_i = 0
+
+    def track_total_validation_stop(
+        self,
+    ):
+        self._assert_total_final_progress()
+        self.report_collection_sizes()
+
+    def track_collection_validation_start(
+        self,
+        collection_name: str,
+    ):
+        eprint(f"collection to validate: {collection_name}")
+        self.envelope_per_col_n = self.collection_sizes.get(collection_name, 0)
+        self.envelope_per_col_i = 0
+        self.log_collection_validation_progress(collection_name)
+
+    def track_collection_validation_stop(
+        self,
+        collection_name: str,
+    ):
+        self.log_collection_validation_progress(
+            collection_name,
+        )
+        self._assert_collection_final_progress()
+
+    def track_collection_validation_increment(
+        self,
+        collection_name: str,
+    ):
+        self.envelope_per_col_i += 1
+        self.total_envelope_i += 1
+
+        if self.total_envelope_i > 0 and self.total_envelope_i % 1_000 == 0:
+            self.log_collection_validation_progress(
+                collection_name,
+            )
+
+    def log_collection_validation_progress(
+        self,
+        mongo_collection: str,
+    ):
+        try:
+            self._assert_intermediate_progress()
+        finally:
+            eprint(
+                f"collection: {mongo_collection}: validated envelopes: "
+                f"{self.envelope_per_col_i}/{self.envelope_per_col_n} "
+                f"{self.total_envelope_i}/{self.total_envelope_n} "
+                f"..."
             )

--- a/src/argrelay/plugin_delegator/DataBackendDelegator.py
+++ b/src/argrelay/plugin_delegator/DataBackendDelegator.py
@@ -35,7 +35,7 @@ collection_name_container_ipos_ = 1
 data_envelope_container_ipos_ = 2
 
 
-class MetadataDelegator(AbstractDelegator):
+class DataBackendDelegator(AbstractDelegator):
     """
     Implements FS_74_69_61_79 get set data envelope.
     """

--- a/src/argrelay/runtime_context/SearchControl.py
+++ b/src/argrelay/runtime_context/SearchControl.py
@@ -15,6 +15,7 @@ class SearchControl:
     MongoDB collection to search `data_envelope`-s in.
     """
 
+    # TODO: TODO_98_35_14_72: exclude `class_name` from `search_control`
     envelope_class: str = field(default_factory = lambda: None)
     """
     Specifies `ReservedPropName.envelope_class` to search.

--- a/src/argrelay/runtime_data/DataModel.py
+++ b/src/argrelay/runtime_data/DataModel.py
@@ -15,6 +15,7 @@ class DataModel:
     collection_name: str
 
     # TODO: Maybe rename to `envelope_class` everywhere for consistency?
+    # TODO: TODO_98_35_14_72: exclude `class_name` from `search_control`:
     class_name: str
     """
     See also synonym `ReservedPropName.envelope_class`.

--- a/src/argrelay/sample_conf/argrelay_plugin.yaml
+++ b/src/argrelay/sample_conf/argrelay_plugin.yaml
@@ -17,7 +17,7 @@ plugin_instance_entries:
             -   InterceptDelegator.default
             -   HelpDelegator.default
             -   QueryEnumDelegator.default
-            -   MetadataDelegator.default
+            -   DataBackendDelegator.default
             -   ServiceDelegator.default
             -   GitRepoDelegator.default
             -   ConfigOnlyDelegator.default
@@ -163,9 +163,9 @@ plugin_instance_entries:
         plugin_config:
             single_func_id: func_id_query_enum_items
 
-    MetadataDelegator.default:
-        plugin_module_name: argrelay.plugin_delegator.MetadataDelegator
-        plugin_class_name: MetadataDelegator
+    DataBackendDelegator.default:
+        plugin_module_name: argrelay.plugin_delegator.DataBackendDelegator
+        plugin_class_name: DataBackendDelegator
 
     ServiceDelegator.default:
         plugin_module_name: argrelay.custom_integ.ServiceDelegator


### PR DESCRIPTION
*   Validate both ways: `search_props` <-> `index_props`.
*   Relax validation where possible (report stats instead).
*   Configure generic `GitRepoLoader` with `class_name`-s it is supposed to load.
*   Fine-tune search_props for `Git*` `data_envelope`-s.
*   Rename `MetadataDelegator` to `DataBackendDelegator`.
*   Move logging and tracking calls under `ProgressTracker`.
*   Report `report_collection_sizes`.
*   Spec `TODO_98_35_14_72.exclude_class_name_from_search_control.md`.
