### PR TITLE
Make MCP proxy wait for tool execution and track its stdio

### DIFF
--- a/data/ConfigOnlyLoader.sleep_group.data.yaml
+++ b/data/ConfigOnlyLoader.sleep_group.data.yaml
@@ -1,0 +1,9 @@
+-
+    envelope_class: class_sleep
+    time_delay: 4s
+-
+    envelope_class: class_sleep
+    time_delay: 16s
+-
+    envelope_class: class_sleep
+    time_delay: 64s

--- a/docs/feature_stories/FS_50_33_17_08.stdio_proxy_and_MCP_server.md
+++ b/docs/feature_stories/FS_50_33_17_08.stdio_proxy_and_MCP_server.md
@@ -308,10 +308,14 @@ src/argrelay_app_mcp_proxy/
 +-- __init__.py
 +-- mcp_proxy/
     +-- __init__.py
-    +-- __main__.py           # entry point: load config, run proxy
-    +-- ArgrelayMcpProxy.py  # core: session init, MCP handler callbacks
-    +-- ToolBuilder.py        # pure functions: parse /mcp_tools/ response,
-                              #   build MCP tool objects, build command lines
+    +-- __main__.py              # entry point: load config, run proxy
+    +-- ArgrelayMcpProxy.py     # core: session init, MCP handler callbacks
+    +-- ToolBuilder.py           # pure functions: parse /mcp_tools/ response,
+                                 #   build MCP tool objects, build command lines
+    +-- InvocationRunner.py     # subprocess entry point: reads relay_result JSON
+                                 #   from stdin, runs plugin, exits with plugin exit code
+    +-- McpProxyConfig.py       # config dataclass: log_dir_rel_path
+    +-- McpProxyConfigSchema.py # marshmallow schema for McpProxyConfig
 ```
 
 ### 4.5 Executable generation and CLI usage
@@ -368,6 +372,69 @@ Add `mcp>=1.0` to `pyproject.toml` dependencies. Do NOT add `anyio` separately -
 `mcp>=1.0` already depends on `anyio`; a duplicate explicit pin risks version conflicts.
 
 The proxy does NOT need to implement JSON-RPC 2.0 framing manually.
+
+### 4.8 Heartbeat: MCP progress notifications for long-running tools
+
+Some argrelay tools run for tens of seconds or longer (e.g. deployment, sleep).
+Without feedback the MCP client may time out or show no sign of activity.
+
+The proxy sends `notifications/progress` (standard MCP JSON-RPC notification) to
+the client while the `InvocationRunner` subprocess is running.
+
+Flow:
+
+```
+client sends: tools/call  sleep  {delay: "64s"}  _meta.progressToken=5
+proxy:
+  - reads progressToken from request_context.meta.progressToken
+  - spawns InvocationRunner subprocess
+  - starts asyncio heartbeat task: fires every heartbeat_interval_sec
+      -> session.send_progress_notification(token, elapsed_sec, None, "running Xs")
+  - await sub_proc.wait()   <- subprocess runs concurrently (separate OS process)
+  - cancels heartbeat task on subprocess exit
+  - returns CallToolResult
+```
+
+Key points:
+
+-   `progressToken` is optional -- sent by the client in `_meta`. If absent,
+    `progress_token` is `None` and no heartbeat task is created (zero overhead).
+-   Heartbeat fires in the asyncio event loop; subprocess runs as a separate OS
+    process. No thread crossing.
+-   `heartbeat_interval_sec` (default `5.0`) is configurable via `McpProxyConfig`.
+-   Claude Code (as of this writing) receives the notifications and processes them
+    (confirmed: `progress_token` present in activity log), but does not render the
+    `message` field text in the TUI.
+
+### 4.9 argrelay_dir propagation from proxy to subprocess
+
+`argrelay_dir` (the project root, `@/` in FS_29_54_67_86 dir structure) is stored
+as a Python module-level global in `argrelay_lib_root.misc_helper_common`.
+This global is process-local -- it does not survive `fork`/`exec`.
+`InvocationRunner` runs in a fresh subprocess, so the global must be re-established.
+
+Three-step chain:
+
+```
+1. Entry script (exe/argrelay_mcp_proxy)
+       calls set_argrelay_dir(path)
+       -> sets _argrelay_dir global in proxy process
+
+2. ArgrelayMcpProxy.call_tool (before create_subprocess_exec)
+       sub_env = os.environ.copy()
+       sub_env["ARGRELAY_DIR"] = get_argrelay_dir()
+       -> bridges Python-global-land -> env-var-land
+
+3. InvocationRunner.main() (before any delegator code)
+       argrelay_dir = os.environ.get("ARGRELAY_DIR")
+       if argrelay_dir:
+           set_argrelay_dir(argrelay_dir)
+       -> bridges env-var-land -> Python-global-land in subprocess
+```
+
+Step 2 is the only cross-process bridge. Without it, `InvocationRunner` reading
+`ARGRELAY_DIR` would never find it because env vars are not inherited from Python
+globals -- only from the OS-level environment passed to `create_subprocess_exec`.
 
 ### 4.7 Integration with Claude Code / Claude Desktop
 
@@ -488,22 +555,69 @@ Create `src/argrelay_app_mcp_proxy/mcp_proxy/ToolBuilder.py`:
 
 ### Phase 3: Proxy core
 
+Create `src/argrelay_app_mcp_proxy/mcp_proxy/McpProxyConfig.py` and `McpProxyConfigSchema.py`:
+
+-   Frozen dataclass `McpProxyConfig` with:
+    -   `log_dir_rel_path: str` -- directory for per-invocation log files.
+    -   `heartbeat_interval_sec: float` (default `5.0`) -- interval between MCP progress notifications sent while a tool is running (see Section 4.8).
+-   Companion marshmallow schema in `McpProxyConfigSchema.py`.
+
+Create `src/argrelay_app_mcp_proxy/mcp_proxy/InvocationRunner.py`:
+
+-   Subprocess entry point spawned by the proxy for each `tools/call` invocation.
+-   At the top of `main()`, before any delegator code: reads `ARGRELAY_DIR` env var
+    and calls `set_argrelay_dir` to re-establish the Python global in the subprocess
+    process (the global is process-local; it does not survive `fork`/`exec`):
+    ```python
+    argrelay_dir = os.environ.get("ARGRELAY_DIR")
+    if argrelay_dir:
+        set_argrelay_dir(argrelay_dir)
+    ```
+-   Reads `relay_result` JSON from stdin.
+-   Deserializes `InvocationInput` via `invocation_input_desc.dict_schema.load`.
+-   Imports plugin class via `import_plugin_class(invocation_input.delegator_plugin_entry)`.
+-   Calls `plugin_class.run_invoke_action(invocation_input)` and exits with its return code.
+-   On any non-`SystemExit` exception: prints traceback to stderr, exits 1.
+-   Invoked as `python -m argrelay_app_mcp_proxy.mcp_proxy.InvocationRunner`.
+-   Isolation rationale: subprocess cannot mutate the proxy's `sys.stdout`/`sys.stderr`,
+    which the MCP stdio transport uses for its protocol framing. Plugin output and
+    subprocess output go to log files via OS-level fd redirect set by the parent's
+    `asyncio.create_subprocess_exec` -- no Python-level `sys.stdout` reassignment needed.
+
 Create `src/argrelay_app_mcp_proxy/mcp_proxy/ArgrelayMcpProxy.py`:
 
--   `__init__(client_config: ClientConfig)`: derive server URL from
-    `client_config.redundant_servers[0]`, init `requests.Session`, MCP `Server`.
--   `start()`: `GET /mcp_tools/` -> `parse_mcp_tools_response` -> store tool list.
--   `register_handlers()`: register `list_tools` and `call_tool` callbacks on MCP server.
--   `_call_tool(name, arguments)`: `build_command_line` -> `POST /relay_line_args/`
-    -> extract result + remaining -> return `TextContent`.
--   `run_stdio()`: `async with stdio_server()` -> `mcp_server.run(...)`.
+-   `__init__(client_config: ClientConfig, mcp_proxy_config: McpProxyConfig)`: derive
+    server URL from `client_config.redundant_servers[0]`, init `requests.Session`,
+    MCP `Server`, `_log_dir` from `mcp_proxy_config.log_dir_rel_path`.
+    `_invoke_lock` deferred to `run_stdio()` (must bind to the correct asyncio event loop).
+-   `start()`: creates `_log_dir`, opens `argrelay_mcp_proxy.proxy.log` appended,
+    calls `GET /mcp_tools/` -> `parse_mcp_tools_response` -> stores tool list and `_tool_map`.
+-   `register_handlers()`: registers `list_tools` and inner `call_tool` callbacks on MCP server.
+    `call_tool` flow:
+    1.  `build_command_line` -> `POST /relay_line_args/` -> `relay_result` JSON.
+    2.  Creates timestamped log triplet: `{ts}.stdout.log`, `{ts}.stderr.log`, `{ts}.activity.log`.
+        Activity log receives proxy-side structured log entries (lock acquire/release, exit code).
+    3.  Acquires `_invoke_lock` (serializes concurrent tool calls to one at a time).
+    4.  Builds `sub_env = os.environ.copy()`, then writes `ARGRELAY_DIR` into it via
+        `get_argrelay_dir()` (bridge from Python-global-land to env-var-land so the
+        subprocess can re-establish the global; always set because the entry script calls
+        `set_argrelay_dir` before any other code runs).
+        Opens stdout/stderr log files, spawns `InvocationRunner` via
+        `asyncio.create_subprocess_exec(sys.executable, "-m", "...InvocationRunner", ..., env=sub_env)` with
+        `stdout=stdout_file, stderr=stderr_file` -- OS-level fd redirect.
+    5.  Sends `relay_result` JSON to subprocess stdin via `stdin.write` + `drain` + `close`,
+        starts optional MCP progress heartbeat task (see Section 4.8), then `await sub_proc.wait()`.
+    6.  After subprocess exits: reads log files, formats result text
+        (`custom_plugin_data` + remaining + `exit_code` + log paths + stdout/stderr content).
+    7.  Returns `CallToolResult(isError=exit_code != 0)`.
+-   `run_stdio()`: creates `_invoke_lock` -> `async with stdio_server()` -> `mcp_server.run(...)`.
 
 Create `src/argrelay_app_mcp_proxy/mcp_proxy/__main__.py`:
 
--   Load `argrelay_client.json` via `load_client_config(get_config_path(...))` --
-    reuse `load_client_config` from `argrelay_app_client.relay_client.__main__`.
--   Derive server URL from `client_config.redundant_servers[0]` + `BASE_URL_FORMAT`.
--   Instantiate `ArgrelayMcpProxy`, call `start()`, `register_handlers()`, `run_stdio()`.
+-   Load `argrelay_client.json` via `load_client_config(get_config_path(...))`.
+-   Load `McpProxyConfig` from its config file.
+-   Instantiate `ArgrelayMcpProxy(client_config, mcp_proxy_config)`, call `start()`,
+    `register_handlers()`, `run()`.
 
 ### Phase 4: Bootstrap integration
 
@@ -537,6 +651,9 @@ src/argrelay_app_mcp_proxy/mcp_proxy/__init__.py
 src/argrelay_app_mcp_proxy/mcp_proxy/__main__.py
 src/argrelay_app_mcp_proxy/mcp_proxy/ArgrelayMcpProxy.py
 src/argrelay_app_mcp_proxy/mcp_proxy/ToolBuilder.py
+src/argrelay_app_mcp_proxy/mcp_proxy/InvocationRunner.py
+src/argrelay_app_mcp_proxy/mcp_proxy/McpProxyConfig.py
+src/argrelay_app_mcp_proxy/mcp_proxy/McpProxyConfigSchema.py
 ```
 
 ### Modified files

--- a/dst/relay_demo/.gitignore
+++ b/dst/relay_demo/.gitignore
@@ -6,3 +6,4 @@
 /argrelay_plugin.yaml
 /check_env_plugin.conf.bash
 /check_env_plugin.conf.yaml
+/argrelay_mcp_proxy.json

--- a/src/argrelay_api_plugin_server_abstract/DelegatorAbstract.py
+++ b/src/argrelay_api_plugin_server_abstract/DelegatorAbstract.py
@@ -58,7 +58,7 @@ class DelegatorAbstract(AbstractPluginServer):
     """
     `DelegatorPlugin` implements two sides:
     *   server-side `invoke_control` prepares data in :class:`InvocationInput` (whatever is necessary)
-    *   client-side `invoke_action` uses data in :class:`InvocationInput` to execute the action anyway it can
+    *   client-side `run_invoke_action` / `invoke_action` uses data in :class:`InvocationInput` to execute the action
 
     To simplify reasoning, ensure that both server-side and client-side:
     *   have access to the same code (non-breaking differences are possible, but same code version ensures that)
@@ -167,11 +167,12 @@ class DelegatorAbstract(AbstractPluginServer):
         pass
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         """
         Execute command on client side based on data received from server side.
+        Returns exit code. Does not call exit() — safe for long-lived callers (MCP proxy, tests).
 
         Implements FS_98_55_40_77 `invoke_control` on client side.
         There is no plugin instance on client side -
@@ -179,7 +180,19 @@ class DelegatorAbstract(AbstractPluginServer):
         *   without instantiating a plugin instance (it is a `@staticmethod`)
         *   specifically, without calling `AbstractPlugin.activate_plugin` (as it is non-static)
         """
-        pass
+        return 0
+
+    @classmethod
+    def invoke_action(
+        cls,
+        invocation_input: InvocationInput,
+    ) -> None:
+        """
+        CLI entry point: calls run_invoke_action then exits with the returned exit code.
+        Terminates the process — correct for short-lived CLI client processes.
+        """
+        exit_code = cls.run_invoke_action(invocation_input)
+        exit(exit_code if exit_code is not None else 0)
 
     @staticmethod
     def extract_search_control_from_function_data_envelope(

--- a/src/argrelay_app_bootstrap/sample_conf/argrelay_mcp_proxy.json
+++ b/src/argrelay_app_bootstrap/sample_conf/argrelay_mcp_proxy.json
@@ -1,0 +1,4 @@
+{
+    "__comment__": "argrelay MCP proxy config",
+    "log_dir_rel_path": "./logs"
+}

--- a/src/argrelay_app_bootstrap/sample_conf/argrelay_plugin.yaml
+++ b/src/argrelay_app_bootstrap/sample_conf/argrelay_plugin.yaml
@@ -24,6 +24,7 @@ server_plugin_instance_groups:
                 -   DelegatorNoopGroup.special_func_group
                 -   DelegatorNoopGroup.check_env_command_group
                 -   DelegatorNoopGroup.ssh_dst_group
+                -   DelegatorNoopGroup.sleep_group
                 -   DelegatorNoopGroup.demo_service_group
                 -   DelegatorNoopGroup.generic_git_group
                 -   DelegatorConfigOnly.default
@@ -205,6 +206,31 @@ server_plugin_instance_groups:
             plugin_class_name: DelegatorNoopGroup
             plugin_dependencies:
                 -   DelegatorSshDst.default
+
+    "sleep_group":
+
+        ConfigOnlyLoader.sleep_group:
+            plugin_module_name: argrelay_lib_server_plugin_core.plugin_loader.ConfigOnlyLoader
+            plugin_class_name: ConfigOnlyLoader
+            plugin_config:
+                envelope_class_to_collection_name_map:
+                    class_sleep: class_sleep
+                collection_name_to_index_props_map:
+                    class_sleep:
+                        -   envelope_class
+                        -   time_delay
+                data_envelopes:
+                  !include "data/ConfigOnlyLoader.sleep_group.data.yaml"
+
+        DelegatorSleep.default:
+            plugin_module_name: argrelay_lib_server_plugin_demo.demo_sleep.DelegatorSleep
+            plugin_class_name: DelegatorSleep
+
+        DelegatorNoopGroup.sleep_group:
+            plugin_module_name: argrelay_lib_server_plugin_core.plugin_delegator.DelegatorNoopGroup
+            plugin_class_name: DelegatorNoopGroup
+            plugin_dependencies:
+                -   DelegatorSleep.default
 
     "demo_service_group":
 

--- a/src/argrelay_app_bootstrap/sample_conf/argrelay_server.yaml
+++ b/src/argrelay_app_bootstrap/sample_conf/argrelay_server.yaml
@@ -283,6 +283,9 @@ server_plugin_control:
                             "ssh":
                                 node_type: func_tree_node
                                 func_id: func_id_ssh_dst
+                            "sleep":
+                                node_type: func_tree_node
+                                func_id: func_id_sleep
                     "duplicates":
                         node_type: tree_path_node
                         sub_tree:

--- a/src/argrelay_app_mcp_proxy/mcp_proxy/ArgrelayMcpProxy.py
+++ b/src/argrelay_app_mcp_proxy/mcp_proxy/ArgrelayMcpProxy.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
 
 import mcp.server
 import mcp.server.stdio
@@ -8,6 +14,8 @@ import mcp.types as types
 import requests
 
 from argrelay_api_server_cli.server_spec.const_int import MCP_TOOLS_PATH
+from argrelay_lib_root.misc_helper_common import get_argrelay_dir
+from argrelay_app_mcp_proxy.mcp_proxy.McpProxyConfig import McpProxyConfig
 from argrelay_app_mcp_proxy.mcp_proxy.ToolBuilder import (
     ToolDesc,
     build_command_line,
@@ -23,11 +31,31 @@ from argrelay_schema_config_client.runtime_data_client_app.ClientConfig import (
 )
 
 
+async def _send_heartbeat(
+    server_session,
+    progress_token,
+    interval_sec: float,
+    invoke_logger: logging.Logger,
+) -> None:
+    elapsed_sec = 0.0
+    while True:
+        await asyncio.sleep(interval_sec)
+        elapsed_sec += interval_sec
+        invoke_logger.info("call_tool: heartbeat; elapsed_sec=%.0f", elapsed_sec)
+        await server_session.send_progress_notification(
+            progress_token,
+            elapsed_sec,
+            None,
+            f"running {elapsed_sec:.0f}s",
+        )
+
+
 class ArgrelayMcpProxy:
 
     def __init__(
         self,
         client_config: ClientConfig,
+        mcp_proxy_config: McpProxyConfig,
     ):
         server_conn = client_config.redundant_servers[0]
         from argrelay_api_server_cli.server_spec.const_int import BASE_URL_FORMAT
@@ -40,12 +68,28 @@ class ArgrelayMcpProxy:
         self.mcp_server = mcp.server.Server("argrelay")
         self.tools: list[ToolDesc] = []
         self._tool_map: dict[str, ToolDesc] = {}
+        self._log_dir = Path(mcp_proxy_config.log_dir_rel_path)
+        self._heartbeat_interval_sec: float = mcp_proxy_config.heartbeat_interval_sec
+        # _invoke_lock created inside run_stdio() (inside asyncio.run()) to ensure
+        # it binds to the correct event loop on all Python versions.
+        self._invoke_lock: asyncio.Lock | None = None
+        self._proxy_logger: logging.Logger | None = None
 
     def start(self) -> None:
+        self._log_dir.mkdir(parents=True, exist_ok=True)
+        proxy_log_path = self._log_dir / "argrelay_mcp_proxy.proxy.log"
+        handler = logging.FileHandler(proxy_log_path, mode="a", encoding="utf-8")
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+        logger = logging.getLogger("argrelay_mcp_proxy")
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+        self._proxy_logger = logger
+        self._proxy_logger.info("proxy start: server_url=%s", self.server_url)
         mcp_tools_resp = self.http.get(self.server_url + MCP_TOOLS_PATH)
         mcp_tools_resp.raise_for_status()
         self.tools = parse_mcp_tools_response(mcp_tools_resp.json())
         self._tool_map = {tool_desc.name: tool_desc for tool_desc in self.tools}
+        self._proxy_logger.info("proxy start: loaded %d tools", len(self.tools))
 
     def register_handlers(self) -> None:
 
@@ -58,8 +102,10 @@ class ArgrelayMcpProxy:
             name: str,
             arguments: dict,
         ) -> list[types.TextContent]:
+            self._proxy_logger.info("call_tool: name=%r arguments=%r", name, arguments)
             tool_desc = self._tool_map.get(name)
             if tool_desc is None:
+                self._proxy_logger.error("call_tool: unknown tool %r", name)
                 raise ValueError(f"Unknown tool: {name!r}")
             command_line = build_command_line(tool_desc, arguments or {})
             relay_payload = {
@@ -75,20 +121,129 @@ class ArgrelayMcpProxy:
             )
             relay_resp.raise_for_status()
             relay_result = relay_resp.json()
-            remaining_args = extract_remaining(relay_result, tool_desc)
-            result_text = format_tool_result(
-                relay_result.get("custom_plugin_data", {}),
-                remaining_args,
+
+            timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+            stdout_path = self._log_dir / f"argrelay_mcp_proxy.{timestamp}.stdout.log"
+            stderr_path = self._log_dir / f"argrelay_mcp_proxy.{timestamp}.stderr.log"
+            activity_path = (
+                self._log_dir / f"argrelay_mcp_proxy.{timestamp}.activity.log"
             )
-            return [types.TextContent(type="text", text=result_text)]
+
+            invoke_logger = logging.getLogger(f"argrelay_mcp_proxy.{timestamp}")
+            invoke_logger.setLevel(logging.DEBUG)
+            invoke_logger.propagate = False
+            invoke_handler = logging.FileHandler(
+                activity_path, mode="w", encoding="utf-8"
+            )
+            invoke_handler.setFormatter(
+                logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+            )
+            invoke_logger.addHandler(invoke_handler)
+
+            try:
+                invoke_logger.info("call_tool: name=%r arguments=%r", name, arguments)
+                invoke_logger.info("call_tool: command_line=%r", command_line)
+                request_ctx = self.mcp_server.request_context
+                progress_token = (
+                    request_ctx.meta.progressToken if request_ctx.meta else None
+                )
+                invoke_logger.info(
+                    "call_tool: acquiring invoke_lock; progress_token=%r heartbeat_interval_sec=%r stdout_log=%s stderr_log=%s activity_log=%s",
+                    progress_token,
+                    self._heartbeat_interval_sec,
+                    stdout_path,
+                    stderr_path,
+                    activity_path,
+                )
+                async with self._invoke_lock:
+                    invoke_logger.info("call_tool: lock acquired; starting subprocess")
+                    sub_env = os.environ.copy()
+                    sub_env["ARGRELAY_DIR"] = get_argrelay_dir()
+                    with (
+                        open(stdout_path, "wb") as stdout_file,
+                        open(stderr_path, "wb") as stderr_file,
+                    ):
+                        sub_proc = await asyncio.create_subprocess_exec(
+                            sys.executable,
+                            "-m",
+                            "argrelay_app_mcp_proxy.mcp_proxy.InvocationRunner",
+                            stdin=asyncio.subprocess.PIPE,
+                            stdout=stdout_file,
+                            stderr=stderr_file,
+                            env=sub_env,
+                        )
+                        sub_proc.stdin.write(json.dumps(relay_result).encode())
+                        await sub_proc.stdin.drain()
+                        sub_proc.stdin.close()
+                        heartbeat_task = None
+                        if progress_token is not None:
+                            heartbeat_task = asyncio.create_task(
+                                _send_heartbeat(
+                                    request_ctx.session,
+                                    progress_token,
+                                    self._heartbeat_interval_sec,
+                                    invoke_logger,
+                                )
+                            )
+                        try:
+                            await sub_proc.wait()
+                        finally:
+                            if heartbeat_task is not None:
+                                heartbeat_task.cancel()
+                                try:
+                                    await heartbeat_task
+                                except asyncio.CancelledError:
+                                    pass
+                    exit_code = sub_proc.returncode
+                    invoke_logger.info(
+                        "call_tool: subprocess done; exit_code=%r", exit_code
+                    )
+
+                stdout_text = stdout_path.read_text()
+                stderr_text = stderr_path.read_text()
+
+                remaining_args = extract_remaining(relay_result, tool_desc)
+                result_text = format_tool_result(
+                    relay_result.get("custom_plugin_data", {}),
+                    remaining_args,
+                )
+                result_text += f"\nexit_code: {exit_code}"
+                result_text += f"\nstdout_log: {stdout_path}"
+                result_text += f"\nstderr_log: {stderr_path}"
+                result_text += f"\nactivity_log: {activity_path}"
+                if stdout_text:
+                    result_text += f"\nstdout:\n{stdout_text}"
+                if stderr_text:
+                    result_text += f"\nstderr:\n{stderr_text}"
+
+                invoke_logger.info("call_tool: returning result")
+            finally:
+                invoke_handler.flush()
+                invoke_handler.close()
+                invoke_logger.removeHandler(invoke_handler)
+            is_error = exit_code != 0
+            return types.CallToolResult(
+                content=[types.TextContent(type="text", text=result_text)],
+                isError=is_error,
+            )
 
     async def run_stdio(self) -> None:
+        # Create lock here — inside asyncio.run() — so it binds to the correct event loop.
+        self._invoke_lock = asyncio.Lock()
+        self._proxy_logger.info("run_stdio: starting stdio_server")
         async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
-            await self.mcp_server.run(
-                read_stream,
-                write_stream,
-                self.mcp_server.create_initialization_options(),
-            )
+            self._proxy_logger.info("run_stdio: stdio_server open; running mcp_server")
+            try:
+                await self.mcp_server.run(
+                    read_stream,
+                    write_stream,
+                    self.mcp_server.create_initialization_options(),
+                )
+            except BaseException:
+                self._proxy_logger.exception("run_stdio: mcp_server.run raised")
+                raise
+            finally:
+                self._proxy_logger.info("run_stdio: mcp_server.run exited")
 
     def run(self) -> None:
         asyncio.run(self.run_stdio())

--- a/src/argrelay_app_mcp_proxy/mcp_proxy/InvocationRunner.py
+++ b/src/argrelay_app_mcp_proxy/mcp_proxy/InvocationRunner.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import traceback
+
+from argrelay_lib_root.misc_helper_common import set_argrelay_dir
+
+
+def main() -> None:
+    argrelay_dir = os.environ.get("ARGRELAY_DIR")
+    if argrelay_dir:
+        set_argrelay_dir(argrelay_dir)
+    try:
+        relay_result = json.load(sys.stdin)
+        from argrelay_api_server_cli.schema_response.InvocationInputSchema import (
+            invocation_input_desc,
+        )
+        from argrelay_api_plugin_abstract.AbstractPlugin import import_plugin_class
+
+        invocation_input = invocation_input_desc.dict_schema.load(relay_result)
+        plugin_class = import_plugin_class(invocation_input.delegator_plugin_entry)
+        exit_code = plugin_class.run_invoke_action(invocation_input)
+        sys.exit(exit_code if exit_code is not None else 0)
+    except SystemExit:
+        raise
+    except BaseException:
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/argrelay_app_mcp_proxy/mcp_proxy/McpProxyConfig.py
+++ b/src/argrelay_app_mcp_proxy/mcp_proxy/McpProxyConfig.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import (
+    dataclass,
+    field,
+)
+
+
+@dataclass(frozen=True)
+class McpProxyConfig:
+    __comment__: str = field()
+    log_dir_rel_path: str = field()
+    heartbeat_interval_sec: float = field(default=5.0)

--- a/src/argrelay_app_mcp_proxy/mcp_proxy/McpProxyConfigSchema.py
+++ b/src/argrelay_app_mcp_proxy/mcp_proxy/McpProxyConfigSchema.py
@@ -1,0 +1,44 @@
+from marshmallow import (
+    fields,
+    RAISE,
+)
+
+from argrelay_app_mcp_proxy.mcp_proxy.McpProxyConfig import McpProxyConfig
+from argrelay_lib_root.misc_helper_common.ObjectSchema import ObjectSchema
+from argrelay_lib_root.misc_helper_common.TypeDesc import TypeDesc
+
+log_dir_rel_path_ = "log_dir_rel_path"
+heartbeat_interval_sec_ = "heartbeat_interval_sec"
+
+
+class McpProxyConfigSchema(ObjectSchema):
+    class Meta:
+        unknown = RAISE
+        strict = True
+
+    model_class = McpProxyConfig
+
+    __comment__ = fields.String(
+        required=False,
+        load_default="",
+    )
+
+    log_dir_rel_path = fields.String(
+        required=False,
+        load_default="./logs",
+    )
+
+    heartbeat_interval_sec = fields.Float(
+        required=False,
+        load_default=5.0,
+    )
+
+
+mcp_proxy_config_desc = TypeDesc(
+    dict_schema=McpProxyConfigSchema(),
+    ref_name=McpProxyConfigSchema.__name__,
+    dict_example={
+        log_dir_rel_path_: "./logs",
+    },
+    default_file_path="argrelay_mcp_proxy.json",
+)

--- a/src/argrelay_app_mcp_proxy/mcp_proxy/__main__.py
+++ b/src/argrelay_app_mcp_proxy/mcp_proxy/__main__.py
@@ -1,12 +1,26 @@
+import json
+
 from argrelay_app_client.relay_client.__main__ import load_client_config
 from argrelay_app_mcp_proxy.mcp_proxy.ArgrelayMcpProxy import ArgrelayMcpProxy
+from argrelay_app_mcp_proxy.mcp_proxy.McpProxyConfig import McpProxyConfig
+from argrelay_app_mcp_proxy.mcp_proxy.McpProxyConfigSchema import mcp_proxy_config_desc
 from argrelay_lib_root.misc_helper_common import get_config_path
 
 
+def load_mcp_proxy_config(file_path: str) -> McpProxyConfig:
+    with open(file_path) as f:
+        config_dict = json.load(f)
+    return mcp_proxy_config_desc.dict_schema.load(config_dict)
+
+
 def main():
-    config_file_path = get_config_path("argrelay_client.json")
-    client_config = load_client_config(config_file_path)
-    mcp_proxy = ArgrelayMcpProxy(client_config)
+    client_config_path = get_config_path("argrelay_client.json")
+    client_config = load_client_config(client_config_path)
+
+    mcp_proxy_config_path = get_config_path("argrelay_mcp_proxy.json")
+    mcp_proxy_config = load_mcp_proxy_config(mcp_proxy_config_path)
+
+    mcp_proxy = ArgrelayMcpProxy(client_config, mcp_proxy_config)
     mcp_proxy.start()
     mcp_proxy.register_handlers()
     mcp_proxy.run()

--- a/src/argrelay_lib_server_plugin_check_env/DelegatorCheckEnvGitCommitId.py
+++ b/src/argrelay_lib_server_plugin_check_env/DelegatorCheckEnvGitCommitId.py
@@ -78,12 +78,13 @@ class DelegatorCheckEnvGitCommitId(DelegatorCheckEnvBase):
         return invocation_input
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         func_id = get_func_id_from_invocation_input(invocation_input)
         assert func_id == CheckEnvFunc.func_id_get_server_project_git_commit_id.name
 
         print(
             f"{invocation_input.custom_plugin_data[CheckEnvField.server_git_commit_id.name]}"
         )
+        return 0

--- a/src/argrelay_lib_server_plugin_check_env/DelegatorCheckEnvServerStartTime.py
+++ b/src/argrelay_lib_server_plugin_check_env/DelegatorCheckEnvServerStartTime.py
@@ -73,12 +73,13 @@ class DelegatorCheckEnvServerStartTime(DelegatorCheckEnvBase):
         return invocation_input
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         func_id = get_func_id_from_invocation_input(invocation_input)
         assert func_id == CheckEnvFunc.func_id_get_server_start_time.name
 
         print(
             f"{invocation_input.custom_plugin_data[CheckEnvField.server_start_time.name]}"
         )
+        return 0

--- a/src/argrelay_lib_server_plugin_check_env/DelegatorCheckEnvServerVersion.py
+++ b/src/argrelay_lib_server_plugin_check_env/DelegatorCheckEnvServerVersion.py
@@ -74,12 +74,13 @@ class DelegatorCheckEnvServerVersion(DelegatorCheckEnvBase):
         return invocation_input
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         func_id = get_func_id_from_invocation_input(invocation_input)
         assert func_id == CheckEnvFunc.func_id_get_server_argrelay_version.name
 
         print(
             f"{invocation_input.custom_plugin_data[CheckEnvField.server_version.name]}"
         )
+        return 0

--- a/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorConfigBase.py
+++ b/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorConfigBase.py
@@ -200,7 +200,7 @@ class DelegatorConfigBase(DelegatorSingleFuncAbstract):
         return invocation_input
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         raise NotImplementedError("Extend: not implemented intentionally")

--- a/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorConfigOnly.py
+++ b/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorConfigOnly.py
@@ -44,9 +44,9 @@ class DelegatorConfigOnly(DelegatorConfigBase):
         )
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         # TODO: TODO_74_73_60_93: Support expected envelope count in config-only delegator:
         #       Use common static functions in `DelegatorConfigBase`.
 
@@ -72,4 +72,4 @@ class DelegatorConfigOnly(DelegatorConfigBase):
             command_line,
             shell=True,
         )
-        exit(sub_proc.returncode)
+        return sub_proc.returncode

--- a/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorDataBackendGet.py
+++ b/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorDataBackendGet.py
@@ -108,9 +108,9 @@ class DelegatorDataBackendGet(DelegatorDataBackendBase):
         return invocation_input
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         func_id = get_func_id_from_invocation_input(invocation_input)
         assert func_id == SpecialFunc.func_id_get_data_envelopes.name
 
@@ -120,3 +120,4 @@ class DelegatorDataBackendGet(DelegatorDataBackendBase):
             data_envelope_container_ipos_
         ].data_envelopes:
             print(json.dumps(data_envelope))
+        return 0

--- a/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorDataBackendSet.py
+++ b/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorDataBackendSet.py
@@ -172,9 +172,9 @@ class DelegatorDataBackendSet(DelegatorDataBackendBase):
         return invocation_input
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         func_id = get_func_id_from_invocation_input(invocation_input)
         assert func_id == SpecialFunc.func_id_set_data_envelopes.name
 
@@ -206,3 +206,4 @@ class DelegatorDataBackendSet(DelegatorDataBackendBase):
         else:
             # 2nd response
             pass
+        return 0

--- a/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorEcho.py
+++ b/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorEcho.py
@@ -60,7 +60,8 @@ class DelegatorEcho(DelegatorSingleFuncAbstract):
         return invocation_input
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         print(" ".join(invocation_input.all_tokens))
+        return 0

--- a/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorError.py
+++ b/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorError.py
@@ -36,9 +36,9 @@ class DelegatorError(DelegatorSingleFuncAbstract):
         return invocation_input
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         error_message = "ERROR: unknown error"
         error_code = ClientExitCode.GeneralError.value
         if invocation_input.custom_plugin_data:
@@ -47,4 +47,4 @@ class DelegatorError(DelegatorSingleFuncAbstract):
             if error_code_ in invocation_input.custom_plugin_data:
                 error_code = invocation_input.custom_plugin_data[error_code_]
         eprint(error_message)
-        exit(error_code)
+        return error_code

--- a/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorHelp.py
+++ b/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorHelp.py
@@ -100,9 +100,9 @@ class DelegatorHelp(DelegatorJumpAbstract):
             )
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         if (
             get_func_id_from_invocation_input(invocation_input)
             == SpecialFunc.func_id_help_hint.name
@@ -153,3 +153,4 @@ class DelegatorHelp(DelegatorJumpAbstract):
                     print(TermColor.reset_style.value, end="")
 
                 print()
+        return 0

--- a/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorIntercept.py
+++ b/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorIntercept.py
@@ -150,9 +150,9 @@ class DelegatorIntercept(DelegatorJumpAbstract):
         return invocation_input
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         # TODO: Print without first function `data_envelope` belonging to `intercept` function:
         func_id = get_func_id_from_invocation_input(invocation_input)
         if func_id == SpecialFunc.func_id_intercept_invocation.name:
@@ -174,3 +174,4 @@ class DelegatorIntercept(DelegatorJumpAbstract):
                 raise RuntimeError(f"not implemented: {output_format}")
         else:
             raise RuntimeError(f"unknown func_id: {func_id}")
+        return 0

--- a/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorNoopBase.py
+++ b/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorNoopBase.py
@@ -28,8 +28,7 @@ class DelegatorNoopBase(DelegatorSingleFuncAbstract):
         return invocation_input
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
-        # Do nothing:
-        pass
+    ) -> int:
+        return 0

--- a/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorQueryEnum.py
+++ b/src/argrelay_lib_server_plugin_core/plugin_delegator/DelegatorQueryEnum.py
@@ -71,7 +71,8 @@ class DelegatorQueryEnum(DelegatorJumpAbstract):
         return invocation_input
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         ClientResponseHandlerDescribeLineArgs.render_result(invocation_input)
+        return 0

--- a/src/argrelay_lib_server_plugin_demo/demo_git/DelegatorGitRepoDescCommit.py
+++ b/src/argrelay_lib_server_plugin_demo/demo_git/DelegatorGitRepoDescCommit.py
@@ -80,7 +80,7 @@ class DelegatorGitRepoDescCommit(DelegatorGitRepoBase):
         return func_envelopes
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
     ) -> None:
         assert (

--- a/src/argrelay_lib_server_plugin_demo/demo_git/DelegatorGitRepoDescTag.py
+++ b/src/argrelay_lib_server_plugin_demo/demo_git/DelegatorGitRepoDescTag.py
@@ -80,7 +80,7 @@ class DelegatorGitRepoDescTag(DelegatorGitRepoBase):
         return func_envelopes
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
     ) -> None:
         assert (

--- a/src/argrelay_lib_server_plugin_demo/demo_git/DelegatorGitRepoGotoRepo.py
+++ b/src/argrelay_lib_server_plugin_demo/demo_git/DelegatorGitRepoGotoRepo.py
@@ -86,9 +86,9 @@ class DelegatorGitRepoGotoRepo(DelegatorGitRepoBase):
         return func_envelopes
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         assert (
             get_func_id_from_invocation_input(invocation_input)
             == func_id_goto_git_repo_
@@ -107,7 +107,7 @@ class DelegatorGitRepoGotoRepo(DelegatorGitRepoBase):
             eprint(
                 f"ERROR: single repo is not selected (not disambiguated from multiple candidates)"
             )
-            exit(ClientExitCode.GeneralError.value)
+            return ClientExitCode.GeneralError.value
 
         repo_envelope = invocation_input.envelope_containers[
             repo_container_ipos_
@@ -125,3 +125,4 @@ class DelegatorGitRepoGotoRepo(DelegatorGitRepoBase):
         exit_code = sub_proc.returncode
         if exit_code != 0:
             raise RuntimeError
+        return exit_code

--- a/src/argrelay_lib_server_plugin_demo/demo_service/DelegatorServiceHostGoto.py
+++ b/src/argrelay_lib_server_plugin_demo/demo_service/DelegatorServiceHostGoto.py
@@ -123,7 +123,7 @@ class DelegatorServiceHostGoto(DelegatorServiceHostBase):
         )
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
     ) -> None:
         func_id = get_func_id_from_invocation_input(invocation_input)

--- a/src/argrelay_lib_server_plugin_demo/demo_service/DelegatorServiceHostList.py
+++ b/src/argrelay_lib_server_plugin_demo/demo_service/DelegatorServiceHostList.py
@@ -80,9 +80,9 @@ class DelegatorServiceHostList(DelegatorServiceHostBase):
         )
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         """
         Print `data_envelope`-s received from server on client side.
         """
@@ -96,3 +96,4 @@ class DelegatorServiceHostList(DelegatorServiceHostBase):
             host_container_ipos_
         ].data_envelopes:
             print(json.dumps(data_envelope))
+        return 0

--- a/src/argrelay_lib_server_plugin_demo/demo_service/DelegatorServiceInstanceDiff.py
+++ b/src/argrelay_lib_server_plugin_demo/demo_service/DelegatorServiceInstanceDiff.py
@@ -111,7 +111,7 @@ class DelegatorServiceInstanceDiff(DelegatorServiceInstanceBase):
         )
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
     ) -> None:
         func_id = get_func_id_from_invocation_input(invocation_input)

--- a/src/argrelay_lib_server_plugin_demo/demo_service/DelegatorServiceInstanceGoto.py
+++ b/src/argrelay_lib_server_plugin_demo/demo_service/DelegatorServiceInstanceGoto.py
@@ -123,7 +123,7 @@ class DelegatorServiceInstanceGoto(DelegatorServiceInstanceBase):
         )
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
     ) -> None:
         func_id = get_func_id_from_invocation_input(invocation_input)

--- a/src/argrelay_lib_server_plugin_demo/demo_service/DelegatorServiceInstanceList.py
+++ b/src/argrelay_lib_server_plugin_demo/demo_service/DelegatorServiceInstanceList.py
@@ -80,9 +80,9 @@ class DelegatorServiceInstanceList(DelegatorServiceInstanceBase):
         )
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         """
         Print `data_envelope`-s received from server on client side.
         """
@@ -96,3 +96,4 @@ class DelegatorServiceInstanceList(DelegatorServiceInstanceBase):
             service_container_ipos_
         ].data_envelopes:
             print(json.dumps(data_envelope))
+        return 0

--- a/src/argrelay_lib_server_plugin_demo/demo_sleep/DelegatorSleep.py
+++ b/src/argrelay_lib_server_plugin_demo/demo_sleep/DelegatorSleep.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import logging
+import subprocess
+
+logger = logging.getLogger()
+
+from argrelay_api_plugin_server_abstract.delegator_utils import (
+    clean_prop_value,
+)
+from argrelay_api_plugin_server_abstract.DelegatorAbstract import (
+    get_func_id_from_interp_ctx,
+    get_func_id_from_invocation_input,
+)
+from argrelay_api_plugin_server_abstract.DelegatorSingleFuncAbstract import (
+    DelegatorSingleFuncAbstract,
+)
+from argrelay_api_server_cli.schema_response.InvocationInput import InvocationInput
+from argrelay_app_server.relay_server.LocalServer import LocalServer
+from argrelay_app_server.runtime_context.InterpContext import InterpContext
+from argrelay_lib_root.enum_desc.ClientExitCode import ClientExitCode
+from argrelay_lib_root.enum_desc.FuncState import FuncState
+from argrelay_lib_root.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay_lib_root.enum_desc.ReservedPropName import ReservedPropName
+from argrelay_lib_root.misc_helper_common import eprint
+from argrelay_lib_server_plugin_core.plugin_delegator.client_invocation_utils import (
+    prohibit_unconsumed_args,
+)
+from argrelay_schema_config_server.schema_config_interp.DataEnvelopeSchema import (
+    instance_data_,
+)
+from argrelay_schema_config_server.schema_config_interp.FunctionEnvelopeInstanceDataSchema import (
+    delegator_plugin_instance_id_,
+    func_id_,
+    search_control_list_,
+)
+from argrelay_schema_config_server.schema_config_interp.SearchControlSchema import (
+    populate_search_control,
+)
+
+func_id_sleep_ = "func_id_sleep"
+
+class_sleep_ = "class_sleep"
+
+time_delay_prop_name_ = "time_delay"
+
+sleep_container_ipos_ = 1
+
+
+class DelegatorSleep(DelegatorSingleFuncAbstract):
+    """
+    Demo delegator wrapping `sleep` command.
+
+    Selects a pre-defined time delay from `class_sleep` data envelopes
+    via CLI arg, strips the `s` suffix, and executes `sleep <n>`.
+    """
+
+    def get_supported_func_envelopes(
+        self,
+    ) -> list[dict]:
+
+        func_envelopes = [
+            {
+                instance_data_: {
+                    func_id_: func_id_sleep_,
+                    delegator_plugin_instance_id_: self.plugin_instance_id,
+                    search_control_list_: [
+                        populate_search_control(
+                            collection_name=class_sleep_,
+                            props_to_values_dict={
+                                ReservedPropName.envelope_class.name: class_sleep_,
+                            },
+                            arg_name_to_prop_name_map=[
+                                # TODO: TODO_61_99_68_90: figure out what to do with explicit `envelope_class` `search_prop`:
+                                {"class": ReservedPropName.envelope_class.name},
+                                # ---
+                                {"delay": time_delay_prop_name_},
+                            ],
+                        ),
+                    ],
+                },
+                ReservedPropName.envelope_class.name: ReservedEnvelopeClass.class_function.name,
+                ReservedPropName.help_hint.name: "Use `sleep` to pause for the selected duration.",
+                ReservedPropName.func_state.name: FuncState.fs_demo.name,
+                ReservedPropName.func_id.name: func_id_sleep_,
+            },
+        ]
+        return func_envelopes
+
+    def run_invoke_control(
+        self,
+        interp_ctx: InterpContext,
+        local_server: LocalServer,
+    ) -> InvocationInput:
+        assert interp_ctx.is_func_found(), "the (first) function envelope must be found"
+
+        func_id = get_func_id_from_interp_ctx(interp_ctx)
+        assert func_id == func_id_sleep_
+
+        vararg_container = interp_ctx.envelope_containers[sleep_container_ipos_]
+        vararg_container.data_envelopes = (
+            local_server.get_query_engine().query_data_envelopes_for(vararg_container)
+        )
+
+        delegator_plugin_instance_id = self.plugin_instance_id
+        invocation_input = InvocationInput.with_interp_context(
+            interp_ctx,
+            delegator_plugin_entry=local_server.plugin_config.server_plugin_instances[
+                delegator_plugin_instance_id
+            ],
+            custom_plugin_data={},
+        )
+        return invocation_input
+
+    @staticmethod
+    def run_invoke_action(
+        invocation_input: InvocationInput,
+    ) -> int:
+        func_id = get_func_id_from_invocation_input(invocation_input)
+        assert func_id == func_id_sleep_
+
+        prohibit_unconsumed_args(invocation_input)
+
+        sleep_data_envelopes = invocation_input.envelope_containers[
+            sleep_container_ipos_
+        ].data_envelopes
+
+        if len(sleep_data_envelopes) > 1:
+            for sleep_data_envelope in sleep_data_envelopes:
+                eprint(f"  {sleep_data_envelope}")
+            eprint(
+                "ERROR: `sleep` duration is ambiguous "
+                "(multiple candidates based on given command line input)"
+            )
+            return ClientExitCode.GeneralError.value
+
+        elif len(sleep_data_envelopes) == 0:
+            eprint(
+                "ERROR: `sleep` duration not found based on given command line input."
+            )
+            return ClientExitCode.GeneralError.value
+
+        else:
+            sleep_data_envelope = sleep_data_envelopes[0]
+            return _run_sleep(sleep_data_envelope)
+
+
+def _run_sleep(
+    sleep_data_envelope: dict,
+) -> int:
+    import sys
+
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.INFO,
+    )
+    raw_delay = clean_prop_value(sleep_data_envelope[time_delay_prop_name_])
+    # Strip trailing `s` suffix (e.g. "4s" → "4")
+    n = int(raw_delay.rstrip("s"))
+    for x in range(1, n + 1):
+        logger.info(f"sleeping for a sec {x} out of {n} times...")
+        sub_proc = subprocess.run(["sleep", "1"])
+        if sub_proc.returncode != 0:
+            return sub_proc.returncode
+    return 0

--- a/src/argrelay_lib_server_plugin_demo/demo_ssh/DelegatorSshDst.py
+++ b/src/argrelay_lib_server_plugin_demo/demo_ssh/DelegatorSshDst.py
@@ -136,9 +136,9 @@ class DelegatorSshDst(DelegatorSingleFuncAbstract):
         return invocation_input
 
     @staticmethod
-    def invoke_action(
+    def run_invoke_action(
         invocation_input: InvocationInput,
-    ) -> None:
+    ) -> int:
         func_id = get_func_id_from_invocation_input(invocation_input)
         assert func_id == func_id_ssh_dst_
 
@@ -157,17 +157,17 @@ class DelegatorSshDst(DelegatorSingleFuncAbstract):
                 "ERROR: `ssh` destination is ambiguous "
                 "(multiple candidates based on given command line input)"
             )
-            exit(ClientExitCode.GeneralError.value)
+            return ClientExitCode.GeneralError.value
 
         elif len(ssh_dst_data_envelopes) == 0:
             eprint(
                 "ERROR: `ssh` destination not found based on given command line input."
             )
-            exit(ClientExitCode.GeneralError.value)
+            return ClientExitCode.GeneralError.value
 
         else:
             ssh_dst_data_envelope = ssh_dst_data_envelopes[0]
-            _run_ssh(ssh_dst_data_envelope)
+            return _run_ssh(ssh_dst_data_envelope)
 
 
 def _data_envelope_to_str(
@@ -181,7 +181,7 @@ def _data_envelope_to_str(
 
 def _run_ssh(
     ssh_dst_data_envelope: dict,
-) -> None:
+) -> int:
     eprint(_data_envelope_to_str(ssh_dst_data_envelope))
 
     user_name = clean_prop_value(ssh_dst_data_envelope[ServicePropName.user_name.name])
@@ -203,5 +203,4 @@ def _run_ssh(
             f'cd "{dir_path}" ; bash --login',
         ],
     )
-    exit_code = sub_proc.returncode
-    exit(exit_code)
+    return sub_proc.returncode

--- a/src/argrelay_test_infra/test_infra/EnvMockBuilder.py
+++ b/src/argrelay_test_infra/test_infra/EnvMockBuilder.py
@@ -215,6 +215,13 @@ class EnvMockBuilder:
     """
     Set by giving `delegator_class` to `set_capture_delegator_invocation_input`.
     """
+
+    allow_invoke_action_exit: bool = field(default=False)
+    """
+    When True, skips the base-class `invoke_action` mock that would otherwise prevent
+    SystemExit in tests with CompType.InvokeAction and no specific delegator mock.
+    Set this when the test explicitly expects SystemExit (e.g. to verify exit codes).
+    """
     invocation_input: InvocationInput = field(default=None)
     """
     Captured `InvocationInput` by using `capture_invocation_input` func on `ServerAction.RelayLineArgs`
@@ -464,6 +471,15 @@ class EnvMockBuilder:
         )
         return self
 
+    def set_allow_invoke_action_exit(self):
+        """
+        Opt out of the automatic base-class `invoke_action` mock.
+        Use when the test explicitly expects `SystemExit` from `CompType.InvokeAction`
+        (e.g. to verify that the correct exit code is propagated).
+        """
+        self.allow_invoke_action_exit = True
+        return self
+
     ####################################################################################################################
     # Server control
 
@@ -710,6 +726,24 @@ class EnvMockBuilder:
                 yield_list.append(
                     exit_stack.enter_context(
                         _mock_delegator_plugin(self.invoke_action_func_full_name)
+                    )
+                )
+            elif (
+                self.comp_type is CompType.InvokeAction
+                and not self.allow_invoke_action_exit
+            ):
+                # When no specific delegator is mocked but comp_type is InvokeAction,
+                # mock the base class to prevent SystemExit from reaching test code.
+                # Skip when allow_invoke_action_exit=True (test explicitly expects SystemExit).
+                yield_list.append(
+                    exit_stack.enter_context(
+                        _mock_delegator_plugin(
+                            f"{DelegatorAbstract.__module__}"
+                            "."
+                            f"{DelegatorAbstract.__name__}"
+                            "."
+                            "invoke_action"
+                        )
                     )
                 )
 

--- a/tests/offline_tests/composite_forest/test_CompositeForestExtractor.py
+++ b/tests/offline_tests/composite_forest/test_CompositeForestExtractor.py
@@ -417,6 +417,7 @@ class ThisTestClass(LocalTestClass):
                 "double_execution": "func_id_double_execution",
             },
             "ssh": "func_id_ssh_dst",
+            "sleep": "func_id_sleep",
         }
 
         test_cases = [

--- a/tests/offline_tests/config_only_plugins/test_config_only_plugins.py
+++ b/tests/offline_tests/config_only_plugins/test_config_only_plugins.py
@@ -279,7 +279,9 @@ exit 1
                             None,
                             None,
                             None,
-                            LocalClientEnvMockBuilder().set_reset_local_server(False),
+                            LocalClientEnvMockBuilder()
+                            .set_reset_local_server(False)
+                            .set_allow_invoke_action_exit(),
                         )
                     expected_exit_code = next(iter(popen_mock_config.values()))[0]
                     self.assertEqual(cm.exception.code, expected_exit_code)

--- a/tests/offline_tests/mcp_proxy/test_ArgrelayMcpProxy.py
+++ b/tests/offline_tests/mcp_proxy/test_ArgrelayMcpProxy.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 import json
-from unittest.mock import MagicMock
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import mcp.types as types
 
 from argrelay_app_mcp_proxy.mcp_proxy.ArgrelayMcpProxy import ArgrelayMcpProxy
+from argrelay_app_mcp_proxy.mcp_proxy.McpProxyConfig import McpProxyConfig
 from argrelay_app_mcp_proxy.mcp_proxy.ToolBuilder import ToolDesc
 from argrelay_lib_root.schema_config.ConnectionConfig import ConnectionConfig
 from argrelay_schema_config_client.runtime_data_client_app.ClientConfig import (
@@ -53,7 +59,11 @@ class ThisTestClass(ServerOnlyTestClass):
 
     def _make_proxy(self) -> ArgrelayMcpProxy:
         client_config = _make_client_config("localhost", 8787)
-        proxy = ArgrelayMcpProxy(client_config)
+        mcp_proxy_config = McpProxyConfig(
+            __comment__="test",
+            log_dir_rel_path="/tmp/argrelay_test_mcp_proxy_logs",
+        )
+        proxy = ArgrelayMcpProxy(client_config, mcp_proxy_config)
 
         test_client = self.test_client
 
@@ -143,3 +153,114 @@ class ThisTestClass(ServerOnlyTestClass):
 
         # when/then:
         proxy.register_handlers()
+
+    def _make_started_proxy(
+        self,
+        log_dir_rel_path: str,
+    ) -> ArgrelayMcpProxy:
+        """Proxy with GET and POST mocked, started and handlers registered."""
+        client_config = _make_client_config("localhost", 8787)
+        mcp_proxy_config = McpProxyConfig(
+            __comment__="test",
+            log_dir_rel_path=log_dir_rel_path,
+        )
+        proxy = ArgrelayMcpProxy(client_config, mcp_proxy_config)
+        test_client = self.test_client
+
+        def _mock_http_get(url, **kwargs):
+            path = url.replace("http://localhost:8787", "")
+            flask_response = test_client.get(path)
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = json.loads(flask_response.data)
+            mock_resp.raise_for_status.return_value = None
+            return mock_resp
+
+        def _mock_http_post(url, json=None, **kwargs):
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = {
+                "custom_plugin_data": {},
+                "envelope_containers": [],
+            }
+            mock_resp.raise_for_status.return_value = None
+            return mock_resp
+
+        proxy.http.get = _mock_http_get
+        proxy.http.post = _mock_http_post
+        proxy.start()
+        proxy.register_handlers()
+        return proxy
+
+    async def _run_call_tool(
+        self,
+        proxy: ArgrelayMcpProxy,
+        tool_name: str,
+        tool_arguments: dict,
+    ):
+        """Invoke call_tool handler with mocked subprocess and request context."""
+        from mcp.server.lowlevel.server import request_ctx
+        from mcp.shared.context import RequestContext
+
+        proxy._invoke_lock = asyncio.Lock()
+
+        mock_proc = MagicMock()
+        mock_proc.stdin.drain = AsyncMock()
+        mock_proc.wait = AsyncMock()
+        mock_proc.returncode = 0
+
+        mock_session = MagicMock()
+        mock_ctx = RequestContext(
+            request_id="test-1",
+            meta=None,
+            session=mock_session,
+            lifespan_context=None,
+        )
+        ctx_token = request_ctx.set(mock_ctx)
+        try:
+            with patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=mock_proc),
+            ):
+                req = types.CallToolRequest(
+                    params=types.CallToolRequestParams(
+                        name=tool_name,
+                        arguments=tool_arguments,
+                    ),
+                )
+                handler = proxy.mcp_server.request_handlers[types.CallToolRequest]
+                return await handler(req)
+        finally:
+            request_ctx.reset(ctx_token)
+
+    def test_call_tool_unknown_tool_is_error(self):
+        with tempfile.TemporaryDirectory() as log_dir:
+            proxy = self._make_started_proxy(log_dir)
+
+            server_result = asyncio.run(
+                self._run_call_tool(proxy, "nonexistent_tool_xyz", {})
+            )
+
+        assert server_result.root.isError is True
+
+    def test_call_tool_known_tool_is_not_error(self):
+        with tempfile.TemporaryDirectory() as log_dir:
+            proxy = self._make_started_proxy(log_dir)
+            tool_name = proxy.tools[0].name
+
+            server_result = asyncio.run(self._run_call_tool(proxy, tool_name, {}))
+
+        assert server_result.root.isError is False
+
+    def test_call_tool_activity_log_records_name_and_arguments(self):
+        with tempfile.TemporaryDirectory() as log_dir:
+            proxy = self._make_started_proxy(log_dir)
+            tool_name = proxy.tools[0].name
+            tool_arguments = {}
+
+            asyncio.run(self._run_call_tool(proxy, tool_name, tool_arguments))
+
+            activity_log_files = list(Path(log_dir).glob("*.activity.log"))
+            assert len(activity_log_files) == 1
+            log_content = activity_log_files[0].read_text()
+
+        assert f"name={tool_name!r}" in log_content
+        assert f"arguments={tool_arguments!r}" in log_content

--- a/tests/offline_tests/mcp_proxy/test_InvocationRunner.py
+++ b/tests/offline_tests/mcp_proxy/test_InvocationRunner.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+
+from argrelay_api_server_cli.server_spec.const_int import MCP_TOOLS_PATH
+from argrelay_lib_root.enum_desc.CompScope import CompScope
+from argrelay_lib_root.enum_desc.ServerAction import ServerAction
+from argrelay_test_infra.test_infra.EnvMockBuilder import ServerOnlyEnvMockBuilder
+from argrelay_test_infra.test_infra.ServerOnlyTestClass import ServerOnlyTestClass
+
+_RUNNER_MODULE = "argrelay_app_mcp_proxy.mcp_proxy.InvocationRunner"
+_ECHO_ARGS_TOOL_NAME = "echo_args"
+
+
+def _run_runner(
+    relay_result_dict: dict, timeout_sec: int = 30
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", _RUNNER_MODULE],
+        input=json.dumps(relay_result_dict).encode(),
+        capture_output=True,
+        timeout=timeout_sec,
+    )
+
+
+class TestInvocationRunnerErrors(unittest.TestCase):
+    """
+    Error-handling tests — no server required.
+    InvocationRunner must exit 1 and write traceback to stderr on bad input.
+    """
+
+    def test_exits_1_on_invalid_json(self):
+        proc = subprocess.run(
+            [sys.executable, "-m", _RUNNER_MODULE],
+            input=b"not valid json{{",
+            capture_output=True,
+            timeout=10,
+        )
+        self.assertEqual(1, proc.returncode)
+
+    def test_stderr_has_traceback_on_invalid_json(self):
+        proc = subprocess.run(
+            [sys.executable, "-m", _RUNNER_MODULE],
+            input=b"not valid json{{",
+            capture_output=True,
+            timeout=10,
+        )
+        self.assertGreater(len(proc.stderr), 0)
+        self.assertIn(b"Traceback", proc.stderr)
+
+    def test_exits_1_on_missing_required_fields(self):
+        proc = _run_runner({})
+        self.assertEqual(1, proc.returncode)
+
+    def test_stderr_has_traceback_on_missing_required_fields(self):
+        proc = _run_runner({})
+        self.assertGreater(len(proc.stderr), 0)
+        self.assertIn(b"Traceback", proc.stderr)
+
+    def test_stdout_empty_on_error(self):
+        proc = _run_runner({})
+        self.assertEqual(b"", proc.stdout)
+
+
+class TestInvocationRunnerWithServer(ServerOnlyTestClass):
+    """
+    Integration tests — InvocationRunner invoked with a real relay_result
+    obtained from an in-process Flask server.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.create_server_in_mocked_env(
+            ServerOnlyEnvMockBuilder().set_test_data_ids_to_load(["TD_63_37_05_36"])
+        )
+        self.test_client = self.flask_app.test_client()
+
+    def tearDown(self):
+        super().tearDown()
+
+    def _get_relay_result_for_echo_args(self) -> dict:
+        mcp_resp = self.test_client.get(MCP_TOOLS_PATH)
+        tools = mcp_resp.get_json()["tools"]
+        echo_tool = next(t for t in tools if t["name"] == _ECHO_ARGS_TOOL_NAME)
+        command_line = " ".join(echo_tool["command_path"])
+        relay_payload = {
+            "server_action": ServerAction.RelayLineArgs.name,
+            "command_line": command_line,
+            "cursor_cpos": len(command_line),
+            "comp_scope": CompScope.ScopeInitial.name,
+            "is_debug_enabled": False,
+        }
+        relay_resp = self.test_client.post(
+            ServerAction.RelayLineArgs.value,
+            json=relay_payload,
+        )
+        self.assertEqual(200, relay_resp.status_code)
+        return relay_resp.get_json()
+
+    def test_exits_0_for_echo_args(self):
+        relay_result = self._get_relay_result_for_echo_args()
+        proc = _run_runner(relay_result)
+        self.assertEqual(0, proc.returncode)
+
+    def test_stdout_contains_output_for_echo_args(self):
+        relay_result = self._get_relay_result_for_echo_args()
+        proc = _run_runner(relay_result)
+        self.assertGreater(len(proc.stdout.strip()), 0)
+
+    def test_stderr_empty_on_success(self):
+        relay_result = self._get_relay_result_for_echo_args()
+        proc = _run_runner(relay_result)
+        self.assertEqual(b"", proc.stderr)
+
+    def test_does_not_mutate_parent_sys_stdout(self):
+        # Subprocess runs in isolated process — parent sys.stdout must not change.
+        original_stdout = sys.stdout
+        relay_result = self._get_relay_result_for_echo_args()
+        _run_runner(relay_result)
+        self.assertIs(original_stdout, sys.stdout)
+
+    def test_does_not_mutate_parent_sys_stderr(self):
+        original_stderr = sys.stderr
+        relay_result = self._get_relay_result_for_echo_args()
+        _run_runner(relay_result)
+        self.assertIs(original_stderr, sys.stderr)

--- a/tests/offline_tests/plugin_delegator/test_DelegatorCheckEnv.py
+++ b/tests/offline_tests/plugin_delegator/test_DelegatorCheckEnv.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from argrelay_lib_root.enum_desc.CheckEnvField import CheckEnvField
+from argrelay_lib_root.enum_desc.CompScope import CompScope
+from argrelay_lib_root.enum_desc.ServerAction import ServerAction
+from argrelay_test_infra.test_infra.EnvMockBuilder import ServerOnlyEnvMockBuilder
+from argrelay_test_infra.test_infra.ServerOnlyTestClass import ServerOnlyTestClass
+
+
+class ThisTestClass(ServerOnlyTestClass):
+    """
+    Verify run_invoke_control returns InvocationInput with custom_plugin_data populated.
+
+    Bug: stray `return 0` before `return invocation_input` in run_invoke_control causes
+    server to dump `{}` (int has no InvocationInput fields), client receives empty dict,
+    custom_plugin_data is missing.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.create_server_in_mocked_env(
+            ServerOnlyEnvMockBuilder().set_test_data_ids_to_load(["TD_63_37_05_36"])
+        )
+        self.test_client = self.flask_app.test_client()
+
+    def tearDown(self):
+        super().tearDown()
+
+    def _post_relay_line_args(self, command_line: str) -> dict:
+        relay_payload = {
+            "server_action": ServerAction.RelayLineArgs.name,
+            "command_line": command_line,
+            "cursor_cpos": len(command_line),
+            "comp_scope": CompScope.ScopeInitial.name,
+            "is_debug_enabled": False,
+        }
+        resp = self.test_client.post(
+            ServerAction.RelayLineArgs.value,
+            json=relay_payload,
+        )
+        self.assertEqual(200, resp.status_code)
+        return resp.get_json()
+
+    def test_server_version_relay_result_has_custom_plugin_data(self):
+        relay_result = self._post_relay_line_args("argrelay.check_env server_version")
+        self.assertIn("custom_plugin_data", relay_result)
+        self.assertIn(
+            CheckEnvField.server_version.name,
+            relay_result["custom_plugin_data"],
+        )
+
+    def test_server_commit_relay_result_has_custom_plugin_data(self):
+        relay_result = self._post_relay_line_args("argrelay.check_env server_commit")
+        self.assertIn("custom_plugin_data", relay_result)
+        self.assertIn(
+            CheckEnvField.server_git_commit_id.name,
+            relay_result["custom_plugin_data"],
+        )
+
+    def test_server_start_time_relay_result_has_custom_plugin_data(self):
+        relay_result = self._post_relay_line_args(
+            "argrelay.check_env server_start_time"
+        )
+        self.assertIn("custom_plugin_data", relay_result)
+        self.assertIn(
+            CheckEnvField.server_start_time.name,
+            relay_result["custom_plugin_data"],
+        )

--- a/tests/offline_tests/plugin_delegator/test_DelegatorHelp.py
+++ b/tests/offline_tests/plugin_delegator/test_DelegatorHelp.py
@@ -210,7 +210,7 @@ some_command list service {SpecialChar.NoPropValue.value} {TermColor.known_envel
                     .set_capture_stderr(True)
                 )
                 with inner_env_mock_builder.build():
-                    DelegatorHelp.invoke_action(invocation_input)
+                    DelegatorHelp.run_invoke_action(invocation_input)
 
                     self.assertEqual(
                         stdout_str,

--- a/tests/offline_tests/plugin_delegator/test_DelegatorIntercept.py
+++ b/tests/offline_tests/plugin_delegator/test_DelegatorIntercept.py
@@ -51,6 +51,7 @@ class ThisTestClass(LocalTestClass):
                     "intercept",
                     "list",
                     "no_data",
+                    "sleep",
                     "ssh",
                 ],
                 None,

--- a/tests/offline_tests/plugin_delegator/test_DelegatorQueryEnum.py
+++ b/tests/offline_tests/plugin_delegator/test_DelegatorQueryEnum.py
@@ -47,6 +47,7 @@ class ThisTestClass(LocalTestClass):
                     "intercept",
                     "list",
                     "no_data",
+                    "sleep",
                     "ssh",
                 ],
                 None,

--- a/tests/offline_tests/plugin_delegator/test_DelegatorSleep.py
+++ b/tests/offline_tests/plugin_delegator/test_DelegatorSleep.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+from argrelay_api_server_cli.schema_response.AssignedValue import AssignedValue
+from argrelay_lib_root.enum_desc.CompType import CompType
+from argrelay_lib_root.enum_desc.FuncState import FuncState
+from argrelay_lib_root.enum_desc.ReservedEnvelopeClass import ReservedEnvelopeClass
+from argrelay_lib_root.enum_desc.ReservedPropName import ReservedPropName
+from argrelay_lib_root.enum_desc.SpecialChar import SpecialChar
+from argrelay_lib_root.enum_desc.ValueSource import ValueSource
+from argrelay_lib_server_plugin_core.plugin_interp.FuncTreeInterpFactory import (
+    func_envelope_path_step_prop_name,
+)
+from argrelay_lib_server_plugin_demo.demo_sleep.DelegatorSleep import (
+    class_sleep_,
+    DelegatorSleep,
+    func_id_sleep_,
+    time_delay_prop_name_,
+)
+from argrelay_test_infra.test_infra import (
+    assert_test_module_name_embeds_prod_class_name,
+    line_no,
+)
+from argrelay_test_infra.test_infra.EnvMockBuilder import (
+    LocalClientEnvMockBuilder,
+)
+from argrelay_test_infra.test_infra.LocalTestClass import LocalTestClass
+
+
+class ThisTestClass(LocalTestClass):
+    same_test_data_per_class = "TD_63_37_05_36"  # demo
+
+    # noinspection PyMethodMayBeStatic
+    def test_relationship(self):
+        assert_test_module_name_embeds_prod_class_name(DelegatorSleep)
+
+    def test_DelegatorSleep(self):
+
+        test_cases = [
+            (
+                line_no(),
+                "lay sleep 4s |",
+                [],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue(
+                            "lay",
+                            ValueSource.init_value,
+                        ),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue(
+                            "sleep",
+                            ValueSource.explicit_offered_arg,
+                        ),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue(
+                            SpecialChar.NoPropValue.value,
+                            ValueSource.implicit_value,
+                        ),
+                        f"{ReservedPropName.func_state.name}": AssignedValue(
+                            FuncState.fs_demo.name,
+                            ValueSource.implicit_value,
+                        ),
+                        f"{ReservedPropName.func_id.name}": AssignedValue(
+                            func_id_sleep_,
+                            ValueSource.implicit_value,
+                        ),
+                    },
+                    1: {
+                        ReservedPropName.envelope_class.name: AssignedValue(
+                            class_sleep_,
+                            ValueSource.init_value,
+                        ),
+                        time_delay_prop_name_: AssignedValue(
+                            "4s", ValueSource.explicit_offered_arg
+                        ),
+                    },
+                    2: None,
+                },
+                DelegatorSleep,
+                {
+                    0: {
+                        ReservedPropName.envelope_class.name: ReservedEnvelopeClass.class_function.name,
+                    },
+                    1: {
+                        ReservedPropName.envelope_class.name: class_sleep_,
+                        time_delay_prop_name_: "4s",
+                    },
+                    2: None,
+                },
+                {
+                    0: 0,
+                    1: 0,
+                },
+                f"Access `{func_id_sleep_}` via `lay sleep` and select 4s duration.",
+            ),
+            (
+                line_no(),
+                "lay sleep 16s |",
+                [],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue(
+                            "lay",
+                            ValueSource.init_value,
+                        ),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue(
+                            "sleep",
+                            ValueSource.explicit_offered_arg,
+                        ),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue(
+                            SpecialChar.NoPropValue.value,
+                            ValueSource.implicit_value,
+                        ),
+                        f"{ReservedPropName.func_state.name}": AssignedValue(
+                            FuncState.fs_demo.name,
+                            ValueSource.implicit_value,
+                        ),
+                        f"{ReservedPropName.func_id.name}": AssignedValue(
+                            func_id_sleep_,
+                            ValueSource.implicit_value,
+                        ),
+                    },
+                    1: {
+                        ReservedPropName.envelope_class.name: AssignedValue(
+                            class_sleep_,
+                            ValueSource.init_value,
+                        ),
+                        time_delay_prop_name_: AssignedValue(
+                            "16s", ValueSource.explicit_offered_arg
+                        ),
+                    },
+                    2: None,
+                },
+                DelegatorSleep,
+                {
+                    0: {
+                        ReservedPropName.envelope_class.name: ReservedEnvelopeClass.class_function.name,
+                    },
+                    1: {
+                        ReservedPropName.envelope_class.name: class_sleep_,
+                        time_delay_prop_name_: "16s",
+                    },
+                    2: None,
+                },
+                {
+                    0: 0,
+                    1: 0,
+                },
+                f"Access `{func_id_sleep_}` via `lay sleep` and select 16s duration.",
+            ),
+            (
+                line_no(),
+                "some_command sleep 64s |",
+                [],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue(
+                            "some_command",
+                            ValueSource.init_value,
+                        ),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue(
+                            "sleep",
+                            ValueSource.explicit_offered_arg,
+                        ),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue(
+                            SpecialChar.NoPropValue.value,
+                            ValueSource.implicit_value,
+                        ),
+                        f"{ReservedPropName.func_state.name}": AssignedValue(
+                            FuncState.fs_demo.name,
+                            ValueSource.implicit_value,
+                        ),
+                        f"{ReservedPropName.func_id.name}": AssignedValue(
+                            func_id_sleep_,
+                            ValueSource.implicit_value,
+                        ),
+                    },
+                    1: {
+                        ReservedPropName.envelope_class.name: AssignedValue(
+                            class_sleep_,
+                            ValueSource.init_value,
+                        ),
+                        time_delay_prop_name_: AssignedValue(
+                            "64s", ValueSource.explicit_offered_arg
+                        ),
+                    },
+                    2: None,
+                },
+                DelegatorSleep,
+                {
+                    0: {
+                        ReservedPropName.envelope_class.name: ReservedEnvelopeClass.class_function.name,
+                    },
+                    1: {
+                        ReservedPropName.envelope_class.name: class_sleep_,
+                        time_delay_prop_name_: "64s",
+                    },
+                    2: None,
+                },
+                {
+                    0: 0,
+                    1: 0,
+                },
+                f"Access `{func_id_sleep_}` via `some_command sleep` and select 64s duration.",
+            ),
+            (
+                line_no(),
+                "lay sleep |",
+                [
+                    "16s",
+                    "4s",
+                    "64s",
+                ],
+                {
+                    0: {
+                        f"{func_envelope_path_step_prop_name(0)}": AssignedValue(
+                            "lay",
+                            ValueSource.init_value,
+                        ),
+                        f"{func_envelope_path_step_prop_name(1)}": AssignedValue(
+                            "sleep",
+                            ValueSource.explicit_offered_arg,
+                        ),
+                        f"{func_envelope_path_step_prop_name(2)}": AssignedValue(
+                            SpecialChar.NoPropValue.value,
+                            ValueSource.implicit_value,
+                        ),
+                        f"{ReservedPropName.func_state.name}": AssignedValue(
+                            FuncState.fs_demo.name,
+                            ValueSource.implicit_value,
+                        ),
+                        f"{ReservedPropName.func_id.name}": AssignedValue(
+                            func_id_sleep_,
+                            ValueSource.implicit_value,
+                        ),
+                    },
+                    1: {
+                        ReservedPropName.envelope_class.name: AssignedValue(
+                            class_sleep_,
+                            ValueSource.init_value,
+                        ),
+                    },
+                    2: None,
+                },
+                DelegatorSleep,
+                {
+                    0: {
+                        ReservedPropName.envelope_class.name: ReservedEnvelopeClass.class_function.name,
+                    },
+                    1: {
+                        ReservedPropName.envelope_class.name: class_sleep_,
+                        time_delay_prop_name_: "4s",
+                    },
+                    2: {
+                        ReservedPropName.envelope_class.name: class_sleep_,
+                        time_delay_prop_name_: "16s",
+                    },
+                    3: {
+                        ReservedPropName.envelope_class.name: class_sleep_,
+                        time_delay_prop_name_: "64s",
+                    },
+                    4: None,
+                },
+                {
+                    0: 0,
+                    1: 0,
+                },
+                f"Tab-complete `lay sleep` with no args shows all available durations.",
+            ),
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case):
+                (
+                    line_number,
+                    test_line,
+                    expected_suggestions,
+                    container_ipos_to_expected_assignments,
+                    delegator_class,
+                    envelope_ipos_to_prop_values,
+                    expected_container_ipos_to_used_token_bucket,
+                    case_comment,
+                ) = test_case
+
+                self.verify_output_via_local_client(
+                    self.__class__.same_test_data_per_class,
+                    test_line,
+                    CompType.InvokeAction,
+                    expected_suggestions,
+                    container_ipos_to_expected_assignments,
+                    None,
+                    delegator_class,
+                    envelope_ipos_to_prop_values,
+                    expected_container_ipos_to_used_token_bucket,
+                    LocalClientEnvMockBuilder().set_reset_local_server(False),
+                )

--- a/tests/offline_tests/plugin_interp/test_InterpTreeInterpFactory.py
+++ b/tests/offline_tests/plugin_interp/test_InterpTreeInterpFactory.py
@@ -67,6 +67,7 @@ class ThisTestClass(LocalTestClass):
                     "intercept",
                     "list",
                     "no_data",
+                    "sleep",
                     "ssh",
                 ],
                 {},

--- a/tests/offline_tests/relay_demo/test_relay_demo.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo.py
@@ -77,6 +77,7 @@ class ThisTestClass(LocalTestClass):
                     "intercept",
                     "list",
                     "no_data",
+                    "sleep",
                     "ssh",
                 ],
                 "Suggest from the set of values for the first unassigned `prop_name`.",
@@ -509,6 +510,7 @@ class ThisTestClass(LocalTestClass):
                     "intercept",
                     "list",
                     "no_data",
+                    "sleep",
                     "ssh",
                 ],
                 {},
@@ -651,14 +653,14 @@ class ThisTestClass(LocalTestClass):
                 # fmt: off
                 f"""
 {TermColor.consumed_token.value}some_command{TermColor.reset_style.value} 
-{ReservedEnvelopeClass.class_function.name}: {TermColor.found_count_n.value}43{TermColor.reset_style.value}
+{ReservedEnvelopeClass.class_function.name}: {TermColor.found_count_n.value}45{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{ReservedPropName.envelope_class.name}: {ReservedEnvelopeClass.class_function.name} {TermColor.other_assigned_arg_value.value}[{ValueSource.init_value.name}]{TermColor.reset_style.value}
 {" " * indent_size}{TermColor.other_assigned_arg_value.value}{func_envelope_path_step_prop_name(0)}: some_command {TermColor.other_assigned_arg_value.value}[{ValueSource.init_value.name}]{TermColor.reset_style.value}
-{" " * indent_size}{TermColor.remaining_value.value}*{func_envelope_path_step_prop_name(1)}: ?{TermColor.reset_style.value} config data desc diff duplicates echo enum goto help intercept list no_data ssh 
-{" " * indent_size}{TermColor.remaining_value.value}{func_envelope_path_step_prop_name(2)}: ?{TermColor.reset_style.value} commit config data desc diff double_execution echo get goto help host intercept list no_data print_with_exit print_with_io_redirect print_with_level repo service set ssh tag {SpecialChar.NoPropValue.value} 
+{" " * indent_size}{TermColor.remaining_value.value}*{func_envelope_path_step_prop_name(1)}: ?{TermColor.reset_style.value} config data desc diff duplicates echo enum goto help intercept list no_data sleep ssh 
+{" " * indent_size}{TermColor.remaining_value.value}{func_envelope_path_step_prop_name(2)}: ?{TermColor.reset_style.value} commit config data desc diff double_execution echo get goto help host intercept list no_data print_with_exit print_with_io_redirect print_with_level repo service set sleep ssh tag {SpecialChar.NoPropValue.value} 
 {" " * indent_size}{TermColor.remaining_value.value}{func_envelope_path_step_prop_name(3)}: ?{TermColor.reset_style.value} commit double_execution get host print_with_exit print_with_io_redirect print_with_level repo service set tag {SpecialChar.NoPropValue.value} 
 {" " * indent_size}{TermColor.remaining_value.value}{ReservedPropName.func_state.name}: ?{TermColor.reset_style.value} {FuncState.fs_alpha} {FuncState.fs_beta} {FuncState.fs_demo} {FuncState.fs_gamma} {FuncState.fs_ignorable} 
-{" " * indent_size}{TermColor.remaining_value.value}{ReservedPropName.func_id.name}: ?{TermColor.reset_style.value} func_id_desc_git_commit func_id_desc_git_tag func_id_desc_host func_id_desc_service func_id_diff_service func_id_double_execution func_id_echo_args func_id_get_data_envelopes func_id_goto_git_repo func_id_goto_host func_id_goto_service func_id_help_hint func_id_intercept_invocation func_id_list_host func_id_list_service func_id_no_data func_id_print_with_exit_code func_id_print_with_io_redirect func_id_print_with_severity_level func_id_query_enum_items func_id_set_data_envelopes func_id_ssh_dst 
+{" " * indent_size}{TermColor.remaining_value.value}{ReservedPropName.func_id.name}: ?{TermColor.reset_style.value} func_id_desc_git_commit func_id_desc_git_tag func_id_desc_host func_id_desc_service func_id_diff_service func_id_double_execution func_id_echo_args func_id_get_data_envelopes func_id_goto_git_repo func_id_goto_host func_id_goto_service func_id_help_hint func_id_intercept_invocation func_id_list_host func_id_list_service func_id_no_data func_id_print_with_exit_code func_id_print_with_io_redirect func_id_print_with_severity_level func_id_query_enum_items func_id_set_data_envelopes func_id_sleep func_id_ssh_dst 
 """,
                 # fmt: on
             ),

--- a/tests/offline_tests/relay_demo/test_relay_demo_trees.py
+++ b/tests/offline_tests/relay_demo/test_relay_demo_trees.py
@@ -66,6 +66,7 @@ tree_step_2: ? intercept help goto desc list host service repo commit
                     "intercept",
                     "list",
                     "no_data",
+                    "sleep",
                     "ssh",
                 ],
                 "Basic test.",


### PR DESCRIPTION
*   Make MCP proxy execution synchronous.
*   Configure MCP proxy to log tool `stdout` and `stderr`.
*   Implement command `sleep` with delay args to test long-running commands.

