### PR TITLE
Recover and adjust for `macOS`

### DIFF
--- a/docs/feature_stories/FS_28_84_41_40.multi_level_bootstrap.md
+++ b/docs/feature_stories/FS_28_84_41_40.multi_level_bootstrap.md
@@ -1,0 +1,28 @@
+---
+feature_story: FS_28_84_41_40
+feature_title: multi-level bootstrap
+feature_status: TODO
+---
+
+# Background
+
+This feature is a combination of several ideas:
+
+*   TODO: TODO_96_01_13_29: multiple bootstrap stages to instantiate configs.
+
+*   Using Python lang as bootstrap process entry point.
+
+*   Using (mostly) template FS_69_15_45_21 template instantiator.
+
+    This is instead of making copies or symlinks of files from deployed packages. 
+
+There is existing FS_85_33_46_53 process to `bootstrap_env` which will likely be replaced (obsoleted) by this feature.
+
+# Things to address
+
+*   TODO: The Python bootstrap should switch automatically into mode: interpreter already known, interpreter not known yet.
+
+*   TODO: There should be some conventions where to put and how to name generated files.
+
+    Maybe they should be under `gen` dir by their origin, not across multiple dirs by their function.
+    They can be referenced from the dir by function using a proxy wrapper (if we talk about scripts).

--- a/docs/feature_stories/FS_69_15_45_21.template_instantiator.md
+++ b/docs/feature_stories/FS_69_15_45_21.template_instantiator.md
@@ -1,0 +1,30 @@
+---
+feature_story: FS_69_15_45_21
+feature_title: template instantiator
+feature_status: TODO
+---
+
+# Motivation
+
+The idea is to avoid copy-ing or symlink-ing static files from deployed Python packages.
+
+Instead, pass control to template instantiators together with parameterizing data to generate those files.
+
+# Principles
+
+Template instantiator-s are meant to form a chain.
+
+Each subsequent template instantiator is started by the previous one.
+
+The very first template instantiator is the initial level of FS_28_84_41_40 multi-level bootstrap.
+
+The contract (what data is being passed with what schema) can be unique
+for each pair of (prev, next) template instantiators.
+
+There is no pre-defined config (or any other input or output) files -
+each template instantiator defines them by itself.
+
+Why do we need that?
+
+To standardize only the initial entry/exit point (FS_28_84_41_40 multi-level bootstrap),
+maybe few subsequent ones (the further away, the less standard).

--- a/docs/feature_stories/FS_85_33_46_53.bootstrap_env.md
+++ b/docs/feature_stories/FS_85_33_46_53.bootstrap_env.md
@@ -6,6 +6,8 @@ feature_status: TEST
 
 See also FS_58_61_77_69 `dev_shell`.
 
+This feature will likely be replaced (obsoleted) by FS_28_84_41_40 multi-level bootstrap.
+
 # Purpose
 
 This feature covers initial setup and upgrades of `argrelay`-integrated projects (their development environments).

--- a/docs/task_refs/TODO_96_01_13_29.multiple_bootstrap_stages_to_instantiate_configs.md
+++ b/docs/task_refs/TODO_96_01_13_29.multiple_bootstrap_stages_to_instantiate_configs.md
@@ -13,6 +13,8 @@ FS_85_33_46_53: bootstrap process should have at least three distinct stages:
 *   use high-level config input (some YAML) to instantiate all other configs
 *   do anything else
 
+See also FS_28_84_41_40 multi-level bootstrap.
+
 ## Minimizing initial Bash bootstrap
 
 Current single `@/exe/bootstrap_env.bash` has to be self-sufficient - it cannot rely on any dependencies.
@@ -23,3 +25,12 @@ Because it is single, it keeps running with the same minimal assumptions about e
 
 With multiple bootstrap stages, next bootstrap stage can run in Python (easier to test) -
 this is similar to the split of FS_36_17_84_44 `check_env` script.
+
+## Using Python for bootstrap
+
+Running Python for bootstrap has few key benefits:
+*   It will tell the choice of Python interpreter making `@/conf/python_env.conf.bash` unnecessary.
+*   Code is independent of target shell (e.g. `bash`, `zsh`, ...) but can generate required files for all.
+*   Easier to implement, test, structure code than in shell scripts.
+
+See also FS_28_84_41_40 multi-level bootstrap.

--- a/exe/bootstrap_env.bash
+++ b/exe/bootstrap_env.bash
@@ -561,7 +561,8 @@ python_module_path_EOF
 
             target_file_path="${argrelay_dir}/${argrelay_dir_dst_path}"
             # Create target parent dirs:
-            mkdir --parents "$( dirname "${target_file_path}" )"
+            # NOTE: --parents is not supported on MacOS:
+            mkdir -p "$( dirname "${target_file_path}" )"
 
             # Install file to the target:
             if [[ ! -e "${target_file_path}" ]] && [[ ! -L "${target_file_path}" ]]

--- a/setup.py
+++ b/setup.py
@@ -242,7 +242,7 @@ See: https://github.com/argrelay/argrelay
         "PyYaml",
         "jsonschema",
         "flasgger",
-        "marshmallow",
+        "marshmallow<4.0.0",
         "marshmallow-oneofschema",
         "apispec",
         "pymongo",

--- a/src/argrelay/_version.py
+++ b/src/argrelay/_version.py
@@ -1,4 +1,4 @@
 # See `docs/dev_notes/version_format.md`:
 # Implements this:
 # https://stackoverflow.com/a/7071358/441652
-__version__ = "0.8.1.dev1"
+__version__ = "0.8.1"

--- a/src/argrelay/custom_integ_res/bootstrap_env.bash
+++ b/src/argrelay/custom_integ_res/bootstrap_env.bash
@@ -561,7 +561,8 @@ python_module_path_EOF
 
             target_file_path="${argrelay_dir}/${argrelay_dir_dst_path}"
             # Create target parent dirs:
-            mkdir --parents "$( dirname "${target_file_path}" )"
+            # NOTE: --parents is not supported on MacOS:
+            mkdir -p "$( dirname "${target_file_path}" )"
 
             # Install file to the target:
             if [[ ! -e "${target_file_path}" ]] && [[ ! -L "${target_file_path}" ]]

--- a/src/argrelay_app_bootstrap/sample_conf/argrelay_plugin.yaml
+++ b/src/argrelay_app_bootstrap/sample_conf/argrelay_plugin.yaml
@@ -301,7 +301,7 @@ server_plugin_instance_groups:
                         -   repo_rel_path: ""
                             load_repo_tags: True
                             load_repo_commits: True
-                            load_tags_last_days: 90
+                            load_tags_last_days: 360
                             load_commits_max_count: 50
                             envelope_properties:
                                 git_repo_alias: argrelay

--- a/src/argrelay_app_client/client_spec/ShellContext.py
+++ b/src/argrelay_app_client/client_spec/ShellContext.py
@@ -62,9 +62,9 @@ class ShellContext:
             command_line = os.environ[COMP_LINE_env_var]
             cursor_cpos = int(os.environ[COMP_POINT_env_var])
             # If `COMP_LINE_env_var` exists, the call is definitely NOT for `CompType.InvokeAction`:
-            comp_type = CompType(int(os.environ[COMP_TYPE_env_var]))
+            comp_type = CompType(int(os.environ.get(COMP_TYPE_env_var, CompType.SubsequentHelp.value)))
             assert comp_type != CompType.InvokeAction
-            comp_key = os.environ[COMP_KEY_env_var]
+            comp_key = os.environ.get(COMP_KEY_env_var, UNKNOWN_COMP_KEY)
         else:
             # See `CallConv.CliArgsConv`:
             argv = [os.path.basename(argv[0])] + argv[1:]

--- a/tests/offline_tests/config_only_plugins/test_config_only_plugins.py
+++ b/tests/offline_tests/config_only_plugins/test_config_only_plugins.py
@@ -100,6 +100,7 @@ class ThisTestClass(LocalTestClass):
                     LocalClientEnvMockBuilder().set_reset_local_server(False),
                 )
 
+
     def test_FS_49_96_50_77_config_only_with_FS_72_53_55_13_default_overrides(self):
         test_cases = [
             (


### PR DESCRIPTION
*   Use `mkdir -p` instead of unsupported `--parents` on `macOS`.
*   Spec: `FS_28_84_41_40.multi_level_bootstrap.md`.
*   Spec: `FS_69_15_45_21.template_instantiator.md`.
*   Fix: use `load_tags_last_days: 360` to let integration test see futher back into history.
*   Set dependency version constraint: `marshmallow<4.0.0`.
