### PR TITLE
Minor: bootstrap fixes, doc updates, named args experiments

### DIFF
--- a/docs/feature_stories/FS_20_88_05_60.named_args.md
+++ b/docs/feature_stories/FS_20_88_05_60.named_args.md
@@ -14,3 +14,11 @@ So far, named args were not necessary feature in most of the cases because value
 can contain unique values and do not intersect.
 For example, for all IP addresses, values can be prefixed with `ip.` and specifying `ip.` on the command line
 will only suggest options from that specific value set (as if prefix `ip_address:` was specified).
+
+TODO: Explain that keys should be prefixed with `-`.
+
+TODO: TODO_66_66_75_78: Split `arg` to `prop` concepts.
+      Also, review names for the args concepts - possibly rename them for clarity.
+      For example, positional args do not really exists
+      (or exists only for interp tree to select special functions)
+      and should rather be named value-only args (whose arg name is guessed by the logic).

--- a/docs/task_refs/TODO_51_29_08_00.combine_interp_factory_with_interp.md
+++ b/docs/task_refs/TODO_51_29_08_00.combine_interp_factory_with_interp.md
@@ -1,2 +1,0 @@
-
-TODO: TODO_51_29_08_00: Move all Interp* and InterpFactory* classes into the same module.

--- a/docs/task_refs/TODO_66_66_75_78.split_arg_and_prop_concepts.md
+++ b/docs/task_refs/TODO_66_66_75_78.split_arg_and_prop_concepts.md
@@ -5,7 +5,16 @@ TODO: TODO_66_66_75_78: Split `arg` to `prop` concepts:
 
 We map `arg` from command line to `prop` for search.
 
-Split "arg" group of concepts (`arg_value`, `arg_type`) and "prop" group of concepts (`prop_value`, `prop_type`):
+Split:
+*   "arg" group of concepts (`arg_value`, `arg_type`)
+*   "prop" group of concepts (`prop_value`, `prop_name`)
+
+Note: there seems to be no way to tell `arg_type` until `arg_value` is matched as a value for some `prop_name`.
+
+In fact, all `command_line`-level concept (like `key`, `arg_bucket`, etc.) have to be clearly distinguished
+from data backend concepts (like `collection_name` and `prop`-s) even though they are closely related via mapping.
+
+Issue:
 *   `command_line` args are mapped to `data_envelope` props and almost identical
 *   BUT: they are not naturally/intuitively inter-change-able as `data_envelope` properties are hardly `command_line` arguments.
 *   Maybe write doc on bounded contexts? Add dictionaries (ubiquitous language) per bash, client, server, data backend?

--- a/exe/bootstrap_env.bash
+++ b/exe/bootstrap_env.bash
@@ -398,6 +398,7 @@ install_project_EOF
     "${ret_command}" 1
 fi
 
+# NOTE: Running this script is supposed to install `argrelay` package - otherwise, subsequent steps will fail:
 source "${argrelay_dir}/exe/install_project.bash"
 
 # Get path of `argrelay` module:
@@ -428,16 +429,22 @@ check_env_src="${argrelay_module_dir_path}/custom_integ_res/check_env.bash"
 check_env_dst="${argrelay_dir}/exe/check_env.bash"
 if [[ ! -L "${check_env_dst}" ]]
 then
-    if [[ -f "${check_env_dst}" ]]
+    if [[ -e "${check_env_dst}" ]]
     then
-        cp -p "${check_env_src}" "${check_env_dst}"
+        if [[ -f "${check_env_dst}" ]]
+        then
+            cp -p "${check_env_src}" "${check_env_dst}"
+        else
+            echo "ERROR: This target path is neither a symlink nor a file - review and remove manually: ${check_env_dst}" 1>&2
+            exit 1
+        fi
     else
-        echo "ERROR: This target path is not a file - review and remove manually: ${check_env_dst}" 1>&2
-        exit 1
+        cp -p "${check_env_src}" "${check_env_dst}"
     fi
 else
     if [[ "$( readlink "${check_env_dst}" )" == "${check_env_src}" ]]
     then
+        # Replace symlink with direct file:
         rm "${check_env_dst}"
         cp -p "${check_env_src}" "${check_env_dst}"
     else

--- a/readme.md
+++ b/readme.md
@@ -10,30 +10,73 @@ See: docs/dev_notes/screencast_notes.md
 -->
 
 <a name="argrelay-about"></a>
-# What's this?
+# About [`argrelay`][argrelay_org]
+
+### What is this?
 
 A framework to "ergonomically" select **custom data** input for command line interface (CLI) tools.
 
-The aim is to augment two-way &#10231; interaction by **prepared** reference data:
-*   &#10230; Human inputs args that (s)he **remembers** (via `Tab`-auto-completion) in **relaxed order**.
-*   &#10229; Machine provides feedback (via `Alt+Shift+Q` query) on current state:
-    *   What args it already **matched** with server data according to **command schema**.
-    *   What **else** it needs to fill remaining command args.
+It integrates (1) standard shell, (2) local commands, (3) server data, ... to make CLI input **intuitive**.
 
-This broadens applicability of CLI input as a slim alternative to graphical user interface (GUI)
-competing in **convenience** for apps especially for developers = "doing more with less".
+*   Although its initial purpose was command **auto-completion**, that become a trivial byproduct of...
+*   Its primary "rich" feature = keyword-based **structured data search**.
 
-*   When your data is instantly and directly queryable, try [`argcomplete`][argcomplete_github].
-*   When your data is sizeable, users need perf (indexing), relaxed syntax, keyword search, try [`argrelay`][argrelay_org].
+### How does it work?
+
+It relies on the same shell API as auto-completion for (e.g.) `git` command,<br/>
+except that requests go to the server **plugin** to run logic against some **indexed** data.
+
+A typical scenario:
+
+*   Human types in some **remembered** args (via `Tab`-auto-completion) in **relaxed syntax and order**.
+*   Machine provides feedback (via `Alt+Shift+Q`-query) on the progress of input interrogation:
+    *   What args machine **already matched** with the data according to **command schema**.
+    *   What **else** machine needs from human to **disambiguate** and select the remaining command args.
+
+### Why is it needed?
+
+CLI is indispensable for:
+*   **ubiquitous automation** (any command is effectively replay-able code)
+*   **quick implementation** (get it done "in the afternoon" instead of next month after fullstack API discussions)
+*   **manual intervention** (when everything else is already failed and unavailable)
+
+And `argrelay` broaden applicability of CLI by **convenience**:
+*   enables **inline search directly in shell** (without copy-and-pasting args from other apps)
+*   reduces cognitive load for rapidly evolving add-hoc tools by **eliminating syntax and options memorization**
+*   unifies CLI (look and feel, validation, help) for multiple commands via generic data-driven framework
+
+<!--
+
+# Features
+
+For sizeable and inter-dependent data, need for perf, relaxed syntax, keyword search, try [`argrelay`][argrelay_org].
+
+*   Command execution is still trivially local to shell.
+
+    The client only fetches more data from the server based on command line args before passing control to user code.
+
+*   All security (auth and authz) to execute command must also be resolved by local process (just like for any script).
+
+*   Precise structured search.
+
+    It may appear fuzzy due to relaxed args order - but any ambiguity is resolved via simple rules of priority.
+
+*   Support for any number of custom command names.
+
+*   Support for any number of custom functions (registered).
+
+    Functions are bound to any command name and args combination.
+
+-->
 
 <a name="argrelay-focus"></a>
-# `argrelay` focus
+# Project focus
 
 > Data-assisted CLI with search and completion
 
 GUI-s are targeted secondarily as they not have the restrictions vs the benefits CLI-s have:
 *   To leverage minimal syntax queries, API requests can be handled from anything (including GUI).
-*   But API-s are purposefully feature-tailored to support (both challenging and rewarding) CLI.
+*   But API-s are purposefully feature-tailored to support (both challenging and rewarding) CLI peculiarities.
 
 <details>
 <summary>show example</summary>
@@ -43,15 +86,17 @@ For example, in GUI-s, typing a query into a search bar may easily be accompanie
 (3) full-text-search results<br/>
 (4) populated async-ly with typing...<br/>
 
-In CLI-s, `grep` does (3) full-text-search, but slow and completely misses the rest (1), (2), (4).
+In CLI-s, `grep` does (3) full-text-search, but it is slow and completely misses the rest (1), (2), (4).
 
-Simple full-text-search is imprecise - facilitating selection in CLI requires:<br/>
-a catalogue-like navigation via structured search with auto-completion.
+Also, simple full-text-search is imprecise - facilitating selection in CLI requires:<br/>
+a catalogue-like navigation selecting keywords via structured data search with auto-completion.
 </details>
 
 <!-- TODO: update the doc first before publishing its link
 Learn more about [how search works][how_search_works.md].
 -->
+
+<!--
 
 <a name="argrelay-overview"></a>
 # Interaction overview
@@ -73,6 +118,8 @@ Wrapping any command by `argrelay`:
 *   reduces cognitive load with minimalistic enum-based query syntax (matching target executable command line)
 *   maintains small client-side footprint (suitable for resource-constrained terminals)
 *   exposes conveniently browsable data inventory (generic CLI builder)
+
+-->
 
 <a name="argrelay-general-dilemma"></a>
 # General dilemma
@@ -96,13 +143,15 @@ Wrapping any command by `argrelay`:
 | :heavy_plus_sign: point-click actions                                         | :heavy_minus_sign: increased typing:exclamation:          |
 | :heavy_plus_sign: intuitive data-driven human interface                       | :heavy_minus_sign: human interface:question: API, in fact |
 
-While retaining advantages of a CLI tool, `argrelay` tries to provide those last :heavy_plus_sign:-s:
+While retaining advantages of a CLI tool,<br/>
+`argrelay` tries to provide a slim alternative to GUI for those last :heavy_plus_sign:-s:
 *   intuitive data-driven interface
 *   reduced typing (args auto-reduction)
 *   keyword options (args auto-completion)
 
-As opposed to GUI-demanding approaches like [Warp][Warp_site] or [IDEA terminal][IDEA_terminal],<br/>
-`argrelay` survives in basic text modes.
+As opposed to GUI-demanding approaches like [Warp][Warp_site] or [IDEA terminal][IDEA_terminal]<br/>
+(in desktop environment where any tool is available),<br/>
+`argrelay` survives in basic text modes (over telnet or SSH).
 
 Given that `argrelay` target audience are devs (using shell),<br/>
 the advantages of CLI tools over GUI can be summarized property-by-property:
@@ -156,7 +205,7 @@ with associated data around to invoke the program selected by the user:
 ```mermaid
 sequenceDiagram
     autonumber
-    participant P as Any program:<br/>user-required<br/>client-side-local
+    participant P as Any program:<br/>user-specific<br/>client-side-local
     actor U as <br/>User
     box transparent <br/>argrelay
     participant C as Client
@@ -213,38 +262,37 @@ This sub-shell configures request hotkeys to bind `lay` command with `@/exe/run_
     If executed (press `Enter`), it runs stub implementations
     (in real app it would do remote `ssh`-login for example).
 
-*   It is possible to:
+*   Browse and retrieve data (for specific query):
 
-    *   Browse and retrieve data used in search and auto-completion as well as execution (for specific query):
+    ```sh
+    lay get ConfigOnlyClass ERROR
+    ```
 
-        ```sh
-        lay get ConfigOnlyClass ERROR
-        ```
+    `stdout` (one JSON per line):
 
-        `stdout` (one JSON per line):
+    ```json
+    {"envelope_payload": {"text_message": "text message C"}, "exit_code": "1", "envelope_class": "ConfigOnlyClass", "severity_level": "ERROR"}
+    {"envelope_payload": {"text_message": "text message D"}, "exit_code": "2", "envelope_class": "ConfigOnlyClass", "severity_level": "ERROR"}
+    ```
 
-        ```
-        {"envelope_payload": {"text_message": "text message C"}, "exit_code": "1", "envelope_class": "ConfigOnlyClass", "severity_level": "ERROR"}
-        {"envelope_payload": {"text_message": "text message D"}, "exit_code": "2", "envelope_class": "ConfigOnlyClass", "severity_level": "ERROR"}
-        ```
+*   Replace this data (for specific query):
 
-    *   Replace this data (for specific query):
+    `stdin` (one JSON per line):
 
-        `stdin` (one JSON per line):
+    ```sh
+    echo '
+    {"envelope_payload": {"text_message": "text message C"}, "exit_code": "101", "envelope_class": "ConfigOnlyClass", "severity_level": "ERROR"}
+    {"envelope_payload": {"text_message": "text message D"}, "exit_code": "102", "envelope_class": "ConfigOnlyClass", "severity_level": "ERROR"}
+    ' |
+    lay set ConfigOnlyClass ERROR
+    ```
 
-        ```sh
-        echo '
-        {"envelope_payload": {"text_message": "text message C"}, "exit_code": "101", "envelope_class": "ConfigOnlyClass", "severity_level": "ERROR"}
-        {"envelope_payload": {"text_message": "text message D"}, "exit_code": "102", "envelope_class": "ConfigOnlyClass", "severity_level": "ERROR"}
-        ' |
-        lay set ConfigOnlyClass ERROR
-        ```
+    <!--
+    TODO: Remove NOTE below when all the docs and validations added.
+    -->
 
-        <!--
-        TODO: Remove NOTE below when all the docs and validations added.
-        -->
-
-        NOTE: Replacing data on the server is in alpha version.
+    NOTE: Replacing data on the server is in alpha version
+          (it misses validations allowing updates incompatible with schema).
 
 *   To clean up, exit the sub-shell:
 
@@ -354,7 +402,7 @@ sequenceDiagram
     autonumber
     actor U as <br/>User
     participant B as Bash
-    participant P as Any program:<br/>user-required<br/>client-side-local
+    participant P as Any program:<br/>user-specific<br/>client-side-local
     box transparent <br/>argrelay
     participant C as Client
     participant S as Server
@@ -393,7 +441,6 @@ Feel free to raise [issues][repo_issues] or [discussions][repo_discussions].
 
 <!-- refs ---------------------------------------------------------------------------------------------------------- -->
 
-[argcomplete_github]: https://github.com/kislyuk/argcomplete
 [argrelay_org]: https://argrelay.org/
 [Warp_site]: https://warp.dev/
 [IDEA_terminal]: https://www.jetbrains.com/help/idea/terminal-emulator.html

--- a/src/argrelay/check_env/PluginCheckEnvArgrelayUnversionedSymlinks.py
+++ b/src/argrelay/check_env/PluginCheckEnvArgrelayUnversionedSymlinks.py
@@ -55,7 +55,7 @@ class PluginCheckEnvArgrelayUnversionedSymlinks(PluginCheckEnvAbstract):
                         result_category = ResultCategory.VerificationWarning,
                         result_key = f"{self.field_name}[{len(results_per_file)}]",
                         result_value = full_path,
-                        result_message = "Running `@/exe/bootstrap_env.bash` may leave unversioned unignored symlinks - review to remove them manually.",
+                        result_message = "Running `@/exe/bootstrap_env.bash` may leave unversioned unignored symlinks - review and decide to remove or ignore them manually.",
                     ))
 
             if len(results_per_file) > 0:

--- a/src/argrelay/check_env/PluginCheckEnvServerResponseValueStartTime.py
+++ b/src/argrelay/check_env/PluginCheckEnvServerResponseValueStartTime.py
@@ -1,7 +1,5 @@
 import time
-from datetime import datetime
-
-from dateutil.tz import tz
+from datetime import datetime, timezone
 
 from argrelay.check_env.CheckEnvResult import CheckEnvResult
 from argrelay.check_env.PluginCheckEnvServerResponseValueAbstract import PluginCheckEnvServerResponseValueAbstract
@@ -37,17 +35,14 @@ class PluginCheckEnvServerResponseValueStartTime(PluginCheckEnvServerResponseVal
         )
         # Put formated time to the message:
         if check_env_result.result_category.VerificationSuccess:
-            from_zone = tz.tzutc()
-            into_zone = tz.tzlocal()
-            utc_time = datetime.utcfromtimestamp(int(field_value))
-            utc_time = utc_time.replace(tzinfo = from_zone)
+            utc_time = datetime.fromtimestamp(int(field_value), timezone.utc)
+            epoch_start = datetime.fromtimestamp(0, timezone.utc)
 
-            epoch_start = datetime.utcfromtimestamp(0)
-
-            abs_time_str = utc_time.astimezone(into_zone).isoformat()
+            # Local timezone:
+            abs_time_str = utc_time.astimezone(None).isoformat()
             rel_time_str = format_time_to_relative(
                 time.time() * 1000,
-                (utc_time.replace(tzinfo = None) - epoch_start).total_seconds() * 1000,
+                (utc_time - epoch_start).total_seconds() * 1000,
             )
 
             check_env_result.result_message = f"{abs_time_str} ~ {rel_time_str}"

--- a/src/argrelay/custom_integ/ConfigOnlyDelegator.py
+++ b/src/argrelay/custom_integ/ConfigOnlyDelegator.py
@@ -46,6 +46,7 @@ class ConfigOnlyDelegator(BaseConfigDelegator):
 
         # Keep this as it is supposed to be referenced in the `command_template`
         envelope_containers = invocation_input.envelope_containers
+        all_tokens = invocation_input.all_tokens
 
         # There is no way to check on client side if this function belongs to this plugin
         # (client has no access to config):

--- a/src/argrelay/custom_integ_res/bootstrap_env.bash
+++ b/src/argrelay/custom_integ_res/bootstrap_env.bash
@@ -398,6 +398,7 @@ install_project_EOF
     "${ret_command}" 1
 fi
 
+# NOTE: Running this script is supposed to install `argrelay` package - otherwise, subsequent steps will fail:
 source "${argrelay_dir}/exe/install_project.bash"
 
 # Get path of `argrelay` module:
@@ -428,16 +429,22 @@ check_env_src="${argrelay_module_dir_path}/custom_integ_res/check_env.bash"
 check_env_dst="${argrelay_dir}/exe/check_env.bash"
 if [[ ! -L "${check_env_dst}" ]]
 then
-    if [[ -f "${check_env_dst}" ]]
+    if [[ -e "${check_env_dst}" ]]
     then
-        cp -p "${check_env_src}" "${check_env_dst}"
+        if [[ -f "${check_env_dst}" ]]
+        then
+            cp -p "${check_env_src}" "${check_env_dst}"
+        else
+            echo "ERROR: This target path is neither a symlink nor a file - review and remove manually: ${check_env_dst}" 1>&2
+            exit 1
+        fi
     else
-        echo "ERROR: This target path is not a file - review and remove manually: ${check_env_dst}" 1>&2
-        exit 1
+        cp -p "${check_env_src}" "${check_env_dst}"
     fi
 else
     if [[ "$( readlink "${check_env_dst}" )" == "${check_env_src}" ]]
     then
+        # Replace symlink with direct file:
         rm "${check_env_dst}"
         cp -p "${check_env_src}" "${check_env_dst}"
     else

--- a/src/argrelay/enum_desc/SpecialChar.py
+++ b/src/argrelay/enum_desc/SpecialChar.py
@@ -16,7 +16,7 @@ class SpecialChar(Enum):
     See FS_97_64_39_94 arg buckets.
     """
 
-    KeyValueDelimiter = ":"
+    ArgNamePrefix = "-"
     """
     See FS_20_88_05_60 named args.
     """

--- a/src/argrelay/enum_desc/TokenType.py
+++ b/src/argrelay/enum_desc/TokenType.py
@@ -18,7 +18,7 @@ class TokenType(Enum):
     PosArg = auto()
 
     """
-    Keyword arg - must have special format (e.g. ending with `:`).
+    Keyword arg - must have special format (e.g. starting with `SpecialChar.ArgNamePrefix.value`).
     """
     KeyArg = auto()
 
@@ -30,11 +30,11 @@ class TokenType(Enum):
 
 def get_token_type(all_tokens: list[str], token_ipos: int) -> TokenType:
     # TODO: POC: FS_20_88_05_60: Either remove it or implement properly: just testing named args:
-    if all_tokens[token_ipos].endswith(SpecialChar.KeyValueDelimiter.value):
+    if all_tokens[token_ipos].startswith(SpecialChar.ArgNamePrefix.value):
         return TokenType.KeyArg
     else:
         if token_ipos > 0:
-            if not all_tokens[token_ipos - 1].endswith(SpecialChar.KeyValueDelimiter.value):
+            if not all_tokens[token_ipos - 1].startswith(SpecialChar.ArgNamePrefix.value):
                 return TokenType.PosArg
             else:
                 return TokenType.ValArg

--- a/src/argrelay/plugin_interp/FuncTreeInterpFactory.py
+++ b/src/argrelay/plugin_interp/FuncTreeInterpFactory.py
@@ -670,15 +670,16 @@ class FuncTreeInterp(AbstractInterp):
     def propose_auto_comp_list(self) -> list[str]:
 
         # TODO: FS_20_88_05_60: POC: Either remove it or implement properly: just testing named args:
-        if (
-            self.interp_ctx.parsed_ctx.tan_token_l_part.endswith(":")
-            or
-            self.interp_ctx.parsed_ctx.tan_token_r_part.startswith(":")
-        ):
+        if self.interp_ctx.parsed_ctx.tan_token_l_part.startswith(SpecialChar.ArgNamePrefix.value):
+            # TODO: exclude those `arg_name`-s which have already been matched with value:
             return [
-                type_name + SpecialChar.KeyValueDelimiter.value
+                SpecialChar.ArgNamePrefix.value + type_name
                 for type_name in self.interp_ctx.curr_container.search_control.props_to_keys_dict
-                if not type_name.startswith("_")
+                if (
+                    not type_name.startswith("_")
+                    and
+                    type_name.startswith(self.interp_ctx.parsed_ctx.tan_token_l_part[1:])
+                )
             ]
 
         # TODO: FS_23_62_89_43: the logic for both if-s (`if-A` and `if-B`) is identical at the moment - what do we want to improve?
@@ -695,7 +696,7 @@ class FuncTreeInterp(AbstractInterp):
             if self.interp_ctx.parsed_ctx.tan_token_l_part == "":
                 return self.remaining_from_next_missing_type()
             else:
-                # TODO: FS_20_88_05_60: Suggest keys (:) of missing types instead - it is `ScopeSubsequent`, user insist and wants something else:
+                # TODO: FS_20_88_05_60: Suggest `arg_name`-s (:) for missing `prop_name`-s instead - it is `ScopeSubsequent`, user insist and wants something else:
                 return self.remaining_from_next_missing_type()
 
         return []

--- a/src/argrelay/relay_server/UsageStatsStore.py
+++ b/src/argrelay/relay_server/UsageStatsStore.py
@@ -15,9 +15,16 @@ class UsageStatsStore:
     def __init__(
         self,
     ):
+        store_dir_path = os.path.join(
+           get_argrelay_dir(),
+           TopDir.var_dir.value,
+        )
+        os.makedirs(
+            store_dir_path,
+            exist_ok=True,
+        )
         self.store_file_path: str = str(os.path.join(
-            get_argrelay_dir(),
-            TopDir.var_dir.value,
+            store_dir_path,
             "usage_stats",
         ))
 

--- a/tests/offline_tests/meta_data/test_TokenType.py
+++ b/tests/offline_tests/meta_data/test_TokenType.py
@@ -7,11 +7,11 @@ class ThisTestClass(BaseTestClass):
 
     def test_get_token_type(self):
         test_cases = [
-            (line_no(), ["KeyArg1:", "ValArg1", "PosArg1"], 0, TokenType.KeyArg, ""),
-            (line_no(), ["KeyArg1:", "ValArg1", "PosArg1"], 1, TokenType.ValArg, ""),
-            (line_no(), ["KeyArg1:", "ValArg1", "PosArg1"], 2, TokenType.PosArg, ""),
-            (line_no(), ["KeyArg1:", "ValArg1", "KeyArg2:"], 2, TokenType.KeyArg, ""),
-            (line_no(), ["KeyArg1:", "KeyArg2:", "ValArg2"], 2, TokenType.ValArg, ""),
+            (line_no(), ["-KeyArg1", "ValArg1", "PosArg1"], 0, TokenType.KeyArg, ""),
+            (line_no(), ["-KeyArg1", "ValArg1", "PosArg1"], 1, TokenType.ValArg, ""),
+            (line_no(), ["-KeyArg1", "ValArg1", "PosArg1"], 2, TokenType.PosArg, ""),
+            (line_no(), ["-KeyArg1", "ValArg1", "-KeyArg2"], 2, TokenType.KeyArg, ""),
+            (line_no(), ["-KeyArg1", "-KeyArg2", "ValArg2"], 2, TokenType.ValArg, ""),
             (line_no(), ["PosArg1", "PosArg2", "PosArg3"], 0, TokenType.PosArg, ""),
         ]
         for test_case in test_cases:


### PR DESCRIPTION
*   Update the top "about" section in main `readme.md` - split it into sections answering specific question.
*   Minor logic update for named args (not functional yet).
*   Use `-` as arg name prefix (instead of `:` as arg name postfix).
*   Update bootstrap and its docs after trial project spin-off:
    *   Fix to copy `@/exe/check_env.bash` if it is missing.
    *   Fix to create `@/var/` dir if it does not exist.
*   Use built-in `datetime` module instead of `dateutil`.
